### PR TITLE
Implement memory summarizer logic

### DIFF
--- a/src/memory/management/mod.rs
+++ b/src/memory/management/mod.rs
@@ -332,10 +332,13 @@ impl AdvancedMemoryManager {
     /// Summarize a group of related memories
     pub async fn summarize_memories(
         &mut self,
+        storage: &(dyn crate::memory::storage::Storage + Send + Sync),
         memory_keys: Vec<String>,
         strategy: SummaryStrategy,
     ) -> Result<SummaryResult> {
-        self.summarizer.summarize_memories(memory_keys, strategy).await
+        self.summarizer
+            .summarize_memories(storage, memory_keys, strategy)
+            .await
     }
 
     /// Optimize memory storage and organization

--- a/tests/summarization_tests.rs
+++ b/tests/summarization_tests.rs
@@ -1,0 +1,54 @@
+use synaptic::{
+    memory::management::{MemorySummarizer, SummaryStrategy},
+    memory::storage::memory::MemoryStorage,
+    memory::types::{MemoryEntry, MemoryType, MemoryMetadata},
+    memory::Storage,
+};
+use std::sync::Arc;
+use chrono::{Utc, Duration};
+
+#[tokio::test]
+async fn test_key_points_summary() -> Result<(), Box<dyn std::error::Error>> {
+    let storage = Arc::new(MemoryStorage::new());
+    let mut summarizer = MemorySummarizer::new();
+
+    let e1 = MemoryEntry::new("k1".into(), "Learn Rust".into(), MemoryType::ShortTerm);
+    let e2 = MemoryEntry::new("k2".into(), "Write tests".into(), MemoryType::ShortTerm);
+    storage.store(&e1).await?;
+    storage.store(&e2).await?;
+
+    let result = summarizer
+        .summarize_memories(&*storage, vec!["k1".into(), "k2".into()], SummaryStrategy::KeyPoints)
+        .await?;
+
+    assert!(result.summary_content.contains("Learn Rust"));
+    assert!(result.summary_content.contains("Write tests"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_chronological_summary() -> Result<(), Box<dyn std::error::Error>> {
+    let storage = Arc::new(MemoryStorage::new());
+    let mut summarizer = MemorySummarizer::new();
+
+    let mut e1 = MemoryEntry::new("old".into(), "Old event".into(), MemoryType::ShortTerm);
+    let mut meta1 = MemoryMetadata::new();
+    meta1.created_at = Utc::now() - Duration::hours(1);
+    e1.metadata = meta1;
+
+    let e2 = MemoryEntry::new("new".into(), "New event".into(), MemoryType::ShortTerm);
+
+    storage.store(&e1).await?;
+    storage.store(&e2).await?;
+
+    let result = summarizer
+        .summarize_memories(&*storage, vec!["old".into(), "new".into()], SummaryStrategy::Chronological)
+        .await?;
+
+    let lines: Vec<&str> = result.summary_content.lines().collect();
+    // first line is header
+    assert!(lines[1].contains("Old event"));
+    assert!(lines[2].contains("New event"));
+    Ok(())
+}
+


### PR DESCRIPTION
## Summary
- load memories from storage in summarizer
- implement basic summary generation helpers
- support storage parameter in advanced manager
- add unit tests for summarizer

## Testing
- `cargo test --no-run`
- `cargo test --test summarization_tests -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_6849d32eb9448324b520e83079fd041c