### PR TITLE
Implement temporal pattern detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ async-trait = "0.1"
 uuid = { version = "1.6", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 indexmap = "2.0"
+num-traits = "0.2"
 
 # Storage
 sled = "0.34"


### PR DESCRIPTION
## Summary
- implement daily, weekly, burst, and trend detection
- use metadata to verify incoming evidence against patterns
- enhance access pattern analysis using new detection logic
- add `num-traits` dependency for weekday conversions

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6849daf535988324bbdb234096b1ab80