### PR TITLE
Add usage stats and metrics updates

### DIFF
--- a/src/analytics/mod.rs
+++ b/src/analytics/mod.rs
@@ -234,8 +234,11 @@ impl AnalyticsEngine {
         }
 
         // Process event through analytics modules
+        let before_predictions = self.predictive.get_predictions().len();
         self.predictive.process_event(&event).await?;
         self.behavioral.process_event(&event).await?;
+        let after_predictions = self.predictive.get_predictions().len();
+        self.metrics.predictions_made += (after_predictions - before_predictions) as u64;
 
         // Update metrics
         self.metrics.events_processed += 1;
@@ -271,6 +274,11 @@ impl AnalyticsEngine {
     /// Get analytics metrics
     pub fn get_metrics(&self) -> &AnalyticsMetrics {
         &self.metrics
+    }
+
+    /// Retrieve a copy of usage statistics
+    pub fn get_usage_stats(&self) -> AnalyticsMetrics {
+        self.metrics.clone()
     }
 
     /// Get recent insights

--- a/src/memory/temporal/versioning.rs
+++ b/src/memory/temporal/versioning.rs
@@ -436,4 +436,9 @@ impl VersionManager {
         
         Ok(())
     }
+
+    /// Get total number of versions across all memories
+    pub fn total_versions(&self) -> usize {
+        self.histories.values().map(|h| h.versions.len()).sum()
+    }
 }


### PR DESCRIPTION
## Summary
- update analytics event recording to count new predictions
- expose analytics usage statistics
- track diff metrics live and expose via Differential module
- surface temporal usage stats and version counts

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6849daeee17083249bd2cca549f7c53f