### PR TITLE
Add active period detection

### DIFF
--- a/src/memory/temporal/mod.rs
+++ b/src/memory/temporal/mod.rs
@@ -297,7 +297,7 @@ impl TemporalMemoryManager {
     }
 
     /// Calculate temporal summary statistics
-    fn calculate_temporal_summary(
+    pub fn calculate_temporal_summary(
         &self,
         version_history: &[MemoryVersion],
         changes: &[ChangeSet],
@@ -331,13 +331,45 @@ impl TemporalMemoryManager {
             1.0
         };
 
+        let bucket_size = Self::determine_bucket_size(time_range);
+        let most_active_period = Self::detect_most_active_period(version_history, bucket_size);
+
         TemporalSummary {
             total_versions,
             total_changes,
-            most_active_period: None, // TODO: Implement period detection
+            most_active_period,
             avg_change_frequency,
             most_common_change_type,
             stability_score,
         }
+    }
+
+    /// Determine bucket size for activity analysis based on overall range
+    fn determine_bucket_size(time_range: &TimeRange) -> Duration {
+        if time_range.duration().num_hours() <= 24 {
+            Duration::hours(1)
+        } else {
+            Duration::days(1)
+        }
+    }
+
+    /// Detect the most active period using the given bucket size
+    fn detect_most_active_period(
+        version_history: &[MemoryVersion],
+        bucket_size: Duration,
+    ) -> Option<TimeRange> {
+        use chrono::NaiveDateTime;
+        let mut counts: HashMap<DateTime<Utc>, usize> = HashMap::new();
+        for version in version_history {
+            let ts = version.created_at.timestamp();
+            let bucket_start = ts - (ts % bucket_size.num_seconds());
+            if let Some(start_naive) = NaiveDateTime::from_timestamp_opt(bucket_start, 0) {
+                let bucket = DateTime::<Utc>::from_utc(start_naive, Utc);
+                *counts.entry(bucket).or_insert(0) += 1;
+            }
+        }
+
+        let (start, _) = counts.into_iter().max_by_key(|(_, c)| *c)?;
+        Some(TimeRange::new(start, start + bucket_size))
     }
 }

--- a/tests/temporal_summary_tests.rs
+++ b/tests/temporal_summary_tests.rs
@@ -1,0 +1,81 @@
+use synaptic::{memory::temporal::{TemporalMemoryManager, TemporalConfig, TimeRange, ChangeType, MemoryVersion}, MemoryEntry, MemoryType};
+use chrono::{DateTime, Utc, Duration, Timelike};
+
+#[tokio::test]
+async fn test_most_active_period_daily() -> Result<(), Box<dyn std::error::Error>> {
+    let manager = TemporalMemoryManager::new(TemporalConfig::default());
+    let now = Utc::now() - Duration::days(3);
+    let start_naive = now.date_naive().and_hms_opt(0, 0, 0).unwrap();
+    let start = DateTime::<Utc>::from_utc(start_naive, Utc);
+    let mut versions = Vec::new();
+
+    // day 0
+    for i in 0..2 {
+        let mut mem = MemoryEntry::new(format!("d0_{}", i), "v".to_string(), MemoryType::ShortTerm);
+        mem.metadata.created_at = start + Duration::hours(i);
+        let mut v = MemoryVersion::new(mem, ChangeType::Created, i as u64);
+        v.created_at = start + Duration::hours(i);
+        versions.push(v);
+    }
+    // day 1 (most active)
+    for i in 0..5 {
+        let mut mem = MemoryEntry::new(format!("d1_{}", i), "v".to_string(), MemoryType::ShortTerm);
+        mem.metadata.created_at = start + Duration::days(1) + Duration::hours(i);
+        let mut v = MemoryVersion::new(mem, ChangeType::Updated, (10 + i) as u64);
+        v.created_at = start + Duration::days(1) + Duration::hours(i);
+        versions.push(v);
+    }
+    // day 2
+    let mut mem = MemoryEntry::new("d2".to_string(), "v".to_string(), MemoryType::ShortTerm);
+    mem.metadata.created_at = start + Duration::days(2);
+    let mut v = MemoryVersion::new(mem, ChangeType::Updated, 20);
+    v.created_at = start + Duration::days(2);
+    versions.push(v);
+
+    let range = TimeRange::new(start, start + Duration::days(3));
+    let summary = manager.calculate_temporal_summary(&versions, &[], &range);
+    let active = summary.most_active_period.expect("period");
+
+    let expected_start_naive = (start + Duration::days(1)).date_naive().and_hms_opt(0,0,0).unwrap();
+    let expected_start = DateTime::<Utc>::from_utc(expected_start_naive, Utc);
+    assert_eq!(active.start, expected_start);
+    assert_eq!(active.end, expected_start + Duration::days(1));
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_most_active_period_hourly() -> Result<(), Box<dyn std::error::Error>> {
+    let manager = TemporalMemoryManager::new(TemporalConfig::default());
+    let now = Utc::now() - Duration::hours(6);
+    let start_naive = now.date_naive().and_hms_opt(now.hour(), 0, 0).unwrap();
+    let start = DateTime::<Utc>::from_utc(start_naive, Utc);
+    let mut versions = Vec::new();
+
+    // hour 1
+    for i in 0..2 {
+        let mut mem = MemoryEntry::new(format!("h1_{}", i), "v".to_string(), MemoryType::ShortTerm);
+        mem.metadata.created_at = start + Duration::hours(1) + Duration::minutes(i as i64);
+        let mut v = MemoryVersion::new(mem, ChangeType::Created, i as u64);
+        v.created_at = start + Duration::hours(1) + Duration::minutes(i as i64);
+        versions.push(v);
+    }
+    // hour 3 (most active)
+    for i in 0..4 {
+        let mut mem = MemoryEntry::new(format!("h3_{}", i), "v".to_string(), MemoryType::ShortTerm);
+        mem.metadata.created_at = start + Duration::hours(3) + Duration::minutes(i as i64);
+        let mut v = MemoryVersion::new(mem, ChangeType::Updated, (10 + i) as u64);
+        v.created_at = start + Duration::hours(3) + Duration::minutes(i as i64);
+        versions.push(v);
+    }
+
+    let range = TimeRange::new(start, start + Duration::hours(6));
+    let summary = manager.calculate_temporal_summary(&versions, &[], &range);
+    let active = summary.most_active_period.expect("period");
+
+    let target = start + Duration::hours(3);
+    let expected_start_naive = target.date_naive().and_hms_opt(target.hour(), 0, 0).unwrap();
+    let expected_start = DateTime::<Utc>::from_utc(expected_start_naive, Utc);
+    assert_eq!(active.start, expected_start);
+    assert_eq!(active.end, expected_start + Duration::hours(1));
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- detect most active period in temporal summaries
- add daily/hourly helper functions for bucket counts
- expose `calculate_temporal_summary` and test most active period detection

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684a088aba70832495febe93d31ebe1d