### PR TITLE
Implement diff compression and range filtering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,8 @@ dashmap = "5.5"
 parking_lot = "0.12"
 tokio-tungstenite = { version = "0.20", optional = true }
 futures-util = { version = "0.3", optional = true }
+diff = "0.1"
+lz4_flex = "0.11"
 
 # Concurrency (already included above)
 

--- a/tests/diff_analyzer_tests.rs
+++ b/tests/diff_analyzer_tests.rs
@@ -1,0 +1,46 @@
+use synaptic::memory::temporal::{DiffAnalyzer, ChangeSet, ChangeType, TimeRange};
+use synaptic::memory::types::{MemoryEntry, MemoryType};
+use chrono::{Utc, Duration};
+use uuid::Uuid;
+
+#[tokio::test]
+async fn test_diff_analysis_with_compression() -> Result<(), Box<dyn std::error::Error>> {
+    let mut analyzer = DiffAnalyzer::new();
+    let m1 = MemoryEntry::new("m1".into(), "Hello world".into(), MemoryType::ShortTerm);
+    let m2 = MemoryEntry::new("m1".into(), "Hello brave new world".into(), MemoryType::ShortTerm);
+    let diff = analyzer.analyze_difference(&m1, &m2).await?;
+    assert!(diff.compression_ratio.is_some());
+    assert!(!diff.content_changes.additions.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_analyze_changes_in_range_filter() -> Result<(), Box<dyn std::error::Error>> {
+    let mut analyzer = DiffAnalyzer::new();
+    let now = Utc::now();
+    let cs_old = ChangeSet {
+        id: Uuid::new_v4(),
+        timestamp: now - Duration::days(2),
+        memory_key: "a".into(),
+        change_type: ChangeType::Created,
+        diffs: Vec::new(),
+        impact_score: 0.5,
+        description: "old".into(),
+    };
+    let cs_new = ChangeSet {
+        id: Uuid::new_v4(),
+        timestamp: now - Duration::hours(1),
+        memory_key: "b".into(),
+        change_type: ChangeType::Updated,
+        diffs: Vec::new(),
+        impact_score: 0.5,
+        description: "new".into(),
+    };
+    analyzer.add_change_set(cs_old.clone());
+    analyzer.add_change_set(cs_new.clone());
+    let range = TimeRange::last_hours(24);
+    let filtered = analyzer.analyze_changes_in_range(&range).await?;
+    assert_eq!(filtered.len(), 1);
+    assert_eq!(filtered[0].id, cs_new.id);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- implement compression ratio calculation for diffs
- add Myers-style diff via `diff` crate for detailed analysis
- filter change sets by time range
- expose helper to add change sets
- test diff compression and range filtering

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684a0b606d7c832497238c24e2d603b7