### PR TITLE
Compute real data processing time

### DIFF
--- a/src/multimodal/data.rs
+++ b/src/multimodal/data.rs
@@ -742,6 +742,7 @@ impl DataMemoryProcessor {
 #[async_trait::async_trait]
 impl MultiModalProcessor for DataMemoryProcessor {
     async fn process(&self, content: &[u8], content_type: &ContentType) -> MultiModalResult<MultiModalMemory> {
+        let start_time = std::time::Instant::now();
         if content.len() > self.config.max_file_size {
             return Err(SynapticError::ProcessingError(
                 format!("Data file size {} exceeds maximum {}", content.len(), self.config.max_file_size)
@@ -793,6 +794,8 @@ impl MultiModalProcessor for DataMemoryProcessor {
         let mut final_metadata = data_metadata;
         final_metadata.summary = summary;
 
+        let processing_time = start_time.elapsed().as_millis() as u64;
+
         // Create multi-modal metadata
         let metadata = MultiModalMetadata {
             title: Some(format!("Data file with {} rows", final_metadata.schema.row_count)),
@@ -800,7 +803,7 @@ impl MultiModalProcessor for DataMemoryProcessor {
             tags: final_metadata.schema.data_types.clone(),
             quality_score: final_metadata.quality_score,
             confidence: 0.9,
-            processing_time_ms: 200, // Placeholder
+            processing_time_ms: processing_time,
             extracted_features: HashMap::new(),
         };
 

--- a/tests/data_processor_tests.rs
+++ b/tests/data_processor_tests.rs
@@ -1,0 +1,14 @@
+#[cfg(feature = "multimodal")]
+use synaptic::multimodal::{data::DataMemoryProcessor, ContentType, MultiModalProcessor};
+
+#[cfg(feature = "multimodal")]
+#[tokio::test]
+async fn test_data_processor_processing_time() {
+    let processor = DataMemoryProcessor::default();
+    let csv = b"a,b\n1,2\n3,4";
+    let content_type = ContentType::Data { format: "CSV".to_string(), schema: None };
+    let memory = processor.process(csv, &content_type).await.unwrap();
+    assert!(memory.metadata.processing_time_ms > 0);
+    assert!(memory.metadata.processing_time_ms < 10_000);
+}
+

--- a/tests/phase5b_document_tests.rs
+++ b/tests/phase5b_document_tests.rs
@@ -132,6 +132,8 @@ fn test_data_processing() {
         format: "CSV".to_string(),
         schema: None,
     });
+    assert!(result.processing_time_ms > 0);
+    assert!(result.processing_time_ms < 10_000);
     assert!(result.metadata.summary.is_some());
     assert!(result.metadata.summary.unwrap().contains("4 rows"));
     
@@ -145,6 +147,8 @@ fn test_data_processing() {
         format: "JSON".to_string(),
         schema: None,
     });
+    assert!(result.processing_time_ms > 0);
+    assert!(result.processing_time_ms < 10_000);
     
     // Test TSV file
     let tsv_path = temp_dir.path().join("test.tsv");
@@ -156,6 +160,8 @@ fn test_data_processing() {
         format: "TSV".to_string(),
         schema: None,
     });
+    assert!(result.processing_time_ms > 0);
+    assert!(result.processing_time_ms < 10_000);
 }
 
 /// Test batch directory processing


### PR DESCRIPTION
## Summary
- measure processing time in `DataMemoryProcessor`
- assert processing_time in data processing tests
- add new test for DataMemoryProcessor

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684a187940548324b997424c8c428218