### PR TITLE
Improve Redis cache metrics

### DIFF
--- a/tests/external_integrations_tests.rs
+++ b/tests/external_integrations_tests.rs
@@ -164,14 +164,13 @@ mod external_integration_tests {
                     MemoryType::ShortTerm,
                 );
                 let _ = client.cache_memory("test_key", &test_entry, None).await;
-                let _ = client.get_cached_memory("test_key").await;
-                let _ = client.delete_cached("test_key").await;
 
-                let stats = client.get_cache_stats().await;
-                match stats {
-                    Ok(cache_stats) => println!("Redis cache stats: {:?}", cache_stats),
-                    Err(e) => println!("Failed to get cache stats: {}", e),
+                if let Ok(stats) = client.get_cache_stats().await {
+                    assert!(stats.used_memory_bytes > 0);
+                    assert!(stats.total_keys >= 1);
                 }
+
+                let _ = client.delete_cached("test_key").await;
             },
             Err(_) => {
                 println!("Redis not available, skipping Redis integration test");


### PR DESCRIPTION
## Summary
- query `INFO MEMORY` to compute real stats
- assert stats fields in integration tests

## Testing
- `cargo test --no-run --quiet`
- `cargo test --no-run --features "external-integrations distributed" --quiet` *(fails: could not compile `candle-core`)*

------
https://chatgpt.com/codex/tasks/task_e_684a1870adfc832483293b4fcf801a33