### PR TITLE
Agent Memory v2 follow-ups: perf fixes (~7x search), optional LlmReasoner, real codex-judged QA number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -301,6 +301,10 @@ ml-models = ["candle-core", "candle-nn", "candle-transformers", "tokenizers"]
 # Optional candle cross-encoder reranker (reuses the ml-models candle stack)
 reranker-model = ["ml-models"]
 llm-integration = ["reqwest", "base64"]
+# Optional LLM-backed MemoryReasoner (write-path extraction/resolution/
+# synthesis via an OpenAI-compatible or Ollama endpoint). Fails open to the
+# heuristic reasoner on any misconfiguration or call failure.
+llm-reasoning = ["reqwest", "embeddings"]
 visualization = ["plotters", "plotters-backend", "image", "base64"]
 external-integrations = ["sql-storage", "ml-models", "llm-integration", "visualization"]
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -151,6 +151,50 @@ Honest findings from the growth run:
   should not be over-read; both confirm multi-second search at these store
   sizes, consistent with the latency table above.
 
+## Performance fixes — before / after (2026-07-13)
+
+After the initial evaluation surfaced the multi-second search and superlinear
+store growth above, three rounds of performance work were done on the
+`feature/agent-memory-v2-followups` branch:
+
+- **P1** (`fed757d`..`242fd96`): incremental `total_size` counter (removed a
+  per-store full-corpus rescan), bounded + deterministic KG/neighbor candidate
+  scans, shrunk the KG write-lock critical section.
+- **P2** (`879956f`..`bb5c842`): read-only query-time embedding (no per-query
+  vocabulary rebuild under a global write lock), a content-hash embedding cache
+  shared across the dense retriever and reranker, lowercase memoization, and
+  dropping the knowledge-graph read lock before storage awaits.
+- **P4** (`a88ab12`, `10c8252`): a character-n-gram **inverted index** in
+  storage so keyword search is candidate-bounded instead of a full scan
+  (results proven byte-identical to the full-scan implementation by an in-test
+  reference), plus token-indexed KG candidate selection.
+
+Retrieval **quality is unchanged** — P2 and P4 are correctness-preserving
+(ranking-parity tests pin identical top-k ordering; P4 returns byte-identical
+search results), so the retrieval/ablation numbers above still hold.
+
+Measured before/after (same harness, same machine, single-shot probe):
+
+| metric | before | after (P1+P2+P4) | change |
+|---|---|---|---|
+| probe search over 1k-entry store | 26.6 s | **3.65–3.70 s** | **~7× faster** |
+| store p50 @ 1k | 9.6 ms | 8.4 ms | ~comparable |
+
+**What is NOT fixed (honest):** the **store path is still superlinear at
+scale.** After the fixes, filling 1k→10k still did not complete within a
+40-minute clean run (comparable to the original ~75 min), so the 10k/100k
+store-latency points were **not re-measured** and 100k remains impractical.
+Root cause identified but not addressed by P1/P2/P4: the default
+`advanced_management` write pipeline (summarizer / search-engine / lifecycle /
+optimizer sub-systems, enabled by `enable_advanced_management = true`) performs
+O(n)-per-store work that dominates once the store is large — the original
+profiler mapped only the storage/KG/embedding/reasoning paths, which are now
+index-backed. **Next performance target:** index or bound the
+`advanced_management` per-store subsystems (or make them opt-in), then re-run
+the 10k/100k growth measurement. The search-latency win above is real and
+measured; the store-growth superlinearity is only partially reduced and is
+tracked as open.
+
 ## QA end-to-end accuracy
 
 **End-to-end QA accuracy — measured on a stratified N-question LoCoMo subset,

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -153,11 +153,61 @@ Honest findings from the growth run:
 
 ## QA end-to-end accuracy
 
-**Not run** — requires an LLM endpoint. To run it: build with
-`--features llm-reasoning` and set `SYNAPTIC_EVAL_LLM_URL` (and
-`SYNAPTIC_EVAL_LLM_MODEL`, optional `SYNAPTIC_EVAL_LLM_KEY`) to an
-OpenAI-compatible endpoint, then rerun the command above. The harness
-reports `QaResult::NotRun` rather than fabricating an accuracy number.
+**End-to-end QA accuracy — measured on a stratified N-question LoCoMo subset,
+judge = codex CLI (gpt-5.6-sol), 2026-07-13. NOT the full 1986-question set;
+NOT directly comparable to published full-set numbers.**
+
+This is a **subset** result (N = 150 of 1,986 questions), stratified evenly
+across the six QTypes (30 each, evenly spaced within each type,
+deterministic — no RNG). It measures the full recall → answer → grade
+pipeline: for each question, up to `k=10` memories are recalled from an
+`AgentMemory` ingested with the question's conversation, the `codex` CLI is
+asked to answer using **only** the recalled snippets, and `codex` then grades
+that answer against the gold answer (YES/NO). Every number below comes from a
+real codex verdict in this run; all 150 questions completed with **0 judge
+failures**. Accuracy is over completed (graded) questions only.
+
+| Metric | Value |
+|---|---|
+| Overall | **25 / 150 = 16.7%** |
+| SingleHop | 8 / 30 = 26.7% |
+| MultiHop | 2 / 30 = 6.7% |
+| Temporal | 9 / 30 = 30.0% |
+| OpenDomain | 5 / 30 = 16.7% |
+| Abstention | 1 / 30 = 3.3% |
+| KnowledgeUpdate | (not present in LoCoMo) |
+
+- **N = 150** selected, **150 completed (graded)**, **0 judge failures**, `k = 10`.
+- **Judge**: `codex` CLI 0.144.0, model `gpt-5.6-sol` (user's subscription,
+  non-interactive `codex exec`). Not feature-gated — `CodexCliJudge` shells
+  out; there is no new crate dependency.
+- **Honesty**: this is a subset, not the full set, and is not comparable to
+  published full-LoCoMo numbers. Low accuracy reflects the strict
+  answer-from-recalled-snippets-only constraint plus TF-IDF recall quality on
+  this hard long-context benchmark; nothing here is estimated or extrapolated.
+  If a run has judge failures, accuracy is reported over completed questions
+  with the failure count, never patched with a guessed verdict.
+
+### Command
+
+```bash
+cargo run --release -p synaptic-eval --bin run_qa -- --subset 150
+```
+
+Flags: `--subset N` (default 150), `--k K` (default 10), `--concurrency C`
+(default 4), `--data PATH` (default `tools/eval/data/locomo10.json`). The
+codex binary path and per-call timeout are configurable via
+`SYNAPTIC_EVAL_CODEX_BIN` (default `codex`) and
+`SYNAPTIC_EVAL_CODEX_TIMEOUT_SECS` (default 120). The binary prints progress
+to stderr (`question i/N`) so the long run (~150 codex answer+grade pairs) is
+observable. Requires a locally installed, logged-in `codex` CLI; if it is
+unavailable the binary exits without fabricating a number.
+
+An OpenAI-compatible HTTP judge (`LlmJudge`) also exists behind the
+`llm-reasoning` feature via `SYNAPTIC_EVAL_LLM_URL` /
+`SYNAPTIC_EVAL_LLM_MODEL` (optional `SYNAPTIC_EVAL_LLM_KEY`); without a judge
+configured the gated `run_eval` path reports `QaResult::NotRun` rather than
+fabricating an accuracy number.
 
 ## LongMemEval-S
 

--- a/docs/superpowers/plans/agent-memory-v2-followups.md
+++ b/docs/superpowers/plans/agent-memory-v2-followups.md
@@ -1,0 +1,58 @@
+# Agent Memory v2 — Follow-ups Plan
+
+> Execute via subagent-driven-development. Same gates/honesty bar as agent-memory-v2. Branch `feature/agent-memory-v2-followups` off `main` @ 5344fa6.
+
+**Goal:** Fix the real performance findings the eval surfaced (search p95 ~14s, superlinear store growth), build the optional LLM reasoner the spec listed, and produce a real (subset) QA-accuracy number via the codex CLI.
+
+## Global Constraints
+- Honesty bar (inherited): disabled paths fail closed; no todo!/unimplemented!/"in a real implementation"/"simulated"; no `.unwrap()`/`println!` in src/. TDD; one conventional commit per deliverable; ledger per task. Gates: fmt; clippy `--all-targets --features "security test-utils" -- -D warnings`; task tests; `cargo test --lib`. CI arbitrates `--all-features`.
+- Performance fixes MUST preserve behavior: the retrieval-quality suite, composite_scoring, reranker, bitemporal, intelligent_write, forgetting, reflection tests all stay green (correctness before speed). Add micro-benchmark or timing assertions only where deterministic.
+
+## Root-cause map (from profiler)
+- **W1** `MemoryStorage::update_stats` full rescan per store (`storage/memory.rs:210,125-141`) → O(n²) store. Fix: incremental `total_size` counter.
+- **W4** `neighbor_facts` scans all short+long-term memories per fact (`lib.rs:607-631`) → O(n·facts)/store. Fix: bounded candidate set (reuse storage tokenized search / cap).
+- **W2/W3/L4** KG `find_similar_node` + `auto_detect_relationships` full-node scans held under `kg.write()` (`knowledge_graph/mod.rs:660,544,578`; `lib.rs:505,654`) → O(n)/store blocking concurrent search. Fix: bound candidate scan (time/tag bucket), shrink write-lock critical section (compute outside the lock).
+- **S1+L1+S3+W5** TF-IDF `embed` rebuilds the whole IDF table under a global `state.write()` on every call, and dense retriever + reranker embed every candidate per query (`tfidf.rs:79,147`; `dense_vector.rs:53,93`; `rerank.rs:216`). Fix: (a) incremental/lazy IDF; (b) read-only query-time embedding (no vocab mutation on queries); (c) content-hash embedding cache reused across dense + rerank so each candidate is embedded at most once.
+- **S2** quadruple full-store `storage.search` per query, each re-lowercasing the corpus (`storage/memory.rs:150-195`). Fix: cache lowercased content / share one candidate fetch across pipelines.
+- **L2** GraphRetriever holds `kg.read()` across `storage.retrieve().await` (`strategies.rs:402,416`). Fix: collect keys, drop guard, then retrieve.
+
+---
+
+### Task P1: Write-path O(n²) → near-constant (W1, W4, W2/W3/L4)
+**Files:** `src/memory/storage/memory.rs` (incremental stats), `src/lib.rs` (neighbor_facts bounding, write-lock scope), `src/memory/knowledge_graph/mod.rs` (bounded candidate scans, shrink lock).
+**Scope:**
+1. W1: replace the per-store full `update_stats` rescan with an incremental `total_size` counter updated on insert/update/delete/batch/transaction. Keep `MemoryStats` values correct (test: stats after N inserts == sum, and match a full recompute).
+2. W4: `neighbor_facts` must NOT scan the whole store — bound it (e.g. reuse the storage tokenized search to fetch top-K candidates by the fact text, cap K≈20), so conflict resolution still works but is O(K) not O(n). Keep the intelligent_write supersede test green.
+3. W2/W3/L4: bound the KG per-store similarity/relationship scans to a candidate set (time-window or tag/embedding-bucketed, capped) instead of all nodes, and shrink the `kg.write()` critical section (compute candidates/similarity outside the lock; hold the write lock only for the actual node/edge mutations). Keep KG behavior tests green.
+**TDD:** a store-scaling test asserting per-store cost does NOT grow ~linearly with store size — e.g. store 2000 entries, assert the last-100 mean store time is within a small multiple (≤3×) of the first-100 mean (deterministic-enough on a quiet machine; if flaky, assert an operation-count proxy instead — e.g. instrument that neighbor_facts examined ≤K entries, not n). Prefer the op-count proxy for determinism. Plus all existing write-path/KG tests stay green.
+**Commits:** may split by offender ("perf(storage): incremental size stats", "perf(core): bound write-path neighbor and KG scans"). Gates each.
+
+### Task P2: Search/embedding hot path (S1/L1/S3/W5, S2, L2)
+**Files:** `src/memory/embeddings/providers/tfidf.rs` (+ `simple_embeddings.rs`), `src/memory/retrieval/dense_vector.rs`, `src/memory/retrieval/rerank.rs`, `src/memory/retrieval/strategies.rs`, `src/memory/storage/memory.rs` (search).
+**Scope:**
+1. TF-IDF read-only query embedding: embedding for scoring must NOT take a write lock or mutate vocabulary — add a read-only embed path (compute term weights against the existing IDF table without rebuilding it). Store-time vocabulary updates may stay, but make IDF recompute incremental/lazy, not a full rebuild per document.
+2. Embedding cache: a content-hash-keyed cache (the `compute_content_hash` helper exists) so a candidate/document is embedded at most once across the dense retriever and the reranker within a query (and reused across queries). Dense retriever + HeuristicReranker consult the cache instead of re-embedding.
+3. S2: avoid 4 independent full-store lowercasing scans — cache lowercased content on entries or share one candidate fetch across the pipelines (whichever is cleaner without breaking the pipeline abstraction). At minimum, memoize the lowercased form.
+4. L2: GraphRetriever must collect related keys, DROP the `kg.read()` guard, THEN `storage.retrieve` — no lock held across awaits.
+**TDD:** correctness-preserving — retrieval_quality + composite_scoring + reranker suites stay green (same rankings). Add a test asserting a query embeds each distinct candidate content at most once (cache hit-count via a test-utils counter), and that the query-time embed path does not mutate vocabulary (vocab size unchanged after N scoring embeds). 
+**Commits:** may split ("perf(embeddings): read-only query embed + incremental IDF + content-hash cache", "perf(retrieval): reuse embeddings, drop KG lock before awaits, memoize lowercase"). Gates each.
+
+### Task P3: Re-run eval, prove the speedup (measured)
+**Files:** `docs/evaluation.md`.
+**Scope:** re-run the LLM-free harness/growth on real LoCoMo (`tools/eval/data/locomo10.json`) after P1+P2; record NEW latency p50/p95/p99 and growth 1k/10k (and attempt 100k if now feasible) BESIDE the pre-fix numbers as a before/after table. Confirm retrieval metrics are unchanged (correctness preserved) or note any delta honestly. No fabricated numbers — real re-run only.
+**Commit:** "docs(eval): performance before/after and (if feasible) 100k growth".
+
+### Task R1: Optional LlmReasoner (write-path LLM)
+**Files:** `src/memory/reasoning/llm.rs` (feature `llm-reasoning`), `src/memory/reasoning/mod.rs` (export), `src/lib.rs` (optional selection).
+**Scope:** implement `LlmReasoner` behind `#[cfg(feature = "llm-reasoning")]` implementing `MemoryReasoner` (extract/resolve/synthesize) by prompting an LLM via the existing reqwest/Ollama provider surface (env-configured endpoint, OpenAI-compatible/Ollama). FAIL-OPEN TO HEURISTIC: when the feature is off OR no endpoint is reachable OR a call fails, fall back to `HeuristicReasoner` (logged, never a fabricated extraction, never a hard failure of the write path). Provide a way to select it (config/env). 
+**TDD:** feature-off unchanged (HeuristicReasoner default). Feature-on with a mock/stub HTTP (or a trait-level test double) asserts: extract parses the LLM's structured JSON facts; a failed/unreachable endpoint falls back to the heuristic result (assert the fallback path, not a panic or fake). No network in tests.
+**Commit:** "feat(reasoning): optional LlmReasoner with heuristic fallback".
+
+### Task Q1: CodexCliJudge + real QA-accuracy subset (IN PROGRESS, tools/eval only)
+Already dispatched: `CodexCliJudge` shelling to `codex exec` (gpt-5.6-sol), run a stratified LoCoMo subset, record the real subset QA accuracy in `docs/evaluation.md` labeled explicitly as a subset. Honesty bar: real measured numbers only; subset clearly marked; not comparable to full-set published numbers.
+
+### Task S1(sweep): Follow-up final sweep
+Fake-path grep; revert spot-checks on ≥2 new tests (a perf-correctness test + LlmReasoner fallback); dangling refs; full gate battery; confirm evaluation.md before/after + QA numbers are real; summary.
+
+## Ordering
+Q1 runs in parallel (tools/eval, disjoint). P1 → P2 (shared files: memory.rs, lib.rs, strategies.rs — sequential). R1 after P1 (shares lib.rs write path). P3 after P1+P2. Sweep last.

--- a/docs/superpowers/plans/agent-memory-v2-followups.md
+++ b/docs/superpowers/plans/agent-memory-v2-followups.md
@@ -36,6 +36,7 @@
 4. L2: GraphRetriever must collect related keys, DROP the `kg.read()` guard, THEN `storage.retrieve` — no lock held across awaits.
 **TDD:** correctness-preserving — retrieval_quality + composite_scoring + reranker suites stay green (same rankings). Add a test asserting a query embeds each distinct candidate content at most once (cache hit-count via a test-utils counter), and that the query-time embed path does not mutate vocabulary (vocab size unchanged after N scoring embeds). 
 **Commits:** may split ("perf(embeddings): read-only query embed + incremental IDF + content-hash cache", "perf(retrieval): reuse embeddings, drop KG lock before awaits, memoize lowercase"). Gates each.
+**Follow-up finding (out of P2 scope, tracked here):** the scoring provider wired into the shipped hybrid pipeline only ever has `embed_for_scoring` called on it — never `embed` — so its TF-IDF vocabulary stays empty and every term's IDF falls back to `1.0`. Dense retrieval is therefore currently hashed-TF cosine with NO real IDF weighting. This is a PRE-EXISTING design gap (ties to the SimpleEmbedder-not-fed-corpus carry-forward), partly explains weak recall, and should be fixed in a future task by feeding the corpus into / sharing the store-time vocabulary with the scoring provider. Documented in `dense_vector.rs` and `tfidf.rs`; deliberately NOT fixed in P2 (perf-only scope).
 
 ### Task P3: Re-run eval, prove the speedup (measured)
 **Files:** `docs/evaluation.md`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,11 +215,27 @@ impl AgentMemory {
 
         // Default reasoner for the intelligent write path: the deterministic
         // heuristic reasoner over the active (TF-IDF) embedding provider.
+        // With the `llm-reasoning` feature enabled AND an endpoint configured
+        // via SYNAPTIC_LLM_URL/SYNAPTIC_LLM_MODEL (or the SYNAPTIC_EVAL_LLM_*
+        // fallbacks), an LlmReasoner is used instead; it fails open to its own
+        // inner HeuristicReasoner on any LLM error, so the write path never
+        // hard-fails or fabricates. Feature off or unconfigured: heuristic.
         #[cfg(feature = "embeddings")]
-        let reasoner: Arc<dyn memory::reasoning::MemoryReasoner> =
-            Arc::new(memory::reasoning::HeuristicReasoner::new(Arc::new(
-                memory::embeddings::TfIdfProvider::default(),
-            )));
+        let reasoner: Arc<dyn memory::reasoning::MemoryReasoner> = {
+            let heuristic: Arc<dyn memory::reasoning::MemoryReasoner> =
+                Arc::new(memory::reasoning::HeuristicReasoner::new(Arc::new(
+                    memory::embeddings::TfIdfProvider::default(),
+                )));
+            #[cfg(feature = "llm-reasoning")]
+            {
+                match memory::reasoning::LlmReasoner::from_env() {
+                    Some(llm) => Arc::new(llm),
+                    None => heuristic,
+                }
+            }
+            #[cfg(not(feature = "llm-reasoning"))]
+            heuristic
+        };
 
         // Reflection engine: clusters memories accumulated since the last
         // reflection by TF-IDF embedding similarity and synthesizes insights

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,9 +243,15 @@ impl AgentMemory {
         // term matches), so multi-word queries yield candidates directly and
         // no widening wrapper is needed.
         let retrieval_pipeline = if config.enable_embeddings {
-            let provider = Arc::new(memory::embeddings::TfIdfProvider::default());
-            let dense_vector =
-                memory::retrieval::DenseVectorRetriever::new(Arc::clone(&storage), provider);
+            // ONE shared provider instance for the dense retriever AND the
+            // reranker: its content-hash scoring cache means each candidate
+            // content is embedded at most once per query across both stages.
+            let provider: Arc<dyn memory::embeddings::provider::EmbeddingProvider> =
+                Arc::new(memory::embeddings::TfIdfProvider::default());
+            let dense_vector = memory::retrieval::DenseVectorRetriever::new(
+                Arc::clone(&storage),
+                Arc::clone(&provider),
+            );
             let keyword = memory::retrieval::KeywordRetriever::new(Arc::clone(&storage));
             // Graph and temporal signals share the same storage; the graph
             // retriever additionally shares the live knowledge-graph handle
@@ -260,7 +266,7 @@ impl AgentMemory {
             // (term overlap, embedding agreement, graph proximity, recency)
             // reorder the fused + composite-scored results.
             let reranker = memory::retrieval::HeuristicReranker::new(
-                Some(Arc::new(memory::embeddings::TfIdfProvider::default())),
+                Some(Arc::clone(&provider)),
                 knowledge_graph.clone(),
             );
             let hybrid = memory::retrieval::HybridRetriever::new(pipeline_config)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,11 @@ pub struct AgentMemory {
     /// relevance × recency × importance scoring. `None` falls back to
     /// `storage.search`.
     retrieval_pipeline: Option<Arc<memory::retrieval::HybridRetriever>>,
+    /// Test-only op-count proxy: max number of candidate memories examined by
+    /// a single `neighbor_facts` call. Bounded write path keeps this <= the
+    /// candidate cap regardless of store size.
+    #[cfg(all(feature = "embeddings", feature = "test-utils"))]
+    neighbor_examined_max: std::sync::atomic::AtomicUsize,
 }
 
 impl AgentMemory {
@@ -370,6 +375,8 @@ impl AgentMemory {
             cross_platform_manager,
             promotion_manager,
             retrieval_pipeline,
+            #[cfg(all(feature = "embeddings", feature = "test-utils"))]
+            neighbor_examined_max: std::sync::atomic::AtomicUsize::new(0),
         };
 
         // Initialize multimodal memory after creating base agent to avoid circular dependency
@@ -500,9 +507,32 @@ impl AgentMemory {
             }
         }
 
-        // Add or update in knowledge graph if enabled (intelligent merging)
+        // Add or update in knowledge graph if enabled (intelligent merging).
+        // The O(n) similarity/relationship computation runs under READ locks;
+        // the write lock is held only for the actual node/edge mutations so
+        // concurrent readers are not blocked behind full-graph scans.
         if let Some(ref kg) = self.knowledge_graph {
-            if let Err(e) = kg.write().await.add_or_update_memory_node(&entry).await {
+            let kg_result: Result<()> = async {
+                let plan = kg.read().await.plan_memory_node_update(&entry).await?;
+                let (node_id, needs_detection) = kg
+                    .write()
+                    .await
+                    .apply_memory_node_plan(plan, &entry)
+                    .await?;
+                if needs_detection {
+                    let edges = kg
+                        .read()
+                        .await
+                        .detect_relationship_edges(node_id, &entry)
+                        .await?;
+                    if !edges.is_empty() {
+                        kg.write().await.add_detected_edges(edges).await?;
+                    }
+                }
+                Ok(())
+            }
+            .await;
+            if let Err(e) = kg_result {
                 tracing::warn!(error = %e, "knowledge graph update degraded during store");
                 degradations.knowledge_graph = Some(e.to_string());
             }
@@ -570,7 +600,7 @@ impl AgentMemory {
             return Ok(());
         }
         for fact in &extraction.facts {
-            let neighbors = self.neighbor_facts(&entry.key, &fact.text, 5);
+            let neighbors = self.neighbor_facts(&entry.key, &fact.text, 5).await?;
             let resolution = reasoner.resolve(fact, &neighbors).await?;
             // The reasoner picks its target among the neighbors we supplied;
             // for id-less outcomes (UpdateInPlace/Append) the target is the
@@ -582,17 +612,19 @@ impl AgentMemory {
         Ok(())
     }
 
-    /// Build the top-`k` neighbor list for a candidate fact from existing
-    /// memories (short- and long-term state), excluding the entry being
-    /// stored. Similarity is a deterministic token-set cosine; ties break by
-    /// key so resolution is reproducible.
+    /// Build the top-`k` neighbor list for a candidate fact, excluding the
+    /// entry being stored. Candidates are fetched via the storage's tokenized
+    /// search (top [`Self::NEIGHBOR_CANDIDATE_LIMIT`] by term overlap) so the
+    /// per-fact cost is bounded instead of scanning every stored memory.
+    /// Similarity over the candidate set is a deterministic token-set cosine;
+    /// ties break by key so resolution is reproducible.
     #[cfg(feature = "embeddings")]
-    fn neighbor_facts(
+    async fn neighbor_facts(
         &self,
         current_key: &str,
         fact_text: &str,
         k: usize,
-    ) -> Vec<memory::reasoning::NeighborFact> {
+    ) -> Result<Vec<memory::reasoning::NeighborFact>> {
         fn tokens(text: &str) -> std::collections::HashSet<String> {
             text.to_lowercase()
                 .split(|c: char| !c.is_alphanumeric())
@@ -602,16 +634,22 @@ impl AgentMemory {
         }
         let candidate_tokens = tokens(fact_text);
         if candidate_tokens.is_empty() {
-            return Vec::new();
+            return Ok(Vec::new());
         }
-        let mut neighbors: Vec<memory::reasoning::NeighborFact> = self
-            .state
-            .get_short_term_memories()
+        // +1 head-room: the search may return the entry being stored itself.
+        let candidates = self
+            .storage
+            .search(fact_text, Self::NEIGHBOR_CANDIDATE_LIMIT + 1)
+            .await?;
+        #[cfg(feature = "test-utils")]
+        let examined = std::sync::atomic::AtomicUsize::new(0);
+        let mut neighbors: Vec<memory::reasoning::NeighborFact> = candidates
             .iter()
-            .chain(self.state.get_long_term_memories().iter())
-            .filter(|(key, _)| key.as_str() != current_key)
-            .filter_map(|(key, mem)| {
-                let mem_tokens = tokens(&mem.value);
+            .filter(|fragment| fragment.entry.key != current_key)
+            .filter_map(|fragment| {
+                #[cfg(feature = "test-utils")]
+                examined.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                let mem_tokens = tokens(&fragment.entry.value);
                 if mem_tokens.is_empty() {
                     return None;
                 }
@@ -620,9 +658,9 @@ impl AgentMemory {
                     / ((candidate_tokens.len() as f64).sqrt() * (mem_tokens.len() as f64).sqrt());
                 if similarity > 0.0 {
                     Some(memory::reasoning::NeighborFact {
-                        id: key.clone(),
+                        id: fragment.entry.key.clone(),
                         similarity,
-                        text: mem.value.clone(),
+                        text: fragment.entry.value.clone(),
                     })
                 } else {
                     None
@@ -635,7 +673,27 @@ impl AgentMemory {
                 .then_with(|| a.id.cmp(&b.id))
         });
         neighbors.truncate(k);
-        neighbors
+        #[cfg(feature = "test-utils")]
+        self.neighbor_examined_max.fetch_max(
+            examined.load(std::sync::atomic::Ordering::Relaxed),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+        Ok(neighbors)
+    }
+
+    /// Upper bound on the candidate memories `neighbor_facts` examines per
+    /// fact. Keeps the intelligent write path O(K) per fact instead of O(n)
+    /// over the whole store; the storage's tokenized search ranks candidates
+    /// by term overlap so the strongest conflict candidates are retained.
+    #[cfg(feature = "embeddings")]
+    const NEIGHBOR_CANDIDATE_LIMIT: usize = 20;
+
+    /// Test-only op-count proxy: the maximum number of candidate memories a
+    /// single `neighbor_facts` call has examined so far.
+    #[cfg(all(feature = "embeddings", feature = "test-utils"))]
+    pub fn max_neighbor_candidates_examined(&self) -> usize {
+        self.neighbor_examined_max
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Apply a conflict resolution outcome to the knowledge graph.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -600,7 +600,7 @@ impl AgentMemory {
             return Ok(());
         }
         for fact in &extraction.facts {
-            let neighbors = self.neighbor_facts(&entry.key, &fact.text, 5).await?;
+            let neighbors = self.neighbor_facts(&entry.key, fact, 5).await?;
             let resolution = reasoner.resolve(fact, &neighbors).await?;
             // The reasoner picks its target among the neighbors we supplied;
             // for id-less outcomes (UpdateInPlace/Append) the target is the
@@ -612,17 +612,32 @@ impl AgentMemory {
         Ok(())
     }
 
-    /// Build the top-`k` neighbor list for a candidate fact, excluding the
-    /// entry being stored. Candidates are fetched via the storage's tokenized
-    /// search (top [`Self::NEIGHBOR_CANDIDATE_LIMIT`] by term overlap) so the
-    /// per-fact cost is bounded instead of scanning every stored memory.
-    /// Similarity over the candidate set is a deterministic token-set cosine;
-    /// ties break by key so resolution is reproducible.
+    /// Build the top-`k` neighbor list for a candidate `fact`, excluding the
+    /// entry being stored.
+    ///
+    /// Candidate source (changed from the previous full state scan): the bulk
+    /// of candidates come from the storage's tokenized search over the fact
+    /// text (top [`Self::NEIGHBOR_CANDIDATE_LIMIT`] by term overlap), so the
+    /// per-fact cost is bounded (O(K)) instead of tokenizing every stored
+    /// short/long-term memory (O(n)).
+    ///
+    /// Bounded-recall tradeoff and its mitigation: a pure top-K keyword search
+    /// can miss a genuinely contradicting memory when the two share only their
+    /// subject (e.g. "Alice lives in Berlin" vs. "Alice lives in Munich" share
+    /// just "alice"/"lives"/"in") while >=K unrelated memories share more
+    /// terms — which would wrongly downgrade a Supersede to an Insert. To make
+    /// same-subject contradictions robust we (a) drop trivial (<3 char) tokens
+    /// from the search query so distinctive terms dominate ranking, and (b)
+    /// UNION the keyword hits with an exact per-subject lookup: for every
+    /// relation subject in the fact we run a targeted search so a memory about
+    /// the same subject is always in the candidate set. The final similarity
+    /// ranking over the union is unchanged (deterministic token-set cosine,
+    /// ties broken by key).
     #[cfg(feature = "embeddings")]
     async fn neighbor_facts(
         &self,
         current_key: &str,
-        fact_text: &str,
+        fact: &memory::reasoning::Fact,
         k: usize,
     ) -> Result<Vec<memory::reasoning::NeighborFact>> {
         fn tokens(text: &str) -> std::collections::HashSet<String> {
@@ -632,15 +647,55 @@ impl AgentMemory {
                 .map(str::to_string)
                 .collect()
         }
-        let candidate_tokens = tokens(fact_text);
+        let candidate_tokens = tokens(&fact.text);
         if candidate_tokens.is_empty() {
             return Ok(Vec::new());
         }
+
+        // (a) Build a keyword query from distinctive (>=3 char) tokens so a
+        // handful of long, discriminating terms outrank many short stopword
+        // matches. Fall back to the raw text if nothing survives the filter.
+        let distinctive: Vec<&str> = fact
+            .text
+            .split(|c: char| !c.is_alphanumeric())
+            .filter(|w| w.chars().count() >= 3)
+            .collect();
+        let query = if distinctive.is_empty() {
+            fact.text.clone()
+        } else {
+            distinctive.join(" ")
+        };
+
+        // Collect a bounded, deduplicated candidate set: the keyword hits ...
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut candidates: Vec<memory::types::MemoryFragment> = Vec::new();
         // +1 head-room: the search may return the entry being stored itself.
-        let candidates = self
+        for fragment in self
             .storage
-            .search(fact_text, Self::NEIGHBOR_CANDIDATE_LIMIT + 1)
-            .await?;
+            .search(&query, Self::NEIGHBOR_CANDIDATE_LIMIT + 1)
+            .await?
+        {
+            if seen.insert(fragment.entry.key.clone()) {
+                candidates.push(fragment);
+            }
+        }
+        // (b) ... unioned with a targeted lookup per relation subject so a
+        // same-subject memory can never be squeezed out of the candidate set.
+        for relation in &fact.relations {
+            if relation.subject.trim().is_empty() {
+                continue;
+            }
+            for fragment in self
+                .storage
+                .search(&relation.subject, Self::NEIGHBOR_CANDIDATE_LIMIT + 1)
+                .await?
+            {
+                if seen.insert(fragment.entry.key.clone()) {
+                    candidates.push(fragment);
+                }
+            }
+        }
+
         #[cfg(feature = "test-utils")]
         let examined = std::sync::atomic::AtomicUsize::new(0);
         let mut neighbors: Vec<memory::reasoning::NeighborFact> = candidates
@@ -681,10 +736,11 @@ impl AgentMemory {
         Ok(neighbors)
     }
 
-    /// Upper bound on the candidate memories `neighbor_facts` examines per
-    /// fact. Keeps the intelligent write path O(K) per fact instead of O(n)
+    /// Upper bound on the keyword-hit candidates `neighbor_facts` pulls per
+    /// search. Keeps the intelligent write path O(K) per fact instead of O(n)
     /// over the whole store; the storage's tokenized search ranks candidates
-    /// by term overlap so the strongest conflict candidates are retained.
+    /// by term overlap so the strongest conflict candidates are retained. The
+    /// per-subject union searches add at most a small constant multiple.
     #[cfg(feature = "embeddings")]
     const NEIGHBOR_CANDIDATE_LIMIT: usize = 20;
 

--- a/src/memory/embeddings/provider.rs
+++ b/src/memory/embeddings/provider.rs
@@ -25,6 +25,24 @@ pub trait EmbeddingProvider: Send + Sync {
     /// * Embedding vector with metadata
     async fn embed(&self, text: &str, options: Option<&EmbedOptions>) -> Result<Embedding>;
 
+    /// Generate an embedding for query-time SCORING.
+    ///
+    /// Unlike [`EmbeddingProvider::embed`] (the document/store-time path,
+    /// which may update provider-internal statistics such as a TF-IDF
+    /// vocabulary), this path must be read-only with respect to provider
+    /// state: calling it any number of times must not mutate the model.
+    /// Providers with an internal cache may serve repeated contents from it.
+    ///
+    /// The default implementation delegates to `embed` for stateless
+    /// providers (API-backed models), whose `embed` is already read-only.
+    async fn embed_for_scoring(
+        &self,
+        text: &str,
+        options: Option<&EmbedOptions>,
+    ) -> Result<Embedding> {
+        self.embed(text, options).await
+    }
+
     /// Generate embeddings for multiple texts (batch operation)
     ///
     /// # Arguments

--- a/src/memory/embeddings/providers/tfidf.rs
+++ b/src/memory/embeddings/providers/tfidf.rs
@@ -28,10 +28,24 @@ use std::sync::{Arc, RwLock};
 ///   or mutating any state, and caches the result by content hash so a given
 ///   content string is embedded at most once (shared across the dense
 ///   retriever and the reranker when they hold the same provider).
+///
+/// The scoring cache is invalidated whenever `embed` mutates the vocabulary
+/// (so a cached vector never reflects stale IDF state), and its size is
+/// capped ([`SCORING_CACHE_CAP`]) to bound memory.
+///
+/// KNOWN PRE-EXISTING RETRIEVAL GAP (out of P2 perf scope, tracked as a
+/// follow-up): in the shipped hybrid pipeline the provider instance shared by
+/// the dense retriever and reranker only ever has `embed_for_scoring` called
+/// on it — never `embed` — so its vocabulary stays empty and every term's IDF
+/// falls back to `1.0`. Dense retrieval is therefore currently hashed-TF
+/// cosine with no real IDF weighting. This ties to the carry-forward gap
+/// where the corpus is not fed into the scoring provider, partly explains the
+/// weak recall, and should be addressed in a future task (NOT here).
 pub struct TfIdfProvider {
     config: TfIdfConfig,
     state: Arc<RwLock<TfIdfState>>,
     /// Content-hash-keyed cache of scoring vectors (query-time path only).
+    /// Invalidated on vocabulary mutation; bounded by [`SCORING_CACHE_CAP`].
     scoring_cache: DashMap<String, Vec<f32>>,
     /// Test-only op counters for the scoring path.
     #[cfg(feature = "test-utils")]
@@ -39,6 +53,12 @@ pub struct TfIdfProvider {
     #[cfg(feature = "test-utils")]
     scoring_cache_hits: std::sync::atomic::AtomicUsize,
 }
+
+/// Upper bound on the number of entries retained in the scoring cache. When
+/// an insertion would exceed this cap the cache is cleared wholesale (a crude
+/// but O(1)-amortized eviction — correctness is unaffected, only cache hit
+/// rate). Sized generously so a single search's candidate set always fits.
+const SCORING_CACHE_CAP: usize = 8192;
 
 /// Configuration for TF-IDF embeddings
 #[derive(Debug, Clone)]
@@ -174,6 +194,12 @@ impl TfIdfProvider {
                 .expect("TfIdfProvider state lock is never poisoned: no panics while held");
             state.update_vocabulary(text, self.config.min_word_length);
         }
+        // Vocabulary/IDF state just changed: any cached scoring vector is now
+        // computed against stale statistics, so drop the whole scoring cache.
+        // (Under the shipped wiring the scoring provider is never fed via
+        // `embed`, so this rarely fires; it keeps mixed embed/scoring callers
+        // correct.)
+        self.scoring_cache.clear();
         self.embed_text_readonly(text)
     }
 
@@ -290,6 +316,11 @@ impl EmbeddingProvider for TfIdfProvider {
         #[cfg(feature = "test-utils")]
         self.scoring_embeds_computed
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        // Bound cache growth: clear wholesale before crossing the cap. Crude
+        // but O(1)-amortized; only affects hit rate, never correctness.
+        if self.scoring_cache.len() >= SCORING_CACHE_CAP {
+            self.scoring_cache.clear();
+        }
         self.scoring_cache
             .insert(content_hash.clone(), vector.clone());
         Ok(self.build_embedding(vector, content_hash, options))
@@ -348,6 +379,48 @@ mod tests {
         assert_eq!(provider.embedding_dimension(), 384);
         assert_eq!(provider.name(), "TfIdfProvider");
         assert!(provider.is_available());
+    }
+
+    #[tokio::test]
+    async fn scoring_cache_invalidated_on_vocab_mutation() {
+        // A scoring vector cached against one vocabulary state must NOT be
+        // served stale after `embed` mutates the vocabulary/IDF state.
+        let provider = TfIdfProvider::default();
+        let text = "alpha beta gamma delta";
+
+        // Seed some vocabulary, then cache a scoring vector for `text`.
+        provider
+            .embed("alpha beta gamma delta", None)
+            .await
+            .expect("seed embed");
+        let before = provider
+            .embed_for_scoring(text, None)
+            .await
+            .expect("scoring embed")
+            .vector;
+
+        // Mutate the vocabulary via the document path so that `alpha`'s
+        // document frequency rises while `beta`/`gamma`/`delta` stay at 1.
+        // This changes the RELATIVE IDF weighting among the query's tokens
+        // (a change that survives normalization), so the scoring vector must
+        // differ from the cached one.
+        for _ in 0..25 {
+            provider
+                .embed("alpha epsilon zeta eta", None)
+                .await
+                .expect("mutating embed");
+        }
+
+        let after = provider
+            .embed_for_scoring(text, None)
+            .await
+            .expect("scoring embed after mutation")
+            .vector;
+
+        assert_ne!(
+            before, after,
+            "scoring cache must reflect the mutated vocabulary, not a stale hit"
+        );
     }
 
     #[tokio::test]

--- a/src/memory/embeddings/providers/tfidf.rs
+++ b/src/memory/embeddings/providers/tfidf.rs
@@ -9,6 +9,7 @@ use super::super::provider::{
 };
 use crate::error::Result;
 use async_trait::async_trait;
+use dashmap::DashMap;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::sync::{Arc, RwLock};
@@ -17,9 +18,26 @@ use std::sync::{Arc, RwLock};
 ///
 /// This provider uses Term Frequency-Inverse Document Frequency to create
 /// semantic embeddings without requiring external APIs or models.
+///
+/// Two embedding paths exist:
+/// - [`EmbeddingProvider::embed`] — the document (store-time) path: updates
+///   the vocabulary incrementally (O(tokens), no full IDF-table rebuild) and
+///   then computes the vector against the updated statistics.
+/// - [`EmbeddingProvider::embed_for_scoring`] — the query-time path: computes
+///   the vector against the EXISTING statistics without taking a write lock
+///   or mutating any state, and caches the result by content hash so a given
+///   content string is embedded at most once (shared across the dense
+///   retriever and the reranker when they hold the same provider).
 pub struct TfIdfProvider {
     config: TfIdfConfig,
     state: Arc<RwLock<TfIdfState>>,
+    /// Content-hash-keyed cache of scoring vectors (query-time path only).
+    scoring_cache: DashMap<String, Vec<f32>>,
+    /// Test-only op counters for the scoring path.
+    #[cfg(feature = "test-utils")]
+    scoring_embeds_computed: std::sync::atomic::AtomicUsize,
+    #[cfg(feature = "test-utils")]
+    scoring_cache_hits: std::sync::atomic::AtomicUsize,
 }
 
 /// Configuration for TF-IDF embeddings
@@ -47,9 +65,12 @@ impl Default for TfIdfConfig {
 }
 
 /// Internal state for TF-IDF embeddings
+///
+/// IDF is derived lazily from `(vocabulary doc-frequency, document_count)`
+/// at embed time — there is no materialized IDF table to rebuild, so
+/// ingesting a document is O(tokens), not O(vocabulary).
 struct TfIdfState {
     vocabulary: HashMap<String, usize>,
-    idf_scores: HashMap<String, f64>,
     document_count: usize,
 }
 
@@ -57,11 +78,12 @@ impl TfIdfState {
     fn new() -> Self {
         Self {
             vocabulary: HashMap::new(),
-            idf_scores: HashMap::new(),
             document_count: 0,
         }
     }
 
+    /// Incremental vocabulary update: O(tokens in `text`). No IDF-table
+    /// rebuild — IDF is computed lazily via [`Self::idf`].
     fn update_vocabulary(&mut self, text: &str, min_word_length: usize) {
         let tokens = Self::tokenize(text, min_word_length);
         let unique_tokens: std::collections::HashSet<_> = tokens.into_iter().collect();
@@ -69,22 +91,19 @@ impl TfIdfState {
         self.document_count += 1;
 
         for token in unique_tokens {
-            *self.vocabulary.entry(token.clone()).or_insert(0) += 1;
+            *self.vocabulary.entry(token).or_insert(0) += 1;
         }
-
-        // Recalculate IDF scores
-        self.calculate_idf_scores();
     }
 
-    fn calculate_idf_scores(&mut self) {
-        if self.document_count == 0 {
-            return;
-        }
-
-        self.idf_scores.clear();
-        for (term, doc_freq) in &self.vocabulary {
-            let idf = ((self.document_count as f64) / (*doc_freq as f64 + 1.0)).ln();
-            self.idf_scores.insert(term.clone(), idf);
+    /// Lazy IDF for a single term, identical in value to the previous
+    /// materialized table: `ln(N / (df + 1))` for known terms, `1.0` for
+    /// terms outside the vocabulary (the old table-miss default).
+    fn idf(&self, token: &str) -> f64 {
+        match self.vocabulary.get(token) {
+            Some(doc_freq) if self.document_count > 0 => {
+                ((self.document_count as f64) / (*doc_freq as f64 + 1.0)).ln()
+            }
+            _ => 1.0,
         }
     }
 
@@ -137,19 +156,34 @@ impl TfIdfProvider {
         Self {
             config,
             state: Arc::new(RwLock::new(TfIdfState::new())),
+            scoring_cache: DashMap::new(),
+            #[cfg(feature = "test-utils")]
+            scoring_embeds_computed: std::sync::atomic::AtomicUsize::new(0),
+            #[cfg(feature = "test-utils")]
+            scoring_cache_hits: std::sync::atomic::AtomicUsize::new(0),
         }
     }
 
-    /// Embed text using TF-IDF
+    /// Embed text using TF-IDF (document path: updates vocabulary first)
     fn embed_text_sync(&self, text: &str) -> Result<Vec<f32>> {
-        // Update vocabulary (this modifies state)
+        // Incremental vocabulary update (O(tokens), no IDF-table rebuild)
         {
-            let mut state = self.state.write().expect("write() should succeed");
+            let mut state = self
+                .state
+                .write()
+                .expect("TfIdfProvider state lock is never poisoned: no panics while held");
             state.update_vocabulary(text, self.config.min_word_length);
         }
+        self.embed_text_readonly(text)
+    }
 
-        // Generate embedding (read-only)
-        let state = self.state.read().expect("read() should succeed");
+    /// Compute the TF-IDF vector for `text` against the EXISTING statistics.
+    /// Read-only: takes only a read lock and never mutates vocabulary.
+    fn embed_text_readonly(&self, text: &str) -> Result<Vec<f32>> {
+        let state = self
+            .state
+            .read()
+            .expect("TfIdfProvider state lock is never poisoned: no panics while held");
         let tokens = TfIdfState::tokenize(text, self.config.min_word_length);
         let tf_scores = TfIdfState::calculate_tf(&tokens);
 
@@ -157,7 +191,7 @@ impl TfIdfProvider {
         let mut embedding = vec![0.0f32; self.config.embedding_dim];
 
         for (token, tf) in tf_scores {
-            let idf = state.idf_scores.get(&token).unwrap_or(&1.0);
+            let idf = state.idf(&token);
             let tfidf = (tf * idf) as f32;
 
             // Hash token to embedding dimension
@@ -172,36 +206,93 @@ impl TfIdfProvider {
 
         Ok(embedding)
     }
-}
 
-#[async_trait]
-impl EmbeddingProvider for TfIdfProvider {
-    async fn embed(&self, text: &str, options: Option<&EmbedOptions>) -> Result<Embedding> {
-        let content_hash = compute_content_hash(text);
-
-        // Generate embedding
-        let mut vector = self.embed_text_sync(text)?;
-
-        // Apply options if provided
+    /// Wrap a raw vector into an [`Embedding`] with standard metadata.
+    fn build_embedding(
+        &self,
+        mut vector: Vec<f32>,
+        content_hash: String,
+        options: Option<&EmbedOptions>,
+    ) -> Embedding {
         if let Some(opts) = options {
             if opts.normalize {
                 normalize_vector(&mut vector);
             }
         }
 
-        // Create embedding with metadata
         let mut embedding = Embedding::new(vector, self.model_id())
             .with_content_hash(content_hash)
             .with_version("1.0".to_string());
 
-        // Add custom metadata if provided
         if let Some(opts) = options {
             for (key, value) in &opts.metadata {
                 embedding.metadata.insert(key.clone(), value.clone());
             }
         }
 
-        Ok(embedding)
+        embedding
+    }
+
+    /// Number of terms currently in the vocabulary (test-utils).
+    #[cfg(feature = "test-utils")]
+    pub fn vocabulary_size(&self) -> usize {
+        self.state
+            .read()
+            .expect("TfIdfProvider state lock is never poisoned: no panics while held")
+            .vocabulary
+            .len()
+    }
+
+    /// Number of scoring embeddings actually computed (cache misses)
+    /// since construction (test-utils).
+    #[cfg(feature = "test-utils")]
+    pub fn scoring_embeds_computed(&self) -> usize {
+        self.scoring_embeds_computed
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Number of scoring embeddings served from the content-hash cache
+    /// since construction (test-utils).
+    #[cfg(feature = "test-utils")]
+    pub fn scoring_cache_hits(&self) -> usize {
+        self.scoring_cache_hits
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
+#[async_trait]
+impl EmbeddingProvider for TfIdfProvider {
+    async fn embed(&self, text: &str, options: Option<&EmbedOptions>) -> Result<Embedding> {
+        let content_hash = compute_content_hash(text);
+        let vector = self.embed_text_sync(text)?;
+        Ok(self.build_embedding(vector, content_hash, options))
+    }
+
+    /// Query-time scoring path: read-only against the existing IDF
+    /// statistics, cached by content hash so each distinct content is
+    /// embedded at most once across the dense retriever and the reranker.
+    async fn embed_for_scoring(
+        &self,
+        text: &str,
+        options: Option<&EmbedOptions>,
+    ) -> Result<Embedding> {
+        let content_hash = compute_content_hash(text);
+
+        if let Some(cached) = self.scoring_cache.get(&content_hash) {
+            #[cfg(feature = "test-utils")]
+            self.scoring_cache_hits
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let vector = cached.clone();
+            return Ok(self.build_embedding(vector, content_hash, options));
+        }
+
+        let vector = self.embed_text_readonly(text)?;
+        #[cfg(feature = "test-utils")]
+        self.scoring_embeds_computed
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.scoring_cache
+            .insert(content_hash.clone(), vector.clone());
+        Ok(self.build_embedding(vector, content_hash, options))
     }
 
     async fn embed_batch(

--- a/src/memory/embeddings/simple_embeddings.rs
+++ b/src/memory/embeddings/simple_embeddings.rs
@@ -8,10 +8,12 @@ use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
 /// Simple embedder using TF-IDF
+///
+/// IDF is derived lazily from the vocabulary document frequencies at embed
+/// time; ingesting a document is O(tokens), with no full IDF-table rebuild.
 pub struct SimpleEmbedder {
     embedding_dim: usize,
     vocabulary: HashMap<String, usize>,
-    idf_scores: HashMap<String, f64>,
     document_count: usize,
 }
 
@@ -21,16 +23,20 @@ impl SimpleEmbedder {
         Self {
             embedding_dim,
             vocabulary: HashMap::new(),
-            idf_scores: HashMap::new(),
             document_count: 0,
         }
     }
 
-    /// Embed text into a vector
+    /// Embed text into a vector (document path: updates vocabulary first)
     pub fn embed_text(&mut self, text: &str) -> Result<Vec<f64>> {
         // Update vocabulary with this text
         self.update_vocabulary(text);
+        self.embed_text_readonly(text)
+    }
 
+    /// Embed text against the EXISTING vocabulary statistics without
+    /// mutating them (read-only query/scoring path).
+    pub fn embed_text_readonly(&self, text: &str) -> Result<Vec<f64>> {
         let tokens = self.tokenize(text);
         let tf_scores = self.calculate_tf(&tokens);
 
@@ -38,7 +44,7 @@ impl SimpleEmbedder {
         let mut embedding = vec![0.0; self.embedding_dim];
 
         for (token, tf) in tf_scores {
-            let idf = self.idf_scores.get(&token).unwrap_or(&1.0);
+            let idf = self.idf(&token);
             let tfidf = tf * idf;
 
             // Hash token to embedding dimension
@@ -52,7 +58,8 @@ impl SimpleEmbedder {
         Ok(embedding)
     }
 
-    /// Update vocabulary and IDF scores with new text
+    /// Update vocabulary document frequencies with new text.
+    /// Incremental: O(tokens in `text`), no IDF-table rebuild.
     pub fn update_vocabulary(&mut self, text: &str) {
         let tokens = self.tokenize(text);
         let unique_tokens: std::collections::HashSet<_> = tokens.into_iter().collect();
@@ -60,11 +67,19 @@ impl SimpleEmbedder {
         self.document_count += 1;
 
         for token in unique_tokens {
-            *self.vocabulary.entry(token.clone()).or_insert(0) += 1;
+            *self.vocabulary.entry(token).or_insert(0) += 1;
         }
+    }
 
-        // Recalculate IDF scores
-        self.calculate_idf_scores();
+    /// Lazy IDF for a single term, identical in value to the previously
+    /// materialized table: `ln(N / df)` for known terms, `1.0` for unknown.
+    fn idf(&self, token: &str) -> f64 {
+        match self.vocabulary.get(token) {
+            Some(doc_freq) if self.document_count > 0 => {
+                (self.document_count as f64 / *doc_freq as f64).ln()
+            }
+            _ => 1.0,
+        }
     }
 
     /// Tokenize text into words
@@ -97,16 +112,6 @@ impl SimpleEmbedder {
         }
 
         tf_scores
-    }
-
-    /// Calculate IDF scores for all vocabulary
-    fn calculate_idf_scores(&mut self) {
-        self.idf_scores.clear();
-
-        for (token, doc_freq) in &self.vocabulary {
-            let idf = (self.document_count as f64 / *doc_freq as f64).ln();
-            self.idf_scores.insert(token.clone(), idf);
-        }
     }
 
     /// Hash a token to an embedding dimension index

--- a/src/memory/knowledge_graph/graph.rs
+++ b/src/memory/knowledge_graph/graph.rs
@@ -88,6 +88,28 @@ impl GraphStats {
     }
 }
 
+/// Recency key used for deterministic candidate ordering: `last_modified`,
+/// falling back to `created_at`, then `ingested_at` (newest first).
+pub(crate) fn node_recency(node: &Node) -> DateTime<Utc> {
+    node.last_modified
+        .or(node.created_at)
+        .unwrap_or(node.ingested_at)
+}
+
+/// Lowercased alphanumeric token set used for content-relevance scoring.
+pub(crate) fn scan_tokens(text: &str) -> HashSet<String> {
+    text.to_lowercase()
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|w| !w.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+/// The text a node is indexed/scored by: description, falling back to label.
+fn node_scan_text(node: &Node) -> &str {
+    node.description.as_deref().unwrap_or(&node.label)
+}
+
 /// Core knowledge graph structure
 pub struct KnowledgeGraph {
     /// All nodes in the graph
@@ -104,6 +126,15 @@ pub struct KnowledgeGraph {
     config: GraphConfig,
     /// Cached statistics
     stats_cache: RwLock<Option<(GraphStats, DateTime<Utc>)>>,
+    /// Inverted token index over each node's scan text (description, falling
+    /// back to label): token -> node ids. Maintained on every node mutation
+    /// (add/update/remove) so candidate selection touches only posting lists
+    /// for the query's tokens instead of scoring all nodes.
+    token_index: RwLock<HashMap<String, HashSet<Uuid>>>,
+    /// Nodes ordered newest-first with id-ascending tie-break:
+    /// (Reverse(recency), id). Forward iteration yields the deterministic
+    /// recency ordering used for candidate windows without sorting all nodes.
+    recency_index: RwLock<std::collections::BTreeSet<(std::cmp::Reverse<DateTime<Utc>>, Uuid)>>,
 }
 
 impl KnowledgeGraph {
@@ -117,7 +148,87 @@ impl KnowledgeGraph {
             metadata: RwLock::new(KnowledgeGraphMetadata::new()),
             config,
             stats_cache: RwLock::new(None),
+            token_index: RwLock::new(HashMap::new()),
+            recency_index: RwLock::new(std::collections::BTreeSet::new()),
         }
+    }
+
+    /// Add `node` to the token and recency indexes.
+    fn index_node(&self, node: &Node) {
+        let mut tokens = self.token_index.write();
+        for token in scan_tokens(node_scan_text(node)) {
+            tokens.entry(token).or_default().insert(node.id);
+        }
+        drop(tokens);
+        self.recency_index
+            .write()
+            .insert((std::cmp::Reverse(node_recency(node)), node.id));
+    }
+
+    /// Remove `node` (with its CURRENT indexed text/recency) from the indexes.
+    fn unindex_node(&self, node: &Node) {
+        let mut tokens = self.token_index.write();
+        for token in scan_tokens(node_scan_text(node)) {
+            if let Some(ids) = tokens.get_mut(&token) {
+                ids.remove(&node.id);
+                if ids.is_empty() {
+                    tokens.remove(&token);
+                }
+            }
+        }
+        drop(tokens);
+        self.recency_index
+            .write()
+            .remove(&(std::cmp::Reverse(node_recency(node)), node.id));
+    }
+
+    /// Insert or replace a node while keeping the token/recency indexes
+    /// coherent. All in-place node content mutations must go through this
+    /// (instead of writing `self.nodes` directly).
+    pub(crate) fn put_node(&self, node: Node) {
+        if let Some(old) = self.nodes.get(&node.id).map(|n| n.clone()) {
+            self.unindex_node(&old);
+        }
+        self.index_node(&node);
+        self.nodes.insert(node.id, node);
+        self.invalidate_stats_cache();
+        self.mark_modified();
+    }
+
+    /// For each node whose indexed text shares >= 1 token with
+    /// `query_tokens`, the number of shared tokens. Cost is proportional to
+    /// the total size of the touched posting lists, not the node count.
+    pub(crate) fn token_overlap_counts(
+        &self,
+        query_tokens: &HashSet<String>,
+    ) -> HashMap<Uuid, usize> {
+        let index = self.token_index.read();
+        let mut counts: HashMap<Uuid, usize> = HashMap::new();
+        for token in query_tokens {
+            if let Some(ids) = index.get(token) {
+                for id in ids {
+                    *counts.entry(*id).or_insert(0) += 1;
+                }
+            }
+        }
+        counts
+    }
+
+    /// Up to `limit` node ids in deterministic recency order (newest first,
+    /// id-ascending tie-break) for which `keep` returns true. Early-stops at
+    /// `limit`, so cost is O(limit + skipped), not O(total nodes) when the
+    /// filter accepts most candidates.
+    pub(crate) fn recency_ordered_ids<F>(&self, limit: usize, mut keep: F) -> Vec<Uuid>
+    where
+        F: FnMut(Uuid) -> bool,
+    {
+        self.recency_index
+            .read()
+            .iter()
+            .map(|(_, id)| *id)
+            .filter(|id| keep(*id))
+            .take(limit)
+            .collect()
     }
 
     /// Add a node to the graph
@@ -129,6 +240,12 @@ impl KnowledgeGraph {
         }
 
         let node_id = node.id;
+        // Unindex a same-id node BEFORE indexing the new one so shared
+        // tokens/recency keys survive the replacement.
+        if let Some(old) = self.nodes.get(&node_id).map(|n| n.clone()) {
+            self.unindex_node(&old);
+        }
+        self.index_node(&node);
         self.nodes.insert(node_id, node);
         self.adjacency.insert(node_id, HashSet::new());
         self.reverse_adjacency.insert(node_id, HashSet::new());
@@ -193,6 +310,7 @@ impl KnowledgeGraph {
     /// Remove a node and all its edges
     pub async fn remove_node(&self, node_id: Uuid) -> Result<bool> {
         if let Some((_, _node)) = self.nodes.remove(&node_id) {
+            self.unindex_node(&_node);
             // Remove all edges connected to this node
             let mut edges_to_remove = Vec::new();
 

--- a/src/memory/knowledge_graph/mod.rs
+++ b/src/memory/knowledge_graph/mod.rs
@@ -45,6 +45,20 @@ pub struct ExtractedRelation {
     pub superseded: bool,
 }
 
+/// Planned knowledge-graph mutation for a stored memory, computed under a
+/// read lock by [`MemoryKnowledgeGraph::plan_memory_node_update`] and applied
+/// under a (short) write lock by
+/// [`MemoryKnowledgeGraph::apply_memory_node_plan`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryNodePlan {
+    /// The memory already has a backing node: update it in place.
+    UpdateExisting(Uuid),
+    /// A sufficiently similar node exists: merge the memory into it.
+    MergeWith(Uuid),
+    /// No existing or similar node: create a new one.
+    CreateNew,
+}
+
 /// Edge property key recording which memory a relation was extracted from.
 const PROP_SOURCE_MEMORY: &str = "source_memory";
 /// Edge property key carrying the normalized predicate.
@@ -307,6 +321,48 @@ impl MemoryKnowledgeGraph {
         self.add_or_update_memory_node(memory).await
     }
 
+    /// Plan the KG mutation for a stored memory WITHOUT mutating the graph.
+    /// This carries the O(n) similarity scan (bounded by
+    /// [`Self::KG_SCAN_LIMIT`]) so callers can run it under a read lock and
+    /// keep the write lock ([`Self::apply_memory_node_plan`]) short.
+    pub async fn plan_memory_node_update(&self, memory: &MemoryEntry) -> Result<MemoryNodePlan> {
+        if let Some(existing_node_id) = self.memory_to_node.get(&memory.key) {
+            return Ok(MemoryNodePlan::UpdateExisting(*existing_node_id));
+        }
+        if let Some(similar_node_id) = self.find_similar_node(memory).await? {
+            return Ok(MemoryNodePlan::MergeWith(similar_node_id));
+        }
+        Ok(MemoryNodePlan::CreateNew)
+    }
+
+    /// Apply a plan produced by [`Self::plan_memory_node_update`]. The plan
+    /// is revalidated against the current graph (it may be stale if the graph
+    /// changed between the read and write locks); a stale plan degrades to
+    /// creating a new node. Returns the node id and whether relationship
+    /// detection ([`Self::detect_relationship_edges`]) still needs to run for
+    /// a freshly created node.
+    pub async fn apply_memory_node_plan(
+        &mut self,
+        plan: MemoryNodePlan,
+        memory: &MemoryEntry,
+    ) -> Result<(Uuid, bool)> {
+        // Revalidate: if the memory got a node since planning, update it.
+        if let Some(existing_node_id) = self.memory_to_node.get(&memory.key).copied() {
+            let node_id = self.update_existing_node(existing_node_id, memory).await?;
+            return Ok((node_id, false));
+        }
+        if let MemoryNodePlan::MergeWith(similar_node_id) = plan {
+            if self.graph.get_node(similar_node_id).await?.is_some() {
+                let node_id = self
+                    .merge_with_existing_node(similar_node_id, memory)
+                    .await?;
+                return Ok((node_id, false));
+            }
+        }
+        let node_id = self.create_node_without_detection(memory).await?;
+        Ok((node_id, true))
+    }
+
     /// Create a relationship between two memory entries
     #[tracing::instrument(skip(self, properties), fields(
         from_memory = %from_memory_key,
@@ -492,12 +548,34 @@ impl MemoryKnowledgeGraph {
         self.graph.get_connected_nodes(node_id).await
     }
 
+    /// Cap on the nodes examined by per-store similarity/relationship
+    /// scans. Bounds the write-path cost per store: instead of scanning every
+    /// node in the graph, at most this many candidates are examined.
+    const KG_SCAN_LIMIT: usize = 256;
+
     /// Auto-detect relationships based on content similarity and metadata
     async fn auto_detect_relationships(
         &mut self,
         node_id: Uuid,
         memory: &MemoryEntry,
     ) -> Result<()> {
+        let edges = self.detect_relationship_edges(node_id, memory).await?;
+        self.add_detected_edges(edges).await
+    }
+
+    /// Read-only relationship detection for a node backing `memory`: computes
+    /// tag-, temporal- and semantic-relationship edges WITHOUT mutating the
+    /// graph, so callers can run it under a read lock and apply the returned
+    /// edges under a short write lock ([`Self::add_detected_edges`]).
+    /// Temporal/semantic candidate scans are capped at
+    /// [`Self::KG_SCAN_LIMIT`] nodes.
+    pub async fn detect_relationship_edges(
+        &self,
+        node_id: Uuid,
+        memory: &MemoryEntry,
+    ) -> Result<Vec<Edge>> {
+        let mut edges = Vec::new();
+
         // Find similar memories based on tags
         for tag in &memory.metadata.tags {
             let similar_memories = self.get_memories_by_concept(tag).await?;
@@ -505,7 +583,7 @@ impl MemoryKnowledgeGraph {
                 if similar_memory_key != memory.key {
                     if let Some(similar_node_id) = self.memory_to_node.get(&similar_memory_key) {
                         // Create a "related_to" relationship
-                        let edge = Edge::new(
+                        edges.push(Edge::new(
                             node_id,
                             *similar_node_id,
                             RelationshipType::RelatedTo,
@@ -513,41 +591,24 @@ impl MemoryKnowledgeGraph {
                                 ("reason".to_string(), "shared_tag".to_string()),
                                 ("tag".to_string(), tag.clone()),
                             ])),
-                        );
-                        let _ = self.graph.add_edge(edge).await;
+                        ));
                     }
                 }
             }
         }
 
-        // Detect temporal relationships
-        self.detect_temporal_relationships(node_id, memory).await?;
-
-        // Detect semantic relationships (if embeddings are available)
-        if memory.embedding.is_some() {
-            self.detect_semantic_relationships(node_id, memory).await?;
-        }
-
-        Ok(())
-    }
-
-    /// Detect temporal relationships between memories
-    async fn detect_temporal_relationships(
-        &mut self,
-        node_id: Uuid,
-        memory: &MemoryEntry,
-    ) -> Result<()> {
-        // Find memories created around the same time
+        // Detect temporal relationships (bounded candidate scan)
         let time_window = chrono::Duration::hours(1);
         let memory_time = memory.created_at();
-
-        for (other_memory_key, other_node_id) in &self.memory_to_node {
+        for (other_memory_key, other_node_id) in
+            self.memory_to_node.iter().take(Self::KG_SCAN_LIMIT)
+        {
             if other_memory_key != &memory.key {
                 if let Some(other_node) = self.graph.get_node(*other_node_id).await? {
                     if let Some(other_time) = other_node.created_at {
                         let time_diff = (memory_time - other_time).abs();
                         if time_diff <= time_window {
-                            let edge = Edge::new(
+                            edges.push(Edge::new(
                                 node_id,
                                 *other_node_id,
                                 RelationshipType::TemporallyRelated,
@@ -555,33 +616,26 @@ impl MemoryKnowledgeGraph {
                                     "time_diff_minutes".to_string(),
                                     time_diff.num_minutes().to_string(),
                                 )])),
-                            );
-                            let _ = self.graph.add_edge(edge).await;
+                            ));
                         }
                     }
                 }
             }
         }
 
-        Ok(())
-    }
-
-    /// Detect semantic relationships using embeddings
-    async fn detect_semantic_relationships(
-        &mut self,
-        node_id: Uuid,
-        memory: &MemoryEntry,
-    ) -> Result<()> {
+        // Detect semantic relationships (if embeddings are available;
+        // bounded candidate scan)
         if let Some(embedding) = &memory.embedding {
             let similarity_threshold = self.config.semantic_similarity_threshold;
-
-            for (other_memory_key, other_node_id) in &self.memory_to_node {
+            for (other_memory_key, other_node_id) in
+                self.memory_to_node.iter().take(Self::KG_SCAN_LIMIT)
+            {
                 if other_memory_key != &memory.key {
                     if let Some(other_node) = self.graph.get_node(*other_node_id).await? {
                         if let Some(other_embedding) = &other_node.embedding {
                             let similarity = cosine_similarity(embedding, other_embedding);
                             if similarity >= similarity_threshold {
-                                let edge = Edge::new(
+                                edges.push(Edge::new(
                                     node_id,
                                     *other_node_id,
                                     RelationshipType::SemanticallyRelated,
@@ -589,8 +643,7 @@ impl MemoryKnowledgeGraph {
                                         "similarity_score".to_string(),
                                         similarity.to_string(),
                                     )])),
-                                );
-                                let _ = self.graph.add_edge(edge).await;
+                                ));
                             }
                         }
                     }
@@ -598,6 +651,17 @@ impl MemoryKnowledgeGraph {
             }
         }
 
+        Ok(edges)
+    }
+
+    /// Apply edges computed by [`Self::detect_relationship_edges`]. Kept
+    /// separate so the O(n) detection can run outside the write lock and only
+    /// this mutation needs `&mut self`. Individual edge failures are ignored
+    /// (best-effort), matching the prior auto-detection behavior.
+    pub async fn add_detected_edges(&mut self, edges: Vec<Edge>) -> Result<()> {
+        for edge in edges {
+            let _ = self.graph.add_edge(edge).await;
+        }
         Ok(())
     }
 
@@ -657,7 +721,7 @@ impl MemoryKnowledgeGraph {
         let similarity_threshold = self.config.semantic_similarity_threshold;
         let mut best_match: Option<(Uuid, f64)> = None;
 
-        for node_ref in self.graph.nodes.iter() {
+        for node_ref in self.graph.nodes.iter().take(Self::KG_SCAN_LIMIT) {
             let node = node_ref.value();
 
             // Skip if this is already mapped to a different memory
@@ -744,15 +808,23 @@ impl MemoryKnowledgeGraph {
 
     /// Create a completely new node
     async fn create_new_node(&mut self, memory: &MemoryEntry) -> Result<Uuid> {
+        let node_id = self.create_node_without_detection(memory).await?;
+
+        // Auto-detect relationships with existing nodes
+        self.auto_detect_relationships(node_id, memory).await?;
+
+        Ok(node_id)
+    }
+
+    /// Create a new node and mappings WITHOUT relationship auto-detection,
+    /// so detection can run separately outside the write lock.
+    async fn create_node_without_detection(&mut self, memory: &MemoryEntry) -> Result<Uuid> {
         let node = Node::from_memory(memory);
         let node_id = self.graph.add_node(node).await?;
 
         // Update mappings
         self.memory_to_node.insert(memory.key.clone(), node_id);
         self.node_to_memory.insert(node_id, memory.key.clone());
-
-        // Auto-detect relationships with existing nodes
-        self.auto_detect_relationships(node_id, memory).await?;
 
         tracing::info!(
             node_id = %node_id,

--- a/src/memory/knowledge_graph/mod.rs
+++ b/src/memory/knowledge_graph/mod.rs
@@ -213,9 +213,11 @@ impl MemoryKnowledgeGraph {
         let Some(node_id) = self.memory_to_node.get(memory_key) else {
             return Ok(false);
         };
-        if let Some(mut node) = self.graph.nodes.get_mut(node_id) {
+        if let Some(mut node) = self.graph.nodes.get(node_id).map(|n| n.clone()) {
             node.description = Some(content.to_string());
             node.last_modified = Some(chrono::Utc::now());
+            // Route through put_node so token/recency indexes stay coherent.
+            self.graph.put_node(node);
             Ok(true)
         } else {
             Ok(false)
@@ -238,9 +240,11 @@ impl MemoryKnowledgeGraph {
         let merged = self
             .merge_content(&existing.description.unwrap_or_default(), new_content)
             .await?;
-        if let Some(mut node) = self.graph.nodes.get_mut(&node_id) {
+        if let Some(mut node) = self.graph.nodes.get(&node_id).map(|n| n.clone()) {
             node.description = Some(merged);
             node.last_modified = Some(chrono::Utc::now());
+            // Route through put_node so token/recency indexes stay coherent.
+            self.graph.put_node(node);
         }
         Ok(true)
     }
@@ -556,18 +560,12 @@ impl MemoryKnowledgeGraph {
     /// Recency key for deterministic ordering: newest first. Uses
     /// `last_modified`, falling back to `created_at`.
     fn node_recency(node: &Node) -> chrono::DateTime<chrono::Utc> {
-        node.last_modified
-            .or(node.created_at)
-            .unwrap_or(node.ingested_at)
+        graph::node_recency(node)
     }
 
     /// Lowercased alphanumeric token set used for content-relevance scoring.
     fn scan_tokens(text: &str) -> std::collections::HashSet<String> {
-        text.to_lowercase()
-            .split(|c: char| !c.is_alphanumeric())
-            .filter(|w| !w.is_empty())
-            .map(str::to_string)
-            .collect()
+        graph::scan_tokens(text)
     }
 
     /// Memory-backed candidate nodes (excluding `exclude_key`), ordered
@@ -582,12 +580,23 @@ impl MemoryKnowledgeGraph {
         query_text: &str,
     ) -> Result<Vec<(Uuid, Node)>> {
         let query_tokens = Self::scan_tokens(query_text);
+        // Candidate ids sharing >= 1 indexed token with the query; cost is
+        // bounded by the touched posting-list sizes, not the node count.
+        let overlap_candidates = self.graph.token_overlap_counts(&query_tokens);
         let mut scored: Vec<(usize, chrono::DateTime<chrono::Utc>, Uuid, Node)> = Vec::new();
-        for (mem_key, node_id) in &self.memory_to_node {
+        for node_id in overlap_candidates.keys() {
+            let Some(mem_key) = self.node_to_memory.get(node_id) else {
+                continue; // entity node: not a memory-backed candidate
+            };
             if mem_key == exclude_key {
                 continue;
             }
             if let Some(node) = self.graph.get_node(*node_id).await? {
+                // Recompute overlap against the DESCRIPTION ONLY (the index
+                // covers description-or-label, so index candidacy is a
+                // superset; a label-only match scores 0 here and is picked
+                // up by the recency fill below, matching the historical
+                // full-scan scoring exactly).
                 let overlap = node
                     .description
                     .as_deref()
@@ -596,6 +605,9 @@ impl MemoryKnowledgeGraph {
                         query_tokens.intersection(&toks).count()
                     })
                     .unwrap_or(0);
+                if overlap == 0 {
+                    continue;
+                }
                 let recency = Self::node_recency(&node);
                 scored.push((overlap, recency, *node_id, node));
             }
@@ -607,6 +619,30 @@ impl MemoryKnowledgeGraph {
                 .then_with(|| a.2.cmp(&b.2))
         });
         scored.truncate(Self::KG_SCAN_LIMIT);
+        // Zero-overlap nodes sort strictly after all positive-overlap nodes
+        // under the historical comparator, among themselves by recency desc
+        // then id asc — exactly the recency index order. Fill any remaining
+        // window slots from it (early-stopping; residual bound is
+        // O(limit + non-memory/skipped nodes interleaved), not a full sort).
+        if scored.len() < Self::KG_SCAN_LIMIT {
+            let taken: std::collections::HashSet<Uuid> =
+                scored.iter().map(|(_, _, id, _)| *id).collect();
+            let fill_ids =
+                self.graph
+                    .recency_ordered_ids(Self::KG_SCAN_LIMIT - scored.len(), |id| {
+                        !taken.contains(&id)
+                            && self
+                                .node_to_memory
+                                .get(&id)
+                                .is_some_and(|mem_key| mem_key != exclude_key)
+                    });
+            for id in fill_ids {
+                if let Some(node) = self.graph.get_node(id).await? {
+                    let recency = Self::node_recency(&node);
+                    scored.push((0, recency, id, node));
+                }
+            }
+        }
         Ok(scored
             .into_iter()
             .map(|(_, _, id, node)| (id, node))
@@ -619,19 +655,22 @@ impl MemoryKnowledgeGraph {
     /// for temporal detection, which is about creation time rather than
     /// content.
     async fn recency_ordered_candidates(&self, exclude_key: &str) -> Result<Vec<(Uuid, Node)>> {
-        let mut nodes: Vec<(chrono::DateTime<chrono::Utc>, Uuid, Node)> = Vec::new();
-        for (mem_key, node_id) in &self.memory_to_node {
-            if mem_key == exclude_key {
-                continue;
-            }
-            if let Some(node) = self.graph.get_node(*node_id).await? {
-                let recency = Self::node_recency(&node);
-                nodes.push((recency, *node_id, node));
+        // The recency index already yields (recency desc, id asc) order:
+        // early-stop after KG_SCAN_LIMIT memory-backed nodes instead of
+        // sorting all of them. Residual bound: O(limit + non-memory nodes
+        // interleaved among the newest), not O(n log n).
+        let ids = self.graph.recency_ordered_ids(Self::KG_SCAN_LIMIT, |id| {
+            self.node_to_memory
+                .get(&id)
+                .is_some_and(|mem_key| mem_key != exclude_key)
+        });
+        let mut nodes = Vec::with_capacity(ids.len());
+        for id in ids {
+            if let Some(node) = self.graph.get_node(id).await? {
+                nodes.push((id, node));
             }
         }
-        nodes.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
-        nodes.truncate(Self::KG_SCAN_LIMIT);
-        Ok(nodes.into_iter().map(|(_, id, node)| (id, node)).collect())
+        Ok(nodes)
     }
 
     /// Auto-detect relationships based on content similarity and metadata
@@ -773,7 +812,7 @@ impl MemoryKnowledgeGraph {
             }
 
             // Store the updated node back
-            self.graph.nodes.insert(node_id, node);
+            self.graph.put_node(node);
 
             // Update relationships based on content changes
             self.update_relationships_for_changed_node(node_id, &old_content, &new_content)
@@ -828,24 +867,43 @@ impl MemoryKnowledgeGraph {
     /// subset instead of an arbitrary map-iteration-order prefix.
     fn relevance_ordered_graph_nodes(&self, query_text: &str) -> Vec<(Uuid, Node)> {
         let query_tokens = Self::scan_tokens(query_text);
-        let mut scored: Vec<(usize, chrono::DateTime<chrono::Utc>, Uuid, Node)> = self
-            .graph
-            .nodes
-            .iter()
-            .map(|node_ref| {
-                let node = node_ref.value().clone();
-                let text = node.description.as_deref().unwrap_or(&node.label);
-                let overlap = query_tokens.intersection(&Self::scan_tokens(text)).count();
+        // Positive-overlap candidates via the token index (posting-list
+        // union), NOT a score of every node. The index is built over the same
+        // description-or-label text this method historically scored, so the
+        // accumulated posting counts equal the historical intersection
+        // counts exactly.
+        let overlap_candidates = self.graph.token_overlap_counts(&query_tokens);
+        let mut scored: Vec<(usize, chrono::DateTime<chrono::Utc>, Uuid, Node)> =
+            Vec::with_capacity(overlap_candidates.len().min(Self::KG_SCAN_LIMIT));
+        for (node_id, overlap) in &overlap_candidates {
+            if let Some(node) = self.graph.nodes.get(node_id).map(|n| n.clone()) {
                 let recency = Self::node_recency(&node);
-                (overlap, recency, node.id, node)
-            })
-            .collect();
+                scored.push((*overlap, recency, *node_id, node));
+            }
+        }
         scored.sort_by(|a, b| {
             b.0.cmp(&a.0)
                 .then_with(|| b.1.cmp(&a.1))
                 .then_with(|| a.2.cmp(&b.2))
         });
         scored.truncate(Self::KG_SCAN_LIMIT);
+        // Zero-overlap nodes order strictly after all positive-overlap ones
+        // under the historical comparator and among themselves by recency
+        // desc then id asc — exactly the recency index order. Fill remaining
+        // window slots from it with early stop.
+        if scored.len() < Self::KG_SCAN_LIMIT {
+            let fill_ids = self
+                .graph
+                .recency_ordered_ids(Self::KG_SCAN_LIMIT - scored.len(), |id| {
+                    !overlap_candidates.contains_key(&id)
+                });
+            for id in fill_ids {
+                if let Some(node) = self.graph.nodes.get(&id).map(|n| n.clone()) {
+                    let recency = Self::node_recency(&node);
+                    scored.push((0, recency, id, node));
+                }
+            }
+        }
         scored
             .into_iter()
             .map(|(_, _, id, node)| (id, node))
@@ -912,7 +970,7 @@ impl MemoryKnowledgeGraph {
             }
 
             // Store updated node
-            self.graph.nodes.insert(node_id, node);
+            self.graph.put_node(node);
 
             // Update mappings
             self.memory_to_node.insert(memory.key.clone(), node_id);

--- a/src/memory/knowledge_graph/mod.rs
+++ b/src/memory/knowledge_graph/mod.rs
@@ -549,9 +549,90 @@ impl MemoryKnowledgeGraph {
     }
 
     /// Cap on the nodes examined by per-store similarity/relationship
-    /// scans. Bounds the write-path cost per store: instead of scanning every
-    /// node in the graph, at most this many candidates are examined.
+    /// scans. Bounds the write-path cost per store: at most this many
+    /// deterministically-ordered candidates are examined.
     const KG_SCAN_LIMIT: usize = 256;
+
+    /// Recency key for deterministic ordering: newest first. Uses
+    /// `last_modified`, falling back to `created_at`.
+    fn node_recency(node: &Node) -> chrono::DateTime<chrono::Utc> {
+        node.last_modified
+            .or(node.created_at)
+            .unwrap_or(node.ingested_at)
+    }
+
+    /// Lowercased alphanumeric token set used for content-relevance scoring.
+    fn scan_tokens(text: &str) -> std::collections::HashSet<String> {
+        text.to_lowercase()
+            .split(|c: char| !c.is_alphanumeric())
+            .filter(|w| !w.is_empty())
+            .map(str::to_string)
+            .collect()
+    }
+
+    /// Memory-backed candidate nodes (excluding `exclude_key`), ordered
+    /// DETERMINISTICALLY by content relevance to `query_text` (token-overlap
+    /// desc), then recency (newest first), then node id, and capped at
+    /// [`Self::KG_SCAN_LIMIT`]. Unlike iterating an unordered `HashMap`/
+    /// `DashMap`, this keeps the examined candidate set reproducible run-to-run
+    /// AND biased toward the memories most likely to match.
+    async fn relevance_ordered_candidates(
+        &self,
+        exclude_key: &str,
+        query_text: &str,
+    ) -> Result<Vec<(Uuid, Node)>> {
+        let query_tokens = Self::scan_tokens(query_text);
+        let mut scored: Vec<(usize, chrono::DateTime<chrono::Utc>, Uuid, Node)> = Vec::new();
+        for (mem_key, node_id) in &self.memory_to_node {
+            if mem_key == exclude_key {
+                continue;
+            }
+            if let Some(node) = self.graph.get_node(*node_id).await? {
+                let overlap = node
+                    .description
+                    .as_deref()
+                    .map(|d| {
+                        let toks = Self::scan_tokens(d);
+                        query_tokens.intersection(&toks).count()
+                    })
+                    .unwrap_or(0);
+                let recency = Self::node_recency(&node);
+                scored.push((overlap, recency, *node_id, node));
+            }
+        }
+        // Overlap desc, then recency desc, then id asc (fully deterministic).
+        scored.sort_by(|a, b| {
+            b.0.cmp(&a.0)
+                .then_with(|| b.1.cmp(&a.1))
+                .then_with(|| a.2.cmp(&b.2))
+        });
+        scored.truncate(Self::KG_SCAN_LIMIT);
+        Ok(scored
+            .into_iter()
+            .map(|(_, _, id, node)| (id, node))
+            .collect())
+    }
+
+    /// Memory-backed candidate nodes (excluding `exclude_key`), ordered
+    /// DETERMINISTICALLY by recency (newest first) then node id — an explicit
+    /// "most-recent-N nodes" window — capped at [`Self::KG_SCAN_LIMIT`]. Used
+    /// for temporal detection, which is about creation time rather than
+    /// content.
+    async fn recency_ordered_candidates(&self, exclude_key: &str) -> Result<Vec<(Uuid, Node)>> {
+        let mut nodes: Vec<(chrono::DateTime<chrono::Utc>, Uuid, Node)> = Vec::new();
+        for (mem_key, node_id) in &self.memory_to_node {
+            if mem_key == exclude_key {
+                continue;
+            }
+            if let Some(node) = self.graph.get_node(*node_id).await? {
+                let recency = Self::node_recency(&node);
+                nodes.push((recency, *node_id, node));
+            }
+        }
+        nodes.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
+        nodes.truncate(Self::KG_SCAN_LIMIT);
+        Ok(nodes.into_iter().map(|(_, id, node)| (id, node)).collect())
+    }
 
     /// Auto-detect relationships based on content similarity and metadata
     async fn auto_detect_relationships(
@@ -597,55 +678,48 @@ impl MemoryKnowledgeGraph {
             }
         }
 
-        // Detect temporal relationships (bounded candidate scan)
+        // Detect temporal relationships over a deterministic most-recent-N
+        // candidate window (creation-time based, so recency ordering is the
+        // relevant one).
         let time_window = chrono::Duration::hours(1);
         let memory_time = memory.created_at();
-        for (other_memory_key, other_node_id) in
-            self.memory_to_node.iter().take(Self::KG_SCAN_LIMIT)
-        {
-            if other_memory_key != &memory.key {
-                if let Some(other_node) = self.graph.get_node(*other_node_id).await? {
-                    if let Some(other_time) = other_node.created_at {
-                        let time_diff = (memory_time - other_time).abs();
-                        if time_diff <= time_window {
-                            edges.push(Edge::new(
-                                node_id,
-                                *other_node_id,
-                                RelationshipType::TemporallyRelated,
-                                Some(HashMap::from([(
-                                    "time_diff_minutes".to_string(),
-                                    time_diff.num_minutes().to_string(),
-                                )])),
-                            ));
-                        }
-                    }
+        for (other_node_id, other_node) in self.recency_ordered_candidates(&memory.key).await? {
+            if let Some(other_time) = other_node.created_at {
+                let time_diff = (memory_time - other_time).abs();
+                if time_diff <= time_window {
+                    edges.push(Edge::new(
+                        node_id,
+                        other_node_id,
+                        RelationshipType::TemporallyRelated,
+                        Some(HashMap::from([(
+                            "time_diff_minutes".to_string(),
+                            time_diff.num_minutes().to_string(),
+                        )])),
+                    ));
                 }
             }
         }
 
-        // Detect semantic relationships (if embeddings are available;
-        // bounded candidate scan)
+        // Detect semantic relationships (if embeddings are available) over a
+        // deterministic content-relevance-ordered candidate window.
         if let Some(embedding) = &memory.embedding {
             let similarity_threshold = self.config.semantic_similarity_threshold;
-            for (other_memory_key, other_node_id) in
-                self.memory_to_node.iter().take(Self::KG_SCAN_LIMIT)
+            for (other_node_id, other_node) in self
+                .relevance_ordered_candidates(&memory.key, &memory.value)
+                .await?
             {
-                if other_memory_key != &memory.key {
-                    if let Some(other_node) = self.graph.get_node(*other_node_id).await? {
-                        if let Some(other_embedding) = &other_node.embedding {
-                            let similarity = cosine_similarity(embedding, other_embedding);
-                            if similarity >= similarity_threshold {
-                                edges.push(Edge::new(
-                                    node_id,
-                                    *other_node_id,
-                                    RelationshipType::SemanticallyRelated,
-                                    Some(HashMap::from([(
-                                        "similarity_score".to_string(),
-                                        similarity.to_string(),
-                                    )])),
-                                ));
-                            }
-                        }
+                if let Some(other_embedding) = &other_node.embedding {
+                    let similarity = cosine_similarity(embedding, other_embedding);
+                    if similarity >= similarity_threshold {
+                        edges.push(Edge::new(
+                            node_id,
+                            other_node_id,
+                            RelationshipType::SemanticallyRelated,
+                            Some(HashMap::from([(
+                                "similarity_score".to_string(),
+                                similarity.to_string(),
+                            )])),
+                        ));
                     }
                 }
             }
@@ -721,31 +795,73 @@ impl MemoryKnowledgeGraph {
         let similarity_threshold = self.config.semantic_similarity_threshold;
         let mut best_match: Option<(Uuid, f64)> = None;
 
-        for node_ref in self.graph.nodes.iter().take(Self::KG_SCAN_LIMIT) {
-            let node = node_ref.value();
-
+        for (node_id, node) in self.relevance_ordered_graph_nodes(&memory.value) {
             // Skip if this is already mapped to a different memory
-            if let Some(existing_memory_key) = self.node_to_memory.get(&node.id) {
+            if let Some(existing_memory_key) = self.node_to_memory.get(&node_id) {
                 if existing_memory_key != &memory.key {
                     continue;
                 }
             }
 
             // Calculate similarity
-            let similarity = self.calculate_node_memory_similarity(node, memory).await?;
+            let similarity = self.calculate_node_memory_similarity(&node, memory).await?;
 
             if similarity >= similarity_threshold {
                 if let Some((_, best_similarity)) = best_match {
                     if similarity > best_similarity {
-                        best_match = Some((node.id, similarity));
+                        best_match = Some((node_id, similarity));
                     }
                 } else {
-                    best_match = Some((node.id, similarity));
+                    best_match = Some((node_id, similarity));
                 }
             }
         }
 
         Ok(best_match.map(|(node_id, _)| node_id))
+    }
+
+    /// All graph nodes ordered DETERMINISTICALLY by content relevance to
+    /// `query_text` (token-overlap of the node's description/label desc), then
+    /// recency (newest first), then id, capped at [`Self::KG_SCAN_LIMIT`].
+    /// Includes non-memory (entity) nodes, so `find_similar_node` keeps its
+    /// original candidate universe but examines a reproducible, relevant
+    /// subset instead of an arbitrary map-iteration-order prefix.
+    fn relevance_ordered_graph_nodes(&self, query_text: &str) -> Vec<(Uuid, Node)> {
+        let query_tokens = Self::scan_tokens(query_text);
+        let mut scored: Vec<(usize, chrono::DateTime<chrono::Utc>, Uuid, Node)> = self
+            .graph
+            .nodes
+            .iter()
+            .map(|node_ref| {
+                let node = node_ref.value().clone();
+                let text = node.description.as_deref().unwrap_or(&node.label);
+                let overlap = query_tokens.intersection(&Self::scan_tokens(text)).count();
+                let recency = Self::node_recency(&node);
+                (overlap, recency, node.id, node)
+            })
+            .collect();
+        scored.sort_by(|a, b| {
+            b.0.cmp(&a.0)
+                .then_with(|| b.1.cmp(&a.1))
+                .then_with(|| a.2.cmp(&b.2))
+        });
+        scored.truncate(Self::KG_SCAN_LIMIT);
+        scored
+            .into_iter()
+            .map(|(_, _, id, node)| (id, node))
+            .collect()
+    }
+
+    /// Test-only: the deterministic candidate node ordering
+    /// `find_similar_node` will scan for `memory`, as (node_id) in order.
+    /// Exposed so tests can prove the candidate set is reproducible and
+    /// relevance-ordered past [`Self::KG_SCAN_LIMIT`].
+    #[cfg(feature = "test-utils")]
+    pub fn debug_similar_candidate_ids(&self, memory: &MemoryEntry) -> Vec<Uuid> {
+        self.relevance_ordered_graph_nodes(&memory.value)
+            .into_iter()
+            .map(|(id, _)| id)
+            .collect()
     }
 
     /// Merge memory with an existing similar node

--- a/src/memory/reasoning/llm.rs
+++ b/src/memory/reasoning/llm.rs
@@ -1,0 +1,418 @@
+//! Optional LLM-backed implementation of [`MemoryReasoner`] (feature
+//! `llm-reasoning`).
+//!
+//! Prompts an OpenAI-compatible chat-completions endpoint (works with
+//! Ollama's `/v1` API) for structured-JSON extraction, conflict resolution,
+//! and synthesis. Configuration comes from environment variables:
+//!
+//! - `SYNAPTIC_LLM_URL` — endpoint base, e.g. `http://localhost:11434/v1`
+//!   (falls back to `SYNAPTIC_EVAL_LLM_URL` for consistency with the eval
+//!   crate).
+//! - `SYNAPTIC_LLM_MODEL` — model name (fallback `SYNAPTIC_EVAL_LLM_MODEL`).
+//! - `SYNAPTIC_LLM_KEY` — optional bearer token (fallback
+//!   `SYNAPTIC_EVAL_LLM_KEY`; omit for Ollama).
+//!
+//! FAIL-OPEN TO HEURISTIC: every method first tries the LLM and, on ANY
+//! failure — transport error, non-2xx status, unparseable reply, invalid
+//! verdict — returns the inner [`HeuristicReasoner`]'s result instead. The
+//! write path therefore always receives a real extraction/resolution, never
+//! a fabricated one and never a hard failure caused by the LLM. The first
+//! fallback is logged at `warn`; subsequent ones at `debug`.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use serde::Deserialize;
+
+use crate::error::Result;
+use crate::memory::embeddings::TfIdfProvider;
+use crate::memory::reasoning::{
+    ConflictResolution, Entity, EntityKind, Extraction, ExtractionContext, Fact, HeuristicReasoner,
+    Insight, MemoryReasoner, NeighborFact, Relation,
+};
+use crate::memory::types::MemoryEntry;
+
+/// Injectable chat call: `(system, user) -> assistant reply text`.
+///
+/// The production implementation posts to a chat-completions endpoint via
+/// reqwest; tests inject canned or failing closures so no network is needed.
+pub type ChatCall = Arc<
+    dyn Fn(
+            String,
+            String,
+        ) -> Pin<Box<dyn Future<Output = std::result::Result<String, String>> + Send>>
+        + Send
+        + Sync,
+>;
+
+/// LLM-backed [`MemoryReasoner`] with a deterministic heuristic fallback.
+pub struct LlmReasoner {
+    call: ChatCall,
+    inner: HeuristicReasoner,
+    warned: AtomicBool,
+}
+
+/// Wire format for the extraction reply (lenient: spans are recomputed).
+#[derive(Deserialize)]
+struct WireExtraction {
+    facts: Vec<WireFact>,
+}
+
+#[derive(Deserialize)]
+struct WireFact {
+    text: String,
+    #[serde(default)]
+    entities: Vec<WireEntity>,
+    #[serde(default)]
+    relations: Vec<WireRelation>,
+}
+
+#[derive(Deserialize)]
+struct WireEntity {
+    name: String,
+    #[serde(default)]
+    kind: String,
+}
+
+#[derive(Deserialize)]
+struct WireRelation {
+    subject: String,
+    predicate: String,
+    object: String,
+}
+
+/// Wire format for the conflict-resolution verdict.
+#[derive(Deserialize)]
+struct WireVerdict {
+    action: String,
+    #[serde(default)]
+    old_id: Option<String>,
+    #[serde(default)]
+    reason: Option<String>,
+}
+
+/// Wire format for the synthesis reply.
+#[derive(Deserialize)]
+struct WireInsight {
+    insight: String,
+    #[serde(default = "default_confidence")]
+    confidence: f64,
+}
+
+fn default_confidence() -> f64 {
+    0.5
+}
+
+impl LlmReasoner {
+    /// Environment variable holding the endpoint base URL.
+    pub const ENV_URL: &'static str = "SYNAPTIC_LLM_URL";
+    /// Environment variable holding the model name.
+    pub const ENV_MODEL: &'static str = "SYNAPTIC_LLM_MODEL";
+    /// Environment variable holding the optional bearer token.
+    pub const ENV_KEY: &'static str = "SYNAPTIC_LLM_KEY";
+
+    /// Build from environment variables (with `SYNAPTIC_EVAL_LLM_*`
+    /// fallbacks). Returns `None` when no endpoint+model is configured —
+    /// the caller keeps the plain heuristic reasoner in that case.
+    pub fn from_env() -> Option<Self> {
+        let env = |primary: &str, fallback: &str| {
+            std::env::var(primary)
+                .ok()
+                .filter(|v| !v.trim().is_empty())
+                .or_else(|| {
+                    std::env::var(fallback)
+                        .ok()
+                        .filter(|v| !v.trim().is_empty())
+                })
+                .map(|v| v.trim().to_string())
+        };
+        let url = env(Self::ENV_URL, "SYNAPTIC_EVAL_LLM_URL")?;
+        let model = match env(Self::ENV_MODEL, "SYNAPTIC_EVAL_LLM_MODEL") {
+            Some(m) => m,
+            None => {
+                tracing::warn!(
+                    "{} is set but no model configured ({}); using heuristic reasoner",
+                    Self::ENV_URL,
+                    Self::ENV_MODEL
+                );
+                return None;
+            }
+        };
+        let api_key = env(Self::ENV_KEY, "SYNAPTIC_EVAL_LLM_KEY");
+        Some(Self::with_call(http_chat_call(url, model, api_key)))
+    }
+
+    /// Build with an injected chat call (used by tests and custom transports).
+    pub fn with_call(call: ChatCall) -> Self {
+        Self {
+            call,
+            inner: HeuristicReasoner::new(Arc::new(TfIdfProvider::default())),
+            warned: AtomicBool::new(false),
+        }
+    }
+
+    /// Log an LLM failure: `warn` the first time, `debug` afterwards.
+    fn log_fallback(&self, method: &str, err: &str) {
+        if !self.warned.swap(true, Ordering::Relaxed) {
+            tracing::warn!(method, error = %err, "LLM reasoner failed; falling back to heuristic");
+        } else {
+            tracing::debug!(method, error = %err, "LLM reasoner failed; falling back to heuristic");
+        }
+    }
+
+    async fn try_extract(&self, text: &str) -> std::result::Result<Extraction, String> {
+        let system = "You extract structured facts from text for a memory system. \
+                      Reply with ONLY a JSON object, no prose, of the form: \
+                      {\"facts\":[{\"text\":\"<sentence>\",\"entities\":[{\"name\":\"<surface form>\",\
+                      \"kind\":\"Person|Place|Org|Date|Number|Quoted|Term\"}],\
+                      \"relations\":[{\"subject\":\"...\",\"predicate\":\"...\",\"object\":\"...\"}]}]}. \
+                      Entity names must be exact substrings of the fact text. \
+                      Use snake_case predicates (e.g. lives_in, works_at).";
+        let user = format!("Extract facts from this text:\n{text}");
+        let reply = (self.call)(system.to_string(), user).await?;
+        let wire: WireExtraction = serde_json::from_str(strip_fences(&reply))
+            .map_err(|e| format!("unparseable extraction reply: {e}"))?;
+        let facts = wire
+            .facts
+            .into_iter()
+            .map(|f| {
+                let entities = f
+                    .entities
+                    .into_iter()
+                    .map(|e| {
+                        let span = f
+                            .text
+                            .find(&e.name)
+                            .map(|s| (s, s + e.name.len()))
+                            .unwrap_or((0, 0));
+                        Entity {
+                            span,
+                            kind: parse_kind(&e.kind),
+                            name: e.name,
+                        }
+                    })
+                    .collect();
+                let relations = f
+                    .relations
+                    .into_iter()
+                    .map(|r| Relation {
+                        subject: r.subject,
+                        predicate: r.predicate,
+                        object: r.object,
+                    })
+                    .collect();
+                Fact {
+                    text: f.text,
+                    entities,
+                    relations,
+                }
+            })
+            .collect();
+        Ok(Extraction { facts })
+    }
+
+    async fn try_resolve(
+        &self,
+        candidate: &Fact,
+        neighbors: &[NeighborFact],
+    ) -> std::result::Result<ConflictResolution, String> {
+        let system = "You decide how a new fact interacts with existing memories. \
+                      Reply with ONLY a JSON object, no prose: \
+                      {\"action\":\"insert|update_in_place|supersede|append|noop\",\
+                      \"old_id\":\"<id of the superseded memory, required for supersede>\",\
+                      \"reason\":\"<short reason>\"}. \
+                      Use supersede when the new fact replaces an outdated memory, \
+                      noop for duplicates, update_in_place for refinements of the \
+                      same memory, append to add detail, insert otherwise.";
+        let neighbor_list = neighbors
+            .iter()
+            .map(|n| {
+                format!(
+                    "- id={} similarity={:.2} text={}",
+                    n.id, n.similarity, n.text
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let user = format!(
+            "New fact: {}\n\nExisting similar memories:\n{}",
+            candidate.text,
+            if neighbor_list.is_empty() {
+                "(none)".to_string()
+            } else {
+                neighbor_list
+            }
+        );
+        let reply = (self.call)(system.to_string(), user).await?;
+        let wire: WireVerdict = serde_json::from_str(strip_fences(&reply))
+            .map_err(|e| format!("unparseable resolve reply: {e}"))?;
+        let reason = wire.reason.unwrap_or_else(|| "llm verdict".to_string());
+        match wire.action.trim().to_ascii_lowercase().as_str() {
+            "insert" => Ok(ConflictResolution::Insert),
+            "update_in_place" => Ok(ConflictResolution::UpdateInPlace { reason }),
+            "append" => Ok(ConflictResolution::Append { reason }),
+            "noop" | "no_op" => Ok(ConflictResolution::NoOp { reason }),
+            "supersede" => {
+                let old_id = wire
+                    .old_id
+                    .ok_or_else(|| "supersede verdict missing old_id".to_string())?;
+                if !neighbors.iter().any(|n| n.id == old_id) {
+                    return Err(format!(
+                        "supersede verdict targets unknown neighbor id {old_id}"
+                    ));
+                }
+                Ok(ConflictResolution::Supersede { old_id, reason })
+            }
+            other => Err(format!("unknown resolve action {other:?}")),
+        }
+    }
+
+    async fn try_synthesize(
+        &self,
+        cluster: &[MemoryEntry],
+    ) -> std::result::Result<Option<Insight>, String> {
+        if cluster.len() < 2 {
+            return Ok(None);
+        }
+        let system = "You synthesize one insight from a cluster of related memories. \
+                      Reply with ONLY a JSON object, no prose: \
+                      {\"insight\":\"<one-sentence insight>\",\"confidence\":<0.0-1.0>}.";
+        let memories = cluster
+            .iter()
+            .enumerate()
+            .map(|(i, e)| format!("[{}] {}", i + 1, e.value))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let user = format!("Related memories:\n{memories}");
+        let reply = (self.call)(system.to_string(), user).await?;
+        let wire: WireInsight = serde_json::from_str(strip_fences(&reply))
+            .map_err(|e| format!("unparseable synthesize reply: {e}"))?;
+        Ok(Some(Insight {
+            text: wire.insight,
+            derived_from: cluster.iter().map(|e| e.id().to_string()).collect(),
+            confidence: wire.confidence.clamp(0.0, 1.0),
+        }))
+    }
+}
+
+#[async_trait::async_trait]
+impl MemoryReasoner for LlmReasoner {
+    async fn extract(&self, text: &str, ctx: &ExtractionContext) -> Result<Extraction> {
+        match self.try_extract(text).await {
+            Ok(extraction) => Ok(extraction),
+            Err(e) => {
+                self.log_fallback("extract", &e);
+                self.inner.extract(text, ctx).await
+            }
+        }
+    }
+
+    async fn resolve(
+        &self,
+        candidate: &Fact,
+        neighbors: &[NeighborFact],
+    ) -> Result<ConflictResolution> {
+        match self.try_resolve(candidate, neighbors).await {
+            Ok(resolution) => Ok(resolution),
+            Err(e) => {
+                self.log_fallback("resolve", &e);
+                self.inner.resolve(candidate, neighbors).await
+            }
+        }
+    }
+
+    async fn synthesize(&self, cluster: &[MemoryEntry]) -> Result<Option<Insight>> {
+        match self.try_synthesize(cluster).await {
+            Ok(insight) => Ok(insight),
+            Err(e) => {
+                self.log_fallback("synthesize", &e);
+                self.inner.synthesize(cluster).await
+            }
+        }
+    }
+
+    fn name(&self) -> &str {
+        "llm"
+    }
+}
+
+/// Map a wire entity kind onto [`EntityKind`]; unknown kinds become `Term`.
+fn parse_kind(kind: &str) -> EntityKind {
+    match kind.trim().to_ascii_lowercase().as_str() {
+        "person" => EntityKind::Person,
+        "place" => EntityKind::Place,
+        "org" | "organization" => EntityKind::Org,
+        "date" => EntityKind::Date,
+        "number" => EntityKind::Number,
+        "quoted" | "quote" => EntityKind::Quoted,
+        _ => EntityKind::Term,
+    }
+}
+
+/// Strip a Markdown code fence (```json ... ```) around a reply, if present.
+fn strip_fences(reply: &str) -> &str {
+    let trimmed = reply.trim();
+    let Some(inner) = trimmed.strip_prefix("```") else {
+        return trimmed;
+    };
+    let inner = inner.strip_suffix("```").unwrap_or(inner);
+    // Drop an optional language tag on the first line (e.g. "json").
+    match inner.find('\n') {
+        Some(nl) if inner[..nl].chars().all(|c| c.is_ascii_alphanumeric()) => inner[nl..].trim(),
+        _ => inner.trim(),
+    }
+}
+
+/// Production chat call: POST to `{url}/chat/completions` (OpenAI-compatible,
+/// including Ollama's `/v1`) and return `choices[0].message.content`.
+fn http_chat_call(url: String, model: String, api_key: Option<String>) -> ChatCall {
+    let client = reqwest::Client::new();
+    let base = url.trim_end_matches('/').to_string();
+    let endpoint = if base.ends_with("/chat/completions") {
+        base
+    } else {
+        format!("{base}/chat/completions")
+    };
+    Arc::new(move |system: String, user: String| {
+        let client = client.clone();
+        let endpoint = endpoint.clone();
+        let model = model.clone();
+        let api_key = api_key.clone();
+        Box::pin(async move {
+            let body = serde_json::json!({
+                "model": model,
+                "temperature": 0.0,
+                "messages": [
+                    {"role": "system", "content": system},
+                    {"role": "user", "content": user},
+                ],
+            });
+            let mut req = client.post(&endpoint).json(&body);
+            if let Some(key) = &api_key {
+                req = req.bearer_auth(key);
+            }
+            let resp = req
+                .send()
+                .await
+                .map_err(|e| format!("request to LLM endpoint failed: {e}"))?;
+            let status = resp.status();
+            if !status.is_success() {
+                let text = resp.text().await.unwrap_or_default();
+                return Err(format!("LLM endpoint returned {status}: {text}"));
+            }
+            let json: serde_json::Value = resp
+                .json()
+                .await
+                .map_err(|e| format!("LLM endpoint returned invalid JSON: {e}"))?;
+            json.get("choices")
+                .and_then(|c| c.get(0))
+                .and_then(|c| c.get("message"))
+                .and_then(|m| m.get("content"))
+                .and_then(|c| c.as_str())
+                .map(|s| s.trim().to_string())
+                .ok_or_else(|| "LLM reply missing choices[0].message.content".to_string())
+        })
+    })
+}

--- a/src/memory/reasoning/mod.rs
+++ b/src/memory/reasoning/mod.rs
@@ -7,8 +7,12 @@
 //! across clusters of related memories.
 
 pub mod heuristic;
+#[cfg(feature = "llm-reasoning")]
+pub mod llm;
 
 pub use heuristic::HeuristicReasoner;
+#[cfg(feature = "llm-reasoning")]
+pub use llm::LlmReasoner;
 
 use crate::error::Result;
 use crate::memory::types::MemoryEntry;

--- a/src/memory/retrieval/dense_vector.rs
+++ b/src/memory/retrieval/dense_vector.rs
@@ -49,8 +49,12 @@ impl DenseVectorRetriever {
         fragment: &MemoryFragment,
         query_embedding: &Embedding,
     ) -> Result<f64> {
-        // Generate embedding for the fragment
-        let fragment_embedding = self.provider.embed(&fragment.entry.value, None).await?;
+        // Generate embedding for the fragment via the read-only,
+        // content-hash-cached scoring path (no vocabulary mutation).
+        let fragment_embedding = self
+            .provider
+            .embed_for_scoring(&fragment.entry.value, None)
+            .await?;
 
         // Compute cosine similarity
         let similarity = query_embedding.cosine_similarity(&fragment_embedding);
@@ -74,8 +78,8 @@ impl RetrievalPipeline for DenseVectorRetriever {
             "DenseVectorRetriever: starting semantic search"
         );
 
-        // Generate embedding for the query
-        let query_embedding = self.provider.embed(query, None).await?;
+        // Generate embedding for the query (read-only scoring path)
+        let query_embedding = self.provider.embed_for_scoring(query, None).await?;
 
         // Get candidate memories from storage
         // In a production system, this would use an ANN index

--- a/src/memory/retrieval/dense_vector.rs
+++ b/src/memory/retrieval/dense_vector.rs
@@ -14,6 +14,16 @@ use std::sync::Arc;
 ///
 /// This retriever generates embeddings for the query and memories,
 /// then ranks results by cosine similarity in the embedding space.
+///
+/// KNOWN PRE-EXISTING RETRIEVAL GAP (tracked as a follow-up; NOT a P2 perf
+/// concern): the scoring provider wired into the shipped hybrid pipeline only
+/// ever has `embed_for_scoring` called on it — never `embed` — so its TF-IDF
+/// vocabulary stays empty and every term's IDF falls back to `1.0`. Dense
+/// retrieval is therefore currently hashed-TF cosine with no real IDF
+/// weighting. This ties to the carry-forward gap where the corpus is not fed
+/// into the scoring provider, partly explains the weak recall, and should be
+/// addressed in a future task (feeding the corpus / sharing the store-time
+/// vocabulary), not here.
 pub struct DenseVectorRetriever {
     storage: Arc<dyn Storage + Send + Sync>,
     provider: Arc<dyn EmbeddingProvider>,

--- a/src/memory/retrieval/rerank.rs
+++ b/src/memory/retrieval/rerank.rs
@@ -121,28 +121,45 @@ impl HeuristicReranker {
         hits as f64 / query_terms.len() as f64
     }
 
-    /// Graph proximity: fraction of the other candidates reachable from this
-    /// candidate within 2 hops. Candidates absent from the graph score 0.
-    async fn graph_proximity(&self, key: &str, other_keys: &HashSet<String>) -> f64 {
+    /// Graph proximity for ALL candidates in one pass: fraction of the other
+    /// candidates reachable from each candidate within 2 hops. Candidates
+    /// absent from the graph score 0. The knowledge-graph read lock is taken
+    /// ONCE for the whole batch and released before this returns, so it is
+    /// never held across the embedding awaits of the main rerank loop.
+    async fn graph_proximities(
+        &self,
+        candidates: &[ScoredMemory],
+        all_keys: &HashSet<String>,
+    ) -> std::collections::HashMap<String, f64> {
+        let mut proximities = std::collections::HashMap::with_capacity(candidates.len());
         let Some(ref kg) = self.knowledge_graph else {
-            return 0.0;
+            return proximities;
         };
-        if other_keys.is_empty() {
-            return 0.0;
-        }
-        let related = match kg.read().await.find_related_memories(key, 2, None).await {
-            Ok(related) => related,
-            Err(e) => {
-                // The candidate may simply not be a graph node yet.
-                tracing::debug!(key = %key, error = %e, "graph proximity unavailable for candidate");
-                return 0.0;
+        let kg_guard = kg.read().await;
+        for candidate in candidates {
+            let key = &candidate.memory.entry.key;
+            let other_count = all_keys.len().saturating_sub(1);
+            if other_count == 0 {
+                continue;
             }
-        };
-        let hits = related
-            .iter()
-            .filter(|r| other_keys.contains(&r.memory_key))
-            .count();
-        (hits as f64 / other_keys.len() as f64).clamp(0.0, 1.0)
+            let related = match kg_guard.find_related_memories(key, 2, None).await {
+                Ok(related) => related,
+                Err(e) => {
+                    // The candidate may simply not be a graph node yet.
+                    tracing::debug!(key = %key, error = %e, "graph proximity unavailable for candidate");
+                    continue;
+                }
+            };
+            let hits = related
+                .iter()
+                .filter(|r| r.memory_key != *key && all_keys.contains(&r.memory_key))
+                .count();
+            proximities.insert(
+                key.clone(),
+                (hits as f64 / other_count as f64).clamp(0.0, 1.0),
+            );
+        }
+        proximities
     }
 
     /// Recency via exponential decay: `0.5 ^ (age_hours / half_life)`.
@@ -173,7 +190,7 @@ impl Reranker for HeuristicReranker {
         // provider is configured and available.
         let query_embedding = match self.embedding_provider {
             Some(ref provider) if provider.is_available() => {
-                Some(provider.embed(query, None).await?)
+                Some(provider.embed_for_scoring(query, None).await?)
             }
             _ => None,
         };
@@ -200,6 +217,10 @@ impl Reranker for HeuristicReranker {
             .map(|c| c.memory.entry.key.clone())
             .collect();
 
+        // Batch the knowledge-graph reads under a single, short-lived read
+        // lock, released before any embedding awaits below.
+        let proximities = self.graph_proximities(&candidates, &all_keys).await;
+
         let mut ranked: Vec<(f64, ScoredMemory)> = Vec::with_capacity(candidates.len());
         for candidate in candidates {
             let content = &candidate.memory.entry.value;
@@ -213,15 +234,16 @@ impl Reranker for HeuristicReranker {
                         .embedding_provider
                         .as_ref()
                         .expect("query_embedding is Some only when a provider is configured");
-                    let ce = provider.embed(content, None).await?;
+                    // Read-only, content-hash-cached scoring path: reuses the
+                    // embedding computed by the dense retriever when the
+                    // provider instance is shared.
+                    let ce = provider.embed_for_scoring(content, None).await?;
                     qe.cosine_similarity(&ce).clamp(0.0, 1.0)
                 }
                 None => 0.0,
             };
 
-            let mut other_keys = all_keys.clone();
-            other_keys.remove(key);
-            let proximity = self.graph_proximity(key, &other_keys).await;
+            let proximity = proximities.get(key).copied().unwrap_or(0.0);
 
             let recency = Self::recency(candidate.memory.entry.created_at(), now);
 

--- a/src/memory/retrieval/strategies.rs
+++ b/src/memory/retrieval/strategies.rs
@@ -399,16 +399,27 @@ impl RetrievalPipeline for GraphRetriever {
                 .map(|s| s.memory.entry.key.clone())
                 .collect();
 
-            let kg_guard = kg.read().await;
-            for (seed_key, seed_score) in seeds {
-                let related = match kg_guard.find_related_memories(&seed_key, 2, None).await {
-                    Ok(related) => related,
-                    Err(e) => {
-                        // Seed may simply not be a graph node yet.
-                        tracing::debug!(seed = %seed_key, error = %e, "graph expansion skipped for seed");
-                        continue;
-                    }
-                };
+            // Phase 1: collect related keys under the graph read lock, then
+            // DROP the guard before any storage awaits — the lock must never
+            // be held across `storage.retrieve`.
+            let mut expansions: Vec<(String, f64, Vec<_>)> = Vec::with_capacity(seeds.len());
+            {
+                let kg_guard = kg.read().await;
+                for (seed_key, seed_score) in seeds {
+                    let related = match kg_guard.find_related_memories(&seed_key, 2, None).await {
+                        Ok(related) => related,
+                        Err(e) => {
+                            // Seed may simply not be a graph node yet.
+                            tracing::debug!(seed = %seed_key, error = %e, "graph expansion skipped for seed");
+                            continue;
+                        }
+                    };
+                    expansions.push((seed_key, seed_score, related));
+                }
+            }
+
+            // Phase 2: fetch expansion candidates from storage, lock-free.
+            for (seed_key, seed_score, related) in expansions {
                 for rel in related {
                     if !seen.insert(rel.memory_key.clone()) {
                         continue;

--- a/src/memory/storage/memory.rs
+++ b/src/memory/storage/memory.rs
@@ -91,6 +91,39 @@ impl Default for RestoreOptions {
     }
 }
 
+/// Insert an entry into the map while keeping the incremental size counter
+/// coherent (adds the new entry's size, subtracts a replaced entry's size).
+/// Shared by the storage and its transaction handles.
+fn insert_tracked(
+    entries: &DashMap<String, MemoryEntry>,
+    total_size: &std::sync::atomic::AtomicUsize,
+    entry: MemoryEntry,
+) {
+    use std::sync::atomic::Ordering;
+    let new_size = entry.estimated_size();
+    let replaced = entries.insert(entry.key.clone(), entry);
+    total_size.fetch_add(new_size, Ordering::Relaxed);
+    if let Some(old) = replaced {
+        total_size.fetch_sub(old.estimated_size(), Ordering::Relaxed);
+    }
+}
+
+/// Remove an entry from the map while keeping the incremental size counter
+/// coherent. Returns true if the key existed.
+fn remove_tracked(
+    entries: &DashMap<String, MemoryEntry>,
+    total_size: &std::sync::atomic::AtomicUsize,
+    key: &str,
+) -> bool {
+    use std::sync::atomic::Ordering;
+    if let Some((_, old)) = entries.remove(key) {
+        total_size.fetch_sub(old.estimated_size(), Ordering::Relaxed);
+        true
+    } else {
+        false
+    }
+}
+
 /// In-memory storage implementation using DashMap for thread-safe concurrent access
 pub struct MemoryStorage {
     /// Main storage for memory entries (wrapped in Arc for transaction support)
@@ -99,6 +132,14 @@ pub struct MemoryStorage {
     stats: RwLock<StorageStats>,
     /// Creation timestamp
     created_at: DateTime<Utc>,
+    /// Incrementally maintained total estimated size of all entries, in
+    /// bytes. Shared with transaction handles so committed transactions keep
+    /// the counter coherent.
+    total_size: Arc<std::sync::atomic::AtomicUsize>,
+    /// Test-only op-count proxy: number of entries examined by stats
+    /// computation. Stays 0 when stats are maintained incrementally.
+    #[cfg(feature = "test-utils")]
+    stats_entries_scanned: std::sync::atomic::AtomicUsize,
 }
 
 impl MemoryStorage {
@@ -108,7 +149,18 @@ impl MemoryStorage {
             entries: Arc::new(DashMap::new()),
             stats: RwLock::new(StorageStats::new("memory".to_string())),
             created_at: Utc::now(),
+            total_size: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            #[cfg(feature = "test-utils")]
+            stats_entries_scanned: std::sync::atomic::AtomicUsize::new(0),
         }
+    }
+
+    /// Test-only op-count proxy: total entries examined by stats computation
+    /// since construction. Incremental stats keep this at 0.
+    #[cfg(feature = "test-utils")]
+    pub fn stats_entries_scanned(&self) -> usize {
+        self.stats_entries_scanned
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Get the number of stored entries
@@ -121,16 +173,13 @@ impl MemoryStorage {
         self.entries.is_empty()
     }
 
-    /// Update internal statistics
+    /// Update internal statistics from the incrementally maintained size
+    /// counter. O(1): no rescan of stored entries.
     fn update_stats(&self) {
         let mut stats = self.stats.write();
         stats.total_entries = self.entries.len();
 
-        let total_size: usize = self
-            .entries
-            .iter()
-            .map(|entry| entry.value().estimated_size())
-            .sum();
+        let total_size = self.total_size.load(std::sync::atomic::Ordering::Relaxed);
 
         stats.total_size_bytes = total_size;
         stats.average_entry_size = if stats.total_entries > 0 {
@@ -206,7 +255,7 @@ impl Storage for MemoryStorage {
     #[tracing::instrument(skip(self, entry), fields(key = %entry.key))]
     async fn store(&self, entry: &MemoryEntry) -> Result<()> {
         tracing::debug!("Storing entry in memory storage");
-        self.entries.insert(entry.key.clone(), entry.clone());
+        insert_tracked(&self.entries, &self.total_size, entry.clone());
         self.update_stats();
         tracing::debug!("Entry stored successfully");
         Ok(())
@@ -238,7 +287,9 @@ impl Storage for MemoryStorage {
 
     async fn update(&self, key: &str, entry: &MemoryEntry) -> Result<()> {
         if self.entries.contains_key(key) {
-            self.entries.insert(key.to_string(), entry.clone());
+            let mut entry = entry.clone();
+            entry.key = key.to_string();
+            insert_tracked(&self.entries, &self.total_size, entry);
             self.update_stats();
             Ok(())
         } else {
@@ -249,7 +300,7 @@ impl Storage for MemoryStorage {
     }
 
     async fn delete(&self, key: &str) -> Result<bool> {
-        let removed = self.entries.remove(key).is_some();
+        let removed = remove_tracked(&self.entries, &self.total_size, key);
         if removed {
             self.update_stats();
         }
@@ -270,6 +321,8 @@ impl Storage for MemoryStorage {
 
     async fn clear(&self) -> Result<()> {
         self.entries.clear();
+        self.total_size
+            .store(0, std::sync::atomic::Ordering::Relaxed);
         self.update_stats();
         Ok(())
     }
@@ -442,6 +495,8 @@ impl MemoryStorage {
         } else {
             tracing::info!("Replacing all existing data with backup");
             self.entries.clear();
+            self.total_size
+                .store(0, std::sync::atomic::Ordering::Relaxed);
         }
 
         // Restore entries
@@ -457,7 +512,7 @@ impl MemoryStorage {
                 continue;
             }
 
-            self.entries.insert(entry.key.clone(), entry);
+            insert_tracked(&self.entries, &self.total_size, entry);
             restored_count += 1;
         }
 
@@ -648,7 +703,7 @@ pub struct BackupInfo {
 impl BatchStorage for MemoryStorage {
     async fn store_batch(&self, entries: &[MemoryEntry]) -> Result<()> {
         for entry in entries {
-            self.entries.insert(entry.key.clone(), entry.clone());
+            insert_tracked(&self.entries, &self.total_size, entry.clone());
         }
         self.update_stats();
         Ok(())
@@ -665,7 +720,7 @@ impl BatchStorage for MemoryStorage {
     async fn delete_batch(&self, keys: &[String]) -> Result<usize> {
         let mut deleted_count = 0;
         for key in keys {
-            if self.entries.remove(key).is_some() {
+            if remove_tracked(&self.entries, &self.total_size, key) {
                 deleted_count += 1;
             }
         }
@@ -722,6 +777,8 @@ impl BatchStorage for MemoryStorage {
 pub struct MemoryTransactionHandle {
     /// Reference to the live storage's entry map (not a copy)
     entries: Arc<DashMap<String, MemoryEntry>>,
+    /// Shared incremental size counter of the owning storage
+    total_size: Arc<std::sync::atomic::AtomicUsize>,
     /// Buffered operations to apply on commit
     operations: Vec<(String, Option<MemoryEntry>)>, // (key, entry) - None means delete
     /// Whether the transaction has been committed or rolled back
@@ -729,9 +786,13 @@ pub struct MemoryTransactionHandle {
 }
 
 impl MemoryTransactionHandle {
-    fn new(entries: Arc<DashMap<String, MemoryEntry>>) -> Self {
+    fn new(
+        entries: Arc<DashMap<String, MemoryEntry>>,
+        total_size: Arc<std::sync::atomic::AtomicUsize>,
+    ) -> Self {
         Self {
             entries,
+            total_size,
             operations: Vec::new(),
             committed: false,
         }
@@ -760,10 +821,12 @@ impl TransactionHandle for MemoryTransactionHandle {
         for (key, entry_opt) in &self.operations {
             match entry_opt {
                 Some(entry) => {
-                    self.entries.insert(key.clone(), entry.clone());
+                    let mut entry = entry.clone();
+                    entry.key = key.clone();
+                    insert_tracked(&self.entries, &self.total_size, entry);
                 }
                 None => {
-                    self.entries.remove(key);
+                    remove_tracked(&self.entries, &self.total_size, key);
                 }
             }
         }
@@ -785,14 +848,14 @@ impl TransactionalStorage for MemoryStorage {
         // Execute all operations atomically
         for operation in transaction.operations() {
             match operation {
-                crate::memory::storage::StorageOperation::Store { key, entry } => {
-                    self.entries.insert(key.clone(), entry.clone());
-                }
-                crate::memory::storage::StorageOperation::Update { key, entry } => {
-                    self.entries.insert(key.clone(), entry.clone());
+                crate::memory::storage::StorageOperation::Store { key, entry }
+                | crate::memory::storage::StorageOperation::Update { key, entry } => {
+                    let mut entry = entry.clone();
+                    entry.key = key.clone();
+                    insert_tracked(&self.entries, &self.total_size, entry);
                 }
                 crate::memory::storage::StorageOperation::Delete { key } => {
-                    self.entries.remove(key);
+                    remove_tracked(&self.entries, &self.total_size, key);
                 }
             }
         }
@@ -801,9 +864,10 @@ impl TransactionalStorage for MemoryStorage {
     }
 
     async fn begin_transaction(&self) -> Result<Box<dyn TransactionHandle>> {
-        Ok(Box::new(MemoryTransactionHandle::new(Arc::clone(
-            &self.entries,
-        ))))
+        Ok(Box::new(MemoryTransactionHandle::new(
+            Arc::clone(&self.entries),
+            Arc::clone(&self.total_size),
+        )))
     }
 }
 

--- a/src/memory/storage/memory.rs
+++ b/src/memory/storage/memory.rs
@@ -11,8 +11,54 @@ use chrono::{DateTime, Utc};
 use dashmap::DashMap;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+
+/// Inverted character n-gram index: gram -> keys of entries whose lowercased
+/// content contains that gram. Search matches query terms as SUBSTRINGS of
+/// entry content, so the index stores all 1-, 2- and 3-character grams: any
+/// entry containing a query term as a substring necessarily contains every
+/// n-gram of that term, making posting lists a guaranteed candidate superset.
+type GramIndex = DashMap<String, HashSet<Arc<str>>>;
+
+/// Maximum indexed gram length (character trigrams).
+const MAX_GRAM_LEN: usize = 3;
+
+/// All distinct 1..=3 character grams of (already lowercased) content.
+fn content_grams(content_lower: &str) -> HashSet<String> {
+    let chars: Vec<char> = content_lower.chars().collect();
+    let mut grams = HashSet::new();
+    for n in 1..=MAX_GRAM_LEN {
+        for window in chars.windows(n) {
+            grams.insert(window.iter().collect());
+        }
+    }
+    grams
+}
+
+/// Add `key` to the posting list of every gram of `content_lower`.
+fn index_add(grams: &GramIndex, key: &Arc<str>, content_lower: &str) {
+    for gram in content_grams(content_lower) {
+        grams.entry(gram).or_default().insert(Arc::clone(key));
+    }
+}
+
+/// Remove `key` from the posting list of every gram of `content_lower`,
+/// dropping posting lists that become empty.
+fn index_remove(grams: &GramIndex, key: &str, content_lower: &str) {
+    for gram in content_grams(content_lower) {
+        let now_empty = grams
+            .get_mut(&gram)
+            .map(|mut set| {
+                set.remove(key);
+                set.is_empty()
+            })
+            .unwrap_or(false);
+        if now_empty {
+            grams.remove_if(&gram, |_, set| set.is_empty());
+        }
+    }
+}
 
 /// Backup data structure for in-memory storage
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -98,13 +144,22 @@ fn insert_tracked(
     entries: &DashMap<String, MemoryEntry>,
     total_size: &std::sync::atomic::AtomicUsize,
     lowercase: &DashMap<String, Arc<str>>,
+    grams: &GramIndex,
     entry: MemoryEntry,
 ) {
     use std::sync::atomic::Ordering;
     let new_size = entry.estimated_size();
     // Memoize the lowercased content so search never re-lowercases the
     // corpus; maintained on every mutation path for coherence.
-    lowercase.insert(entry.key.clone(), Arc::from(entry.value.to_lowercase()));
+    let lowered: Arc<str> = Arc::from(entry.value.to_lowercase());
+    let old_lowered = lowercase.insert(entry.key.clone(), Arc::clone(&lowered));
+    // Keep the inverted n-gram index coherent: drop the replaced content's
+    // postings, then add the new content's.
+    if let Some(old) = old_lowered {
+        index_remove(grams, &entry.key, &old);
+    }
+    let key_arc: Arc<str> = Arc::from(entry.key.as_str());
+    index_add(grams, &key_arc, &lowered);
     let replaced = entries.insert(entry.key.clone(), entry);
     total_size.fetch_add(new_size, Ordering::Relaxed);
     if let Some(old) = replaced {
@@ -118,10 +173,13 @@ fn remove_tracked(
     entries: &DashMap<String, MemoryEntry>,
     total_size: &std::sync::atomic::AtomicUsize,
     lowercase: &DashMap<String, Arc<str>>,
+    grams: &GramIndex,
     key: &str,
 ) -> bool {
     use std::sync::atomic::Ordering;
-    lowercase.remove(key);
+    if let Some((_, old_lowered)) = lowercase.remove(key) {
+        index_remove(grams, key, &old_lowered);
+    }
     if let Some((_, old)) = entries.remove(key) {
         total_size.fetch_sub(old.estimated_size(), Ordering::Relaxed);
         true
@@ -146,10 +204,19 @@ pub struct MemoryStorage {
     /// path (store/update/delete/batch/transactions/restore), so search
     /// scans never re-lowercase the whole corpus per query.
     lowercase: Arc<DashMap<String, Arc<str>>>,
+    /// Inverted character n-gram index over lowercased content, maintained on
+    /// every mutation path alongside `lowercase`, so `search_entries` ranks
+    /// only candidate entries (posting-list unions) instead of scanning all n.
+    grams: Arc<GramIndex>,
     /// Test-only op-count proxy: number of entries examined by stats
     /// computation. Stays 0 when stats are maintained incrementally.
     #[cfg(feature = "test-utils")]
     stats_entries_scanned: std::sync::atomic::AtomicUsize,
+    /// Test-only op-count proxy: number of candidate entries ranked by
+    /// `search_entries` since construction. Stays proportional to the
+    /// posting-list union size, not the store size.
+    #[cfg(feature = "test-utils")]
+    entries_ranked: std::sync::atomic::AtomicUsize,
 }
 
 impl MemoryStorage {
@@ -161,9 +228,21 @@ impl MemoryStorage {
             created_at: Utc::now(),
             total_size: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             lowercase: Arc::new(DashMap::new()),
+            grams: Arc::new(DashMap::new()),
             #[cfg(feature = "test-utils")]
             stats_entries_scanned: std::sync::atomic::AtomicUsize::new(0),
+            #[cfg(feature = "test-utils")]
+            entries_ranked: std::sync::atomic::AtomicUsize::new(0),
         }
+    }
+
+    /// Test-only op-count proxy: total candidate entries ranked by search
+    /// since construction. Index-backed search keeps this bounded by the
+    /// posting-list union size per query, not the store size.
+    #[cfg(feature = "test-utils")]
+    pub fn entries_ranked(&self) -> usize {
+        self.entries_ranked
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Test-only op-count proxy: total entries examined by stats computation
@@ -214,17 +293,62 @@ impl MemoryStorage {
             return Vec::new();
         }
 
+        // Candidate keys via the inverted n-gram index: union over query
+        // terms of one posting list per term. For terms of >= MAX_GRAM_LEN
+        // chars, the RAREST of the term's grams is used — any entry containing
+        // the term as a substring contains every gram of it, so a single
+        // posting list is already a guaranteed superset of that term's
+        // matches. Cost is O(sum of chosen posting-list sizes), not O(n).
+        let mut candidates: HashSet<Arc<str>> = HashSet::new();
+        for term in &terms {
+            let chars: Vec<char> = term.chars().collect();
+            let gram_len = chars.len().min(MAX_GRAM_LEN);
+            let mut rarest: Option<(usize, String)> = None;
+            let mut term_impossible = false;
+            for window in chars.windows(gram_len) {
+                let gram: String = window.iter().collect();
+                match self.grams.get(&gram) {
+                    Some(postings) => {
+                        let len = postings.len();
+                        if rarest.as_ref().map_or(true, |(best, _)| len < *best) {
+                            rarest = Some((len, gram));
+                        }
+                    }
+                    None => {
+                        // A gram of the term appears nowhere: no entry can
+                        // contain the term as a substring.
+                        term_impossible = true;
+                        break;
+                    }
+                }
+            }
+            if term_impossible {
+                continue;
+            }
+            if let Some((_, gram)) = rarest {
+                if let Some(postings) = self.grams.get(&gram) {
+                    candidates.extend(postings.iter().cloned());
+                }
+            }
+        }
+
         // (distinct terms matched, total term frequency, key, entry, lowered len)
         let mut matches: Vec<(usize, usize, String, MemoryEntry, usize)> = Vec::new();
-        for entry_ref in self.entries.iter() {
+        for key in candidates {
+            let Some(entry_ref) = self.entries.get(&*key) else {
+                continue;
+            };
             let entry = entry_ref.value();
+            #[cfg(feature = "test-utils")]
+            self.entries_ranked
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             // Memoized lowercase: computed once per entry mutation, not once
             // per (entry x pipeline x query) scan.
             let content_lower: Arc<str> = match self.lowercase.get(&entry.key) {
                 Some(cached) => Arc::clone(cached.value()),
                 None => {
                     // Coherence fallback (should not happen: all mutation
-                    // paths populate the cache).
+                    // paths populate the cache and the index together).
                     let lowered: Arc<str> = Arc::from(entry.value.to_lowercase());
                     self.lowercase
                         .insert(entry.key.clone(), Arc::clone(&lowered));
@@ -289,6 +413,7 @@ impl Storage for MemoryStorage {
             &self.entries,
             &self.total_size,
             &self.lowercase,
+            &self.grams,
             entry.clone(),
         );
         self.update_stats();
@@ -324,7 +449,13 @@ impl Storage for MemoryStorage {
         if self.entries.contains_key(key) {
             let mut entry = entry.clone();
             entry.key = key.to_string();
-            insert_tracked(&self.entries, &self.total_size, &self.lowercase, entry);
+            insert_tracked(
+                &self.entries,
+                &self.total_size,
+                &self.lowercase,
+                &self.grams,
+                entry,
+            );
             self.update_stats();
             Ok(())
         } else {
@@ -335,7 +466,13 @@ impl Storage for MemoryStorage {
     }
 
     async fn delete(&self, key: &str) -> Result<bool> {
-        let removed = remove_tracked(&self.entries, &self.total_size, &self.lowercase, key);
+        let removed = remove_tracked(
+            &self.entries,
+            &self.total_size,
+            &self.lowercase,
+            &self.grams,
+            key,
+        );
         if removed {
             self.update_stats();
         }
@@ -357,6 +494,7 @@ impl Storage for MemoryStorage {
     async fn clear(&self) -> Result<()> {
         self.entries.clear();
         self.lowercase.clear();
+        self.grams.clear();
         self.total_size
             .store(0, std::sync::atomic::Ordering::Relaxed);
         self.update_stats();
@@ -532,6 +670,7 @@ impl MemoryStorage {
             tracing::info!("Replacing all existing data with backup");
             self.entries.clear();
             self.lowercase.clear();
+            self.grams.clear();
             self.total_size
                 .store(0, std::sync::atomic::Ordering::Relaxed);
         }
@@ -549,7 +688,13 @@ impl MemoryStorage {
                 continue;
             }
 
-            insert_tracked(&self.entries, &self.total_size, &self.lowercase, entry);
+            insert_tracked(
+                &self.entries,
+                &self.total_size,
+                &self.lowercase,
+                &self.grams,
+                entry,
+            );
             restored_count += 1;
         }
 
@@ -744,6 +889,7 @@ impl BatchStorage for MemoryStorage {
                 &self.entries,
                 &self.total_size,
                 &self.lowercase,
+                &self.grams,
                 entry.clone(),
             );
         }
@@ -762,7 +908,13 @@ impl BatchStorage for MemoryStorage {
     async fn delete_batch(&self, keys: &[String]) -> Result<usize> {
         let mut deleted_count = 0;
         for key in keys {
-            if remove_tracked(&self.entries, &self.total_size, &self.lowercase, key) {
+            if remove_tracked(
+                &self.entries,
+                &self.total_size,
+                &self.lowercase,
+                &self.grams,
+                key,
+            ) {
                 deleted_count += 1;
             }
         }
@@ -823,6 +975,8 @@ pub struct MemoryTransactionHandle {
     total_size: Arc<std::sync::atomic::AtomicUsize>,
     /// Shared lowercase memoization map of the owning storage
     lowercase: Arc<DashMap<String, Arc<str>>>,
+    /// Shared inverted n-gram index of the owning storage
+    grams: Arc<GramIndex>,
     /// Buffered operations to apply on commit
     operations: Vec<(String, Option<MemoryEntry>)>, // (key, entry) - None means delete
     /// Whether the transaction has been committed or rolled back
@@ -834,11 +988,13 @@ impl MemoryTransactionHandle {
         entries: Arc<DashMap<String, MemoryEntry>>,
         total_size: Arc<std::sync::atomic::AtomicUsize>,
         lowercase: Arc<DashMap<String, Arc<str>>>,
+        grams: Arc<GramIndex>,
     ) -> Self {
         Self {
             entries,
             total_size,
             lowercase,
+            grams,
             operations: Vec::new(),
             committed: false,
         }
@@ -869,10 +1025,22 @@ impl TransactionHandle for MemoryTransactionHandle {
                 Some(entry) => {
                     let mut entry = entry.clone();
                     entry.key = key.clone();
-                    insert_tracked(&self.entries, &self.total_size, &self.lowercase, entry);
+                    insert_tracked(
+                        &self.entries,
+                        &self.total_size,
+                        &self.lowercase,
+                        &self.grams,
+                        entry,
+                    );
                 }
                 None => {
-                    remove_tracked(&self.entries, &self.total_size, &self.lowercase, key);
+                    remove_tracked(
+                        &self.entries,
+                        &self.total_size,
+                        &self.lowercase,
+                        &self.grams,
+                        key,
+                    );
                 }
             }
         }
@@ -898,10 +1066,22 @@ impl TransactionalStorage for MemoryStorage {
                 | crate::memory::storage::StorageOperation::Update { key, entry } => {
                     let mut entry = entry.clone();
                     entry.key = key.clone();
-                    insert_tracked(&self.entries, &self.total_size, &self.lowercase, entry);
+                    insert_tracked(
+                        &self.entries,
+                        &self.total_size,
+                        &self.lowercase,
+                        &self.grams,
+                        entry,
+                    );
                 }
                 crate::memory::storage::StorageOperation::Delete { key } => {
-                    remove_tracked(&self.entries, &self.total_size, &self.lowercase, key);
+                    remove_tracked(
+                        &self.entries,
+                        &self.total_size,
+                        &self.lowercase,
+                        &self.grams,
+                        key,
+                    );
                 }
             }
         }
@@ -914,6 +1094,7 @@ impl TransactionalStorage for MemoryStorage {
             Arc::clone(&self.entries),
             Arc::clone(&self.total_size),
             Arc::clone(&self.lowercase),
+            Arc::clone(&self.grams),
         )))
     }
 }

--- a/src/memory/storage/memory.rs
+++ b/src/memory/storage/memory.rs
@@ -97,10 +97,14 @@ impl Default for RestoreOptions {
 fn insert_tracked(
     entries: &DashMap<String, MemoryEntry>,
     total_size: &std::sync::atomic::AtomicUsize,
+    lowercase: &DashMap<String, Arc<str>>,
     entry: MemoryEntry,
 ) {
     use std::sync::atomic::Ordering;
     let new_size = entry.estimated_size();
+    // Memoize the lowercased content so search never re-lowercases the
+    // corpus; maintained on every mutation path for coherence.
+    lowercase.insert(entry.key.clone(), Arc::from(entry.value.to_lowercase()));
     let replaced = entries.insert(entry.key.clone(), entry);
     total_size.fetch_add(new_size, Ordering::Relaxed);
     if let Some(old) = replaced {
@@ -113,9 +117,11 @@ fn insert_tracked(
 fn remove_tracked(
     entries: &DashMap<String, MemoryEntry>,
     total_size: &std::sync::atomic::AtomicUsize,
+    lowercase: &DashMap<String, Arc<str>>,
     key: &str,
 ) -> bool {
     use std::sync::atomic::Ordering;
+    lowercase.remove(key);
     if let Some((_, old)) = entries.remove(key) {
         total_size.fetch_sub(old.estimated_size(), Ordering::Relaxed);
         true
@@ -136,6 +142,10 @@ pub struct MemoryStorage {
     /// bytes. Shared with transaction handles so committed transactions keep
     /// the counter coherent.
     total_size: Arc<std::sync::atomic::AtomicUsize>,
+    /// Memoized lowercased content per key, maintained on every mutation
+    /// path (store/update/delete/batch/transactions/restore), so search
+    /// scans never re-lowercase the whole corpus per query.
+    lowercase: Arc<DashMap<String, Arc<str>>>,
     /// Test-only op-count proxy: number of entries examined by stats
     /// computation. Stays 0 when stats are maintained incrementally.
     #[cfg(feature = "test-utils")]
@@ -150,6 +160,7 @@ impl MemoryStorage {
             stats: RwLock::new(StorageStats::new("memory".to_string())),
             created_at: Utc::now(),
             total_size: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            lowercase: Arc::new(DashMap::new()),
             #[cfg(feature = "test-utils")]
             stats_entries_scanned: std::sync::atomic::AtomicUsize::new(0),
         }
@@ -203,11 +214,23 @@ impl MemoryStorage {
             return Vec::new();
         }
 
-        // (distinct terms matched, total term frequency, key, entry)
-        let mut matches: Vec<(usize, usize, String, MemoryEntry)> = Vec::new();
+        // (distinct terms matched, total term frequency, key, entry, lowered len)
+        let mut matches: Vec<(usize, usize, String, MemoryEntry, usize)> = Vec::new();
         for entry_ref in self.entries.iter() {
             let entry = entry_ref.value();
-            let content_lower = entry.value.to_lowercase();
+            // Memoized lowercase: computed once per entry mutation, not once
+            // per (entry x pipeline x query) scan.
+            let content_lower: Arc<str> = match self.lowercase.get(&entry.key) {
+                Some(cached) => Arc::clone(cached.value()),
+                None => {
+                    // Coherence fallback (should not happen: all mutation
+                    // paths populate the cache).
+                    let lowered: Arc<str> = Arc::from(entry.value.to_lowercase());
+                    self.lowercase
+                        .insert(entry.key.clone(), Arc::clone(&lowered));
+                    lowered
+                }
+            };
 
             let mut distinct = 0usize;
             let mut total_freq = 0usize;
@@ -220,7 +243,13 @@ impl MemoryStorage {
             }
 
             if distinct > 0 {
-                matches.push((distinct, total_freq, entry.key.clone(), entry.clone()));
+                matches.push((
+                    distinct,
+                    total_freq,
+                    entry.key.clone(),
+                    entry.clone(),
+                    content_lower.len(),
+                ));
             }
         }
 
@@ -233,11 +262,12 @@ impl MemoryStorage {
 
         matches
             .into_iter()
-            .map(|(_, total_freq, _, entry)| {
+            .map(|(_, total_freq, _, entry, lowered_len)| {
                 // Relevance keeps the prior shape: term frequency normalized
-                // by content length.
-                let relevance_score =
-                    total_freq as f64 / entry.value.to_lowercase().len().max(1) as f64;
+                // by content length (lowercasing preserves byte length only
+                // for most text, so use the memoized lowered length, which
+                // matches the previous computation exactly).
+                let relevance_score = total_freq as f64 / lowered_len.max(1) as f64;
                 MemoryFragment::new(entry, relevance_score)
             })
             .collect()
@@ -255,7 +285,12 @@ impl Storage for MemoryStorage {
     #[tracing::instrument(skip(self, entry), fields(key = %entry.key))]
     async fn store(&self, entry: &MemoryEntry) -> Result<()> {
         tracing::debug!("Storing entry in memory storage");
-        insert_tracked(&self.entries, &self.total_size, entry.clone());
+        insert_tracked(
+            &self.entries,
+            &self.total_size,
+            &self.lowercase,
+            entry.clone(),
+        );
         self.update_stats();
         tracing::debug!("Entry stored successfully");
         Ok(())
@@ -289,7 +324,7 @@ impl Storage for MemoryStorage {
         if self.entries.contains_key(key) {
             let mut entry = entry.clone();
             entry.key = key.to_string();
-            insert_tracked(&self.entries, &self.total_size, entry);
+            insert_tracked(&self.entries, &self.total_size, &self.lowercase, entry);
             self.update_stats();
             Ok(())
         } else {
@@ -300,7 +335,7 @@ impl Storage for MemoryStorage {
     }
 
     async fn delete(&self, key: &str) -> Result<bool> {
-        let removed = remove_tracked(&self.entries, &self.total_size, key);
+        let removed = remove_tracked(&self.entries, &self.total_size, &self.lowercase, key);
         if removed {
             self.update_stats();
         }
@@ -321,6 +356,7 @@ impl Storage for MemoryStorage {
 
     async fn clear(&self) -> Result<()> {
         self.entries.clear();
+        self.lowercase.clear();
         self.total_size
             .store(0, std::sync::atomic::Ordering::Relaxed);
         self.update_stats();
@@ -495,6 +531,7 @@ impl MemoryStorage {
         } else {
             tracing::info!("Replacing all existing data with backup");
             self.entries.clear();
+            self.lowercase.clear();
             self.total_size
                 .store(0, std::sync::atomic::Ordering::Relaxed);
         }
@@ -512,7 +549,7 @@ impl MemoryStorage {
                 continue;
             }
 
-            insert_tracked(&self.entries, &self.total_size, entry);
+            insert_tracked(&self.entries, &self.total_size, &self.lowercase, entry);
             restored_count += 1;
         }
 
@@ -703,7 +740,12 @@ pub struct BackupInfo {
 impl BatchStorage for MemoryStorage {
     async fn store_batch(&self, entries: &[MemoryEntry]) -> Result<()> {
         for entry in entries {
-            insert_tracked(&self.entries, &self.total_size, entry.clone());
+            insert_tracked(
+                &self.entries,
+                &self.total_size,
+                &self.lowercase,
+                entry.clone(),
+            );
         }
         self.update_stats();
         Ok(())
@@ -720,7 +762,7 @@ impl BatchStorage for MemoryStorage {
     async fn delete_batch(&self, keys: &[String]) -> Result<usize> {
         let mut deleted_count = 0;
         for key in keys {
-            if remove_tracked(&self.entries, &self.total_size, key) {
+            if remove_tracked(&self.entries, &self.total_size, &self.lowercase, key) {
                 deleted_count += 1;
             }
         }
@@ -779,6 +821,8 @@ pub struct MemoryTransactionHandle {
     entries: Arc<DashMap<String, MemoryEntry>>,
     /// Shared incremental size counter of the owning storage
     total_size: Arc<std::sync::atomic::AtomicUsize>,
+    /// Shared lowercase memoization map of the owning storage
+    lowercase: Arc<DashMap<String, Arc<str>>>,
     /// Buffered operations to apply on commit
     operations: Vec<(String, Option<MemoryEntry>)>, // (key, entry) - None means delete
     /// Whether the transaction has been committed or rolled back
@@ -789,10 +833,12 @@ impl MemoryTransactionHandle {
     fn new(
         entries: Arc<DashMap<String, MemoryEntry>>,
         total_size: Arc<std::sync::atomic::AtomicUsize>,
+        lowercase: Arc<DashMap<String, Arc<str>>>,
     ) -> Self {
         Self {
             entries,
             total_size,
+            lowercase,
             operations: Vec::new(),
             committed: false,
         }
@@ -823,10 +869,10 @@ impl TransactionHandle for MemoryTransactionHandle {
                 Some(entry) => {
                     let mut entry = entry.clone();
                     entry.key = key.clone();
-                    insert_tracked(&self.entries, &self.total_size, entry);
+                    insert_tracked(&self.entries, &self.total_size, &self.lowercase, entry);
                 }
                 None => {
-                    remove_tracked(&self.entries, &self.total_size, key);
+                    remove_tracked(&self.entries, &self.total_size, &self.lowercase, key);
                 }
             }
         }
@@ -852,10 +898,10 @@ impl TransactionalStorage for MemoryStorage {
                 | crate::memory::storage::StorageOperation::Update { key, entry } => {
                     let mut entry = entry.clone();
                     entry.key = key.clone();
-                    insert_tracked(&self.entries, &self.total_size, entry);
+                    insert_tracked(&self.entries, &self.total_size, &self.lowercase, entry);
                 }
                 crate::memory::storage::StorageOperation::Delete { key } => {
-                    remove_tracked(&self.entries, &self.total_size, key);
+                    remove_tracked(&self.entries, &self.total_size, &self.lowercase, key);
                 }
             }
         }
@@ -867,6 +913,7 @@ impl TransactionalStorage for MemoryStorage {
         Ok(Box::new(MemoryTransactionHandle::new(
             Arc::clone(&self.entries),
             Arc::clone(&self.total_size),
+            Arc::clone(&self.lowercase),
         )))
     }
 }

--- a/tests/inverted_index_tests.rs
+++ b/tests/inverted_index_tests.rs
@@ -1,0 +1,193 @@
+//! P4: inverted (n-gram) index correctness + scaling tests for
+//! `MemoryStorage::search_entries`.
+//!
+//! Correctness: index-backed search must return EXACTLY the same keys in the
+//! same order as a naive full-scan reference implementation.
+//! Scaling: search must rank only index candidates, not all n entries.
+
+#![cfg(feature = "test-utils")]
+// Test code: panics on failure are the intended behaviour.
+#![allow(clippy::unwrap_used, clippy::panic)]
+
+use synaptic::memory::storage::memory::MemoryStorage;
+use synaptic::memory::storage::Storage;
+use synaptic::memory::types::{MemoryEntry, MemoryType};
+
+/// Full-scan reference: replicates the documented ranking contract of
+/// `search_entries` (any-term substring match; distinct terms desc, total
+/// frequency desc, key asc) independently of the index.
+fn reference_search(corpus: &[(String, String)], query: &str, limit: usize) -> Vec<String> {
+    let query_lower = query.to_lowercase();
+    let terms: Vec<&str> = query_lower.split_whitespace().collect();
+    if terms.is_empty() {
+        return Vec::new();
+    }
+    let mut matches: Vec<(usize, usize, String)> = Vec::new();
+    for (key, value) in corpus {
+        let content = value.to_lowercase();
+        let mut distinct = 0usize;
+        let mut freq = 0usize;
+        for term in &terms {
+            let occurrences = content.matches(term).count();
+            if occurrences > 0 {
+                distinct += 1;
+                freq += occurrences;
+            }
+        }
+        if distinct > 0 {
+            matches.push((distinct, freq, key.clone()));
+        }
+    }
+    matches.sort_by(|a, b| {
+        b.0.cmp(&a.0)
+            .then_with(|| b.1.cmp(&a.1))
+            .then_with(|| a.2.cmp(&b.2))
+    });
+    matches.truncate(limit);
+    matches.into_iter().map(|(_, _, k)| k).collect()
+}
+
+async fn seed(storage: &MemoryStorage, corpus: &[(String, String)]) {
+    for (key, value) in corpus {
+        let entry = MemoryEntry::new(key.clone(), value.clone(), MemoryType::LongTerm);
+        storage.store(&entry).await.unwrap();
+    }
+}
+
+async fn searched_keys(storage: &MemoryStorage, query: &str, limit: usize) -> Vec<String> {
+    storage
+        .search(query, limit)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|f| f.entry.key)
+        .collect()
+}
+
+fn corpus() -> Vec<(String, String)> {
+    vec![
+        ("doc_cat".into(), "the cat sat on the mat".into()),
+        ("doc_dog".into(), "a dog chased the cat around".into()),
+        ("doc_bird".into(), "birds sing in the morning".into()),
+        (
+            "doc_concat".into(),
+            "we concatenate strings carefully".into(),
+        ),
+        ("doc_pet".into(), "a cat is a fine pet and companion".into()),
+        ("doc_freq".into(), "cat cat cat cat everywhere".into()),
+        ("doc_tie_a".into(), "one cat only here".into()),
+        ("doc_tie_b".into(), "one cat only here".into()),
+        ("doc_upper".into(), "The CAT and The DOG shout".into()),
+        ("doc_short".into(), "ox ax".into()),
+        ("doc_unrelated".into(), "quantum flux capacitors hum".into()),
+        ("doc_empty".into(), "".into()),
+    ]
+}
+
+#[tokio::test]
+async fn index_search_matches_full_scan_reference_exactly() {
+    let corpus = corpus();
+    let storage = MemoryStorage::new();
+    seed(&storage, &corpus).await;
+
+    let queries = [
+        "cat",              // single term, several matches incl. substring "concatenate"
+        "cat dog",          // multi-term union
+        "cat animal pet",   // partial term overlap
+        "zebra",            // no match
+        "the",              // matches most docs (stopword-like, high fan-out)
+        "e",                // 1-char term (sub-trigram)
+        "ox",               // 2-char term
+        "CAT DOG",          // case-insensitivity
+        "cat cat",          // duplicate query terms
+        "quantum flux hum", // all terms in one doc
+    ];
+    for query in queries {
+        for limit in [1usize, 3, 100] {
+            let expected = reference_search(&corpus, query, limit);
+            let actual = searched_keys(&storage, query, limit).await;
+            assert_eq!(
+                actual, expected,
+                "index search diverged from full-scan reference for query {query:?} limit {limit}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn index_is_maintained_across_update_and_delete() {
+    let mut corpus = corpus();
+    let storage = MemoryStorage::new();
+    seed(&storage, &corpus).await;
+
+    // Delete: the key must no longer appear for its terms.
+    storage.delete("doc_freq").await.unwrap();
+    corpus.retain(|(k, _)| k != "doc_freq");
+    assert_eq!(
+        searched_keys(&storage, "cat", 100).await,
+        reference_search(&corpus, "cat", 100)
+    );
+    assert!(!searched_keys(&storage, "cat", 100)
+        .await
+        .contains(&"doc_freq".to_string()));
+
+    // Update: old tokens must stop matching, new tokens must match.
+    let updated = MemoryEntry::new(
+        "doc_bird".to_string(),
+        "a stealthy cat stalks".to_string(),
+        MemoryType::LongTerm,
+    );
+    storage.update("doc_bird", &updated).await.unwrap();
+    for (k, v) in corpus.iter_mut() {
+        if k == "doc_bird" {
+            *v = "a stealthy cat stalks".to_string();
+        }
+    }
+    assert_eq!(
+        searched_keys(&storage, "cat", 100).await,
+        reference_search(&corpus, "cat", 100)
+    );
+    assert!(searched_keys(&storage, "sing morning", 100)
+        .await
+        .is_empty());
+
+    // Clear: nothing matches anymore.
+    storage.clear().await.unwrap();
+    assert!(searched_keys(&storage, "cat", 100).await.is_empty());
+}
+
+#[tokio::test]
+async fn search_ranks_only_index_candidates_not_all_entries() {
+    let storage = MemoryStorage::new();
+    // Large store: n entries that share NO grams with the query term.
+    let n = 5_000usize;
+    for i in 0..n {
+        let entry = MemoryEntry::new(
+            format!("filler_{i:05}"),
+            "www www www www".to_string(),
+            MemoryType::LongTerm,
+        );
+        storage.store(&entry).await.unwrap();
+    }
+    // A handful of matching entries.
+    for i in 0..5 {
+        let entry = MemoryEntry::new(
+            format!("hit_{i}"),
+            format!("zebra sighting number {i}"),
+            MemoryType::LongTerm,
+        );
+        storage.store(&entry).await.unwrap();
+    }
+
+    let before = storage.entries_ranked();
+    let results = storage.search("zebra", 10).await.unwrap();
+    let ranked = storage.entries_ranked() - before;
+
+    assert_eq!(results.len(), 5, "all matching entries found");
+    assert!(
+        ranked <= 5,
+        "search must rank only index candidates (got {ranked}, store has {})",
+        n + 5
+    );
+    assert!(ranked < n / 100, "ranking work must not scale with n");
+}

--- a/tests/knowledge_graph_tests.rs
+++ b/tests/knowledge_graph_tests.rs
@@ -256,3 +256,79 @@ async fn test_knowledge_graph_enabled_vs_disabled() -> Result<(), Box<dyn Error>
 
     Ok(())
 }
+
+/// Determinism regression (P1 W2/W3): past the per-store scan cap, the
+/// candidate set `find_similar_node` examines must be a DETERMINISTIC,
+/// relevance-ordered subset — not an arbitrary `HashMap`/`DashMap`
+/// iteration-order prefix (whose order is per-instance seed-randomized).
+///
+/// Two independently-built graphs (same memories, same insertion order) must
+/// yield the identical candidate ordering, and a content-relevant node placed
+/// well past the cap must survive into the examined window.
+#[cfg(feature = "test-utils")]
+#[tokio::test]
+async fn kg_similar_candidate_scan_is_deterministic_past_cap() -> Result<(), Box<dyn Error>> {
+    use synaptic::memory::knowledge_graph::{GraphConfig, MemoryKnowledgeGraph};
+    use synaptic::memory::types::{MemoryEntry, MemoryType};
+
+    async fn build() -> Result<MemoryKnowledgeGraph, Box<dyn Error>> {
+        let mut kg = MemoryKnowledgeGraph::new(GraphConfig::default());
+        // 400 filler memories (> the 256 cap) with unrelated content.
+        for i in 0..400 {
+            let e = MemoryEntry::new(
+                format!("filler_{i}"),
+                format!("unrelated filler content number {i} about weather and traffic"),
+                MemoryType::LongTerm,
+            );
+            kg.add_or_update_memory_node(&e).await?;
+        }
+        // One highly relevant memory sharing distinctive tokens with the probe.
+        let relevant = MemoryEntry::new(
+            "relevant_node".to_string(),
+            "quantum entanglement photon superposition experiment".to_string(),
+            MemoryType::LongTerm,
+        );
+        kg.add_or_update_memory_node(&relevant).await?;
+        Ok(kg)
+    }
+
+    let probe = MemoryEntry::new(
+        "probe".to_string(),
+        "quantum entanglement photon superposition".to_string(),
+        MemoryType::LongTerm,
+    );
+
+    let kg_a = build().await?;
+    let kg_b = build().await?;
+
+    let ids_a = kg_a.debug_similar_candidate_ids(&probe);
+    let ids_b = kg_b.debug_similar_candidate_ids(&probe);
+
+    // Same node ids in the same order despite independent, seed-randomized maps.
+    let node_a = kg_a.get_node_for_memory("relevant_node").await?.unwrap();
+    let node_b = kg_b.get_node_for_memory("relevant_node").await?.unwrap();
+
+    // The candidate windows are bounded by the cap.
+    assert!(ids_a.len() <= 256);
+    assert_eq!(ids_a.len(), ids_b.len(), "candidate window size must match");
+
+    // The content-relevant node (inserted last, i.e. entry #400) must survive
+    // the cap in BOTH graphs by relevance ordering, and be examined first.
+    assert!(
+        ids_a.contains(&node_a),
+        "relevant node must survive the scan cap deterministically"
+    );
+    assert!(ids_b.contains(&node_b));
+    assert_eq!(
+        ids_a.first().copied(),
+        Some(node_a),
+        "the most content-relevant node must be examined first"
+    );
+    assert_eq!(
+        ids_b.first().copied(),
+        Some(node_b),
+        "ordering must be reproducible run-to-run"
+    );
+
+    Ok(())
+}

--- a/tests/llm_reasoner_tests.rs
+++ b/tests/llm_reasoner_tests.rs
@@ -1,0 +1,234 @@
+//! Tests for the optional `LlmReasoner` (feature `llm-reasoning`).
+//!
+//! NO NETWORK: the reasoner's chat call is injectable, so these tests drive
+//! it with canned JSON responses (the parse path) and with failing calls
+//! (the fail-open-to-heuristic path).
+#![cfg(feature = "llm-reasoning")]
+
+use std::sync::Arc;
+
+use synaptic::memory::embeddings::TfIdfProvider;
+use synaptic::memory::reasoning::llm::{ChatCall, LlmReasoner};
+use synaptic::memory::reasoning::{
+    ConflictResolution, ExtractionContext, Fact, HeuristicReasoner, MemoryReasoner, NeighborFact,
+};
+use synaptic::memory::types::MemoryEntry;
+
+fn canned(reply: &str) -> ChatCall {
+    let reply = reply.to_string();
+    Arc::new(move |_system, _user| {
+        let reply = reply.clone();
+        Box::pin(async move { Ok(reply) })
+    })
+}
+
+fn failing() -> ChatCall {
+    Arc::new(|_system, _user| Box::pin(async move { Err("connection refused".to_string()) }))
+}
+
+fn ctx() -> ExtractionContext {
+    ExtractionContext {
+        source_key: "k1".to_string(),
+        timestamp: chrono::Utc::now(),
+    }
+}
+
+fn heuristic() -> HeuristicReasoner {
+    HeuristicReasoner::new(Arc::new(TfIdfProvider::default()))
+}
+
+#[tokio::test]
+async fn extract_parses_structured_json_from_llm() {
+    let reply = r#"{"facts":[{"text":"Alice moved to Berlin.","entities":[{"name":"Alice","kind":"Person"},{"name":"Berlin","kind":"Place"}],"relations":[{"subject":"Alice","predicate":"lives_in","object":"Berlin"}]}]}"#;
+    let reasoner = LlmReasoner::with_call(canned(reply));
+    let extraction = reasoner
+        .extract("Alice moved to Berlin.", &ctx())
+        .await
+        .expect("extract must not fail");
+    assert_eq!(extraction.facts.len(), 1);
+    let fact = &extraction.facts[0];
+    assert_eq!(fact.text, "Alice moved to Berlin.");
+    assert_eq!(fact.entities.len(), 2);
+    assert_eq!(fact.entities[0].name, "Alice");
+    assert_eq!(fact.entities[1].name, "Berlin");
+    // Spans are recovered by locating the entity in the fact text.
+    assert_eq!(fact.entities[0].span, (0, 5));
+    assert_eq!(fact.relations.len(), 1);
+    assert_eq!(fact.relations[0].predicate, "lives_in");
+}
+
+#[tokio::test]
+async fn extract_handles_code_fenced_json() {
+    let reply = "```json\n{\"facts\":[{\"text\":\"Bob works at Acme Corp.\",\"entities\":[{\"name\":\"Bob\",\"kind\":\"Person\"}],\"relations\":[]}]}\n```";
+    let reasoner = LlmReasoner::with_call(canned(reply));
+    let extraction = reasoner
+        .extract("Bob works at Acme Corp.", &ctx())
+        .await
+        .expect("extract must not fail");
+    assert_eq!(extraction.facts.len(), 1);
+    assert_eq!(extraction.facts[0].entities[0].name, "Bob");
+}
+
+#[tokio::test]
+async fn resolve_parses_llm_verdict() {
+    let reply = r#"{"action":"supersede","old_id":"n1","reason":"newer location"}"#;
+    let reasoner = LlmReasoner::with_call(canned(reply));
+    let candidate = Fact {
+        text: "Alice moved to Munich.".to_string(),
+        entities: vec![],
+        relations: vec![],
+    };
+    let neighbors = vec![NeighborFact {
+        id: "n1".to_string(),
+        similarity: 0.8,
+        text: "Alice lives in Berlin.".to_string(),
+    }];
+    let resolution = reasoner
+        .resolve(&candidate, &neighbors)
+        .await
+        .expect("resolve must not fail");
+    assert_eq!(
+        resolution,
+        ConflictResolution::Supersede {
+            old_id: "n1".to_string(),
+            reason: "newer location".to_string(),
+        }
+    );
+}
+
+#[tokio::test]
+async fn synthesize_parses_llm_insight_with_cluster_ids() {
+    let reply = r#"{"insight":"Alice has been relocating across Europe.","confidence":0.9}"#;
+    let reasoner = LlmReasoner::with_call(canned(reply));
+    let cluster = vec![
+        MemoryEntry::new(
+            "a".to_string(),
+            "Alice moved to Berlin.".to_string(),
+            synaptic::memory::types::MemoryType::LongTerm,
+        ),
+        MemoryEntry::new(
+            "b".to_string(),
+            "Alice moved to Munich.".to_string(),
+            synaptic::memory::types::MemoryType::LongTerm,
+        ),
+    ];
+    let insight = reasoner
+        .synthesize(&cluster)
+        .await
+        .expect("synthesize must not fail")
+        .expect("insight expected");
+    assert_eq!(insight.text, "Alice has been relocating across Europe.");
+    assert!((insight.confidence - 0.9).abs() < 1e-9);
+    let ids: Vec<String> = cluster.iter().map(|e| e.id().to_string()).collect();
+    assert_eq!(insight.derived_from, ids);
+}
+
+#[tokio::test]
+async fn extract_falls_back_to_heuristic_on_call_failure() {
+    let reasoner = LlmReasoner::with_call(failing());
+    let text = "Alice moved to Berlin.";
+    let got = reasoner
+        .extract(text, &ctx())
+        .await
+        .expect("fail-open: must return heuristic result, not Err");
+    let want = heuristic()
+        .extract(text, &ctx())
+        .await
+        .expect("heuristic extract");
+    assert_eq!(
+        got, want,
+        "fallback must equal the HeuristicReasoner result"
+    );
+    assert!(!got.facts.is_empty(), "heuristic extracts a real fact here");
+}
+
+#[tokio::test]
+async fn extract_falls_back_to_heuristic_on_unparseable_reply() {
+    let reasoner = LlmReasoner::with_call(canned("sorry, I cannot help with that"));
+    let text = "Alice moved to Berlin.";
+    let got = reasoner
+        .extract(text, &ctx())
+        .await
+        .expect("fail-open: must return heuristic result, not Err");
+    let want = heuristic()
+        .extract(text, &ctx())
+        .await
+        .expect("heuristic extract");
+    assert_eq!(got, want);
+}
+
+#[tokio::test]
+async fn resolve_falls_back_to_heuristic_on_call_failure() {
+    let reasoner = LlmReasoner::with_call(failing());
+    let candidate = Fact {
+        text: "Alice moved to Berlin.".to_string(),
+        entities: vec![],
+        relations: vec![],
+    };
+    let neighbors = vec![NeighborFact {
+        id: "n1".to_string(),
+        similarity: 0.99,
+        text: "Alice moved to Berlin.".to_string(),
+    }];
+    let got = reasoner
+        .resolve(&candidate, &neighbors)
+        .await
+        .expect("fail-open: must return heuristic result, not Err");
+    let want = heuristic()
+        .resolve(&candidate, &neighbors)
+        .await
+        .expect("heuristic resolve");
+    assert_eq!(got, want);
+}
+
+#[tokio::test]
+async fn resolve_falls_back_when_supersede_targets_unknown_neighbor() {
+    // A verdict referencing a non-neighbor id is invalid; fail open.
+    let reply = r#"{"action":"supersede","old_id":"not-a-neighbor","reason":"x"}"#;
+    let reasoner = LlmReasoner::with_call(canned(reply));
+    let candidate = Fact {
+        text: "Alice moved to Munich.".to_string(),
+        entities: vec![],
+        relations: vec![],
+    };
+    let neighbors = vec![NeighborFact {
+        id: "n1".to_string(),
+        similarity: 0.8,
+        text: "Alice lives in Berlin.".to_string(),
+    }];
+    let got = reasoner
+        .resolve(&candidate, &neighbors)
+        .await
+        .expect("fail-open: must return heuristic result, not Err");
+    let want = heuristic()
+        .resolve(&candidate, &neighbors)
+        .await
+        .expect("heuristic resolve");
+    assert_eq!(got, want);
+}
+
+#[tokio::test]
+async fn synthesize_falls_back_to_heuristic_on_call_failure() {
+    let reasoner = LlmReasoner::with_call(failing());
+    let cluster = vec![
+        MemoryEntry::new(
+            "a".to_string(),
+            "Alice moved to Berlin.".to_string(),
+            synaptic::memory::types::MemoryType::LongTerm,
+        ),
+        MemoryEntry::new(
+            "b".to_string(),
+            "Alice moved to Munich.".to_string(),
+            synaptic::memory::types::MemoryType::LongTerm,
+        ),
+    ];
+    let got = reasoner
+        .synthesize(&cluster)
+        .await
+        .expect("fail-open: must return heuristic result, not Err");
+    let want = heuristic()
+        .synthesize(&cluster)
+        .await
+        .expect("heuristic synthesize");
+    assert_eq!(got, want);
+}

--- a/tests/search_perf_tests.rs
+++ b/tests/search_perf_tests.rs
@@ -1,0 +1,149 @@
+//! Deterministic op-count and correctness tests for the search hot path.
+//!
+//! These tests are op-count based (not wall-clock): they assert that a
+//! search embeds each distinct candidate content at most once, that
+//! query-time scoring embeds never mutate the provider vocabulary, and that
+//! the top-k ranking for a fixed corpus + query is unchanged by the
+//! optimizations.
+
+// Test code: unwrap/panic on failure is the intended behaviour.
+#![allow(clippy::unwrap_used, clippy::panic)]
+
+use synaptic::{AgentMemory, MemoryConfig, StorageBackend};
+
+/// Fixed corpus shared by the tests: keys with distinct contents.
+fn corpus() -> Vec<(&'static str, &'static str)> {
+    vec![
+        (
+            "doc_pooling",
+            "database connection pooling configuration tuning for postgres",
+        ),
+        (
+            "doc_conn",
+            "database connection retry logic and timeout handling",
+        ),
+        ("doc_db", "database schema migration tooling overview notes"),
+        ("doc_rust", "rust programming language memory safety"),
+        ("doc_python", "python scripting for data pipelines"),
+        ("doc_cooking", "cooking recipes for italian pasta dishes"),
+    ]
+}
+
+/// (c) Correctness pin: the top-k ordering for a fixed corpus + query is
+/// identical to the ordering produced before the hot-path optimizations
+/// (captured from the pre-change pipeline on this branch).
+#[tokio::test]
+async fn top_k_ranking_unchanged_for_fixed_corpus() {
+    let mut memory = AgentMemory::new(MemoryConfig {
+        storage_backend: StorageBackend::Memory,
+        enable_embeddings: true,
+        ..Default::default()
+    })
+    .await
+    .expect("agent memory constructs");
+
+    for (key, value) in corpus() {
+        memory
+            .store(key, value)
+            .await
+            .unwrap_or_else(|e| panic!("store {key}: {e}"));
+    }
+
+    let results = memory
+        .search("database connection pooling", 3)
+        .await
+        .expect("search ok");
+    let keys: Vec<&str> = results.iter().map(|r| r.entry.key.as_str()).collect();
+
+    // Pinned pre-optimization ordering (captured on this branch before the
+    // read-only embed / cache changes). Rankings must be preserved.
+    assert_eq!(
+        keys,
+        vec!["doc_pooling", "doc_conn", "doc_db"],
+        "top-k ranking must be identical before/after the perf changes"
+    );
+}
+
+#[cfg(feature = "test-utils")]
+mod op_counts {
+    use super::corpus;
+    use std::sync::Arc;
+    use synaptic::memory::embeddings::TfIdfProvider;
+    use synaptic::memory::retrieval::{
+        DenseVectorRetriever, HeuristicReranker, HybridRetriever, PipelineConfig,
+    };
+    use synaptic::memory::storage::memory::MemoryStorage;
+    use synaptic::memory::storage::Storage;
+    use synaptic::memory::types::{MemoryEntry, MemoryType};
+
+    /// (a) A single hybrid search (dense retriever + heuristic reranker
+    /// sharing one provider) embeds each DISTINCT content at most once:
+    /// the number of actually computed scoring embeddings is bounded by
+    /// distinct candidate contents + 1 (the query), not ~2N from the dense
+    /// pass and the rerank pass embedding candidates independently.
+    #[tokio::test]
+    async fn single_search_embeds_each_distinct_content_at_most_once() {
+        let storage = Arc::new(MemoryStorage::new());
+        for (key, value) in corpus() {
+            let entry = MemoryEntry::new(key.to_string(), value.to_string(), MemoryType::LongTerm);
+            storage.store(&entry).await.unwrap();
+        }
+
+        let provider = Arc::new(TfIdfProvider::default());
+        // Threshold 0.0 so every candidate is scored and the top-K (>1)
+        // reaches the reranker.
+        let dense =
+            DenseVectorRetriever::new(storage.clone(), provider.clone()).with_threshold(0.0);
+        let reranker = HeuristicReranker::new(Some(provider.clone()), None);
+        let hybrid = HybridRetriever::new(PipelineConfig::semantic_focus())
+            .add_pipeline(Arc::new(dense))
+            .with_reranker(Arc::new(reranker));
+
+        let results = hybrid
+            .search("database connection pooling", 5)
+            .await
+            .unwrap();
+        assert!(!results.is_empty(), "search should return candidates");
+
+        let distinct_contents = corpus().len();
+        let computed = provider.scoring_embeds_computed();
+        assert!(
+            computed <= distinct_contents + 1,
+            "one search must compute at most {} scoring embeds \
+             (distinct contents + query), got {} — candidates are being re-embedded",
+            distinct_contents + 1,
+            computed
+        );
+        assert!(
+            provider.scoring_cache_hits() > 0,
+            "the reranker must reuse the dense retriever's cached embeddings"
+        );
+    }
+
+    /// (b) Query-time scoring embeds are read-only: they never mutate the
+    /// provider vocabulary (no write lock, no IDF rebuild).
+    #[tokio::test]
+    async fn scoring_embeds_do_not_mutate_vocabulary() {
+        use synaptic::memory::embeddings::provider::EmbeddingProvider;
+
+        let provider = TfIdfProvider::default();
+        // Seed the vocabulary through the document (store-time) path.
+        for (_, value) in corpus() {
+            provider.embed(value, None).await.unwrap();
+        }
+        let vocab_before = provider.vocabulary_size();
+        assert!(vocab_before > 0, "document embeds must build vocabulary");
+
+        // Run many scoring embeds over NEW, unseen texts.
+        for i in 0..50 {
+            let text = format!("unseen scoring query text number {i} zebra quokka");
+            provider.embed_for_scoring(&text, None).await.unwrap();
+        }
+
+        assert_eq!(
+            provider.vocabulary_size(),
+            vocab_before,
+            "scoring embeds must not mutate the vocabulary"
+        );
+    }
+}

--- a/tests/write_path_scaling_tests.rs
+++ b/tests/write_path_scaling_tests.rs
@@ -176,7 +176,10 @@ async fn stats_computation_never_rescans_entries() {
 async fn neighbor_facts_examines_bounded_candidates() {
     use synaptic::{AgentMemory, MemoryConfig};
 
-    const K: usize = 32; // generous upper bound on the configured candidate cap
+    // Generous upper bound on the configured candidate cap: the keyword hit
+    // set (<=21) unioned with a small constant number of per-subject lookups
+    // (<=21 each). Independent of store size, which is the point.
+    const K: usize = 96;
 
     let mut memory = AgentMemory::new(MemoryConfig::default())
         .await

--- a/tests/write_path_scaling_tests.rs
+++ b/tests/write_path_scaling_tests.rs
@@ -1,0 +1,207 @@
+//! Write-path scaling tests (Task P1, agent-memory-v2 follow-ups).
+//!
+//! These assert operation-count proxies rather than wall-clock time so they
+//! stay deterministic: storage stats must not rescan all entries per store
+//! (incremental size counter), and `neighbor_facts` must examine a bounded
+//! candidate set regardless of store size.
+
+// Test code: panic on unexpected state is the intended behaviour.
+#![allow(clippy::panic)]
+
+use synaptic::memory::storage::memory::MemoryStorage;
+use synaptic::memory::storage::{BatchStorage, Storage, TransactionalStorage};
+use synaptic::memory::types::{MemoryEntry, MemoryType};
+
+fn entry(key: &str, value: &str) -> MemoryEntry {
+    MemoryEntry::new(key.to_string(), value.to_string(), MemoryType::LongTerm)
+}
+
+/// Recompute the expected total size from the entries the test itself
+/// tracks — independent of any storage-internal full scan.
+fn expected_size(entries: &[MemoryEntry]) -> usize {
+    entries.iter().map(|e| e.estimated_size()).sum()
+}
+
+#[tokio::test]
+async fn total_size_is_correct_after_inserts_updates_and_deletes() {
+    let storage = MemoryStorage::new();
+    let mut live: Vec<MemoryEntry> = Vec::new();
+
+    // Inserts.
+    for i in 0..50 {
+        let e = entry(&format!("k{i}"), &format!("value number {i} padding"));
+        storage.store(&e).await.expect("store");
+        live.push(e);
+    }
+    let stats = storage.stats().await.expect("stats");
+    assert_eq!(stats.total_entries, 50);
+    assert_eq!(stats.total_size_bytes, expected_size(&live));
+
+    // Update (replaces an existing entry with a longer value).
+    let updated = entry("k10", "a much longer replacement value with extra content");
+    storage.update("k10", &updated).await.expect("update");
+    live[10] = updated;
+    let stats = storage.stats().await.expect("stats");
+    assert_eq!(stats.total_size_bytes, expected_size(&live));
+
+    // Re-store an existing key (insert overwrite path).
+    let restored = entry("k11", "short");
+    storage.store(&restored).await.expect("re-store");
+    live[11] = restored;
+    let stats = storage.stats().await.expect("stats");
+    assert_eq!(stats.total_size_bytes, expected_size(&live));
+
+    // Delete: the incremental counter must be decremented.
+    assert!(storage.delete("k20").await.expect("delete"));
+    live.retain(|e| e.key != "k20");
+    let stats = storage.stats().await.expect("stats");
+    assert_eq!(stats.total_entries, 49);
+    assert_eq!(stats.total_size_bytes, expected_size(&live));
+
+    // Deleting a missing key must not change anything.
+    assert!(!storage.delete("missing").await.expect("delete missing"));
+    let stats = storage.stats().await.expect("stats");
+    assert_eq!(stats.total_size_bytes, expected_size(&live));
+}
+
+#[tokio::test]
+async fn total_size_is_correct_after_batch_and_clear() {
+    let storage = MemoryStorage::new();
+    let mut live: Vec<MemoryEntry> = Vec::new();
+
+    let batch: Vec<MemoryEntry> = (0..30)
+        .map(|i| entry(&format!("b{i}"), &format!("batch value {i}")))
+        .collect();
+    storage.store_batch(&batch).await.expect("store_batch");
+    live.extend(batch.iter().cloned());
+    let stats = storage.stats().await.expect("stats");
+    assert_eq!(stats.total_size_bytes, expected_size(&live));
+
+    // Batch overwrite of existing keys must not double-count.
+    let overwrite: Vec<MemoryEntry> = (0..10)
+        .map(|i| {
+            entry(
+                &format!("b{i}"),
+                &format!("rewritten longer batch value {i}"),
+            )
+        })
+        .collect();
+    storage.store_batch(&overwrite).await.expect("overwrite");
+    for e in &overwrite {
+        let slot = live
+            .iter_mut()
+            .find(|l| l.key == e.key)
+            .expect("existing slot");
+        *slot = e.clone();
+    }
+    let stats = storage.stats().await.expect("stats");
+    assert_eq!(stats.total_size_bytes, expected_size(&live));
+
+    let deleted = storage
+        .delete_batch(&["b0".to_string(), "b1".to_string(), "nope".to_string()])
+        .await
+        .expect("delete_batch");
+    assert_eq!(deleted, 2);
+    live.retain(|e| e.key != "b0" && e.key != "b1");
+    let stats = storage.stats().await.expect("stats");
+    assert_eq!(stats.total_size_bytes, expected_size(&live));
+
+    storage.clear().await.expect("clear");
+    let stats = storage.stats().await.expect("stats");
+    assert_eq!(stats.total_entries, 0);
+    assert_eq!(stats.total_size_bytes, 0);
+}
+
+#[tokio::test]
+async fn total_size_is_correct_after_transaction_commit() {
+    use synaptic::memory::storage::StorageTransaction;
+
+    let storage = MemoryStorage::new();
+    let seed = entry("seed", "seed value that will be deleted");
+    storage.store(&seed).await.expect("seed");
+
+    let mut tx = StorageTransaction::new();
+    let t1 = entry("t1", "transactional value one");
+    let t2 = entry("t2", "transactional value two, a little longer");
+    tx.store("t1".to_string(), t1.clone());
+    tx.store("t2".to_string(), t2.clone());
+    tx.delete("seed".to_string());
+    storage.execute_transaction(tx).await.expect("execute tx");
+
+    let live = vec![t1, t2];
+    let stats = storage.stats().await.expect("stats");
+    assert_eq!(stats.total_entries, 2);
+    assert_eq!(stats.total_size_bytes, expected_size(&live));
+
+    // Handle-based transaction path must also keep stats coherent.
+    let mut handle = storage.begin_transaction().await.expect("begin");
+    let t3 = entry("t3", "handle transactional value three");
+    handle.store("t3", &t3).await.expect("tx store");
+    handle.delete("t1").await.expect("tx delete");
+    handle.commit().await.expect("commit");
+
+    let live = vec![live[1].clone(), t3];
+    let stats = storage.stats().await.expect("stats");
+    assert_eq!(stats.total_entries, 2);
+    assert_eq!(stats.total_size_bytes, expected_size(&live));
+}
+
+/// Op-count proxy: computing stats must be O(1) — no per-call rescan of all
+/// entries. The storage exposes (behind `test-utils`) a counter of entries
+/// examined by stats computation; it must stay 0 no matter how many stores
+/// and stats calls happen.
+#[cfg(feature = "test-utils")]
+#[tokio::test]
+async fn stats_computation_never_rescans_entries() {
+    let storage = MemoryStorage::new();
+    for i in 0..500 {
+        let e = entry(&format!("s{i}"), &format!("scaling entry number {i}"));
+        storage.store(&e).await.expect("store");
+    }
+    for _ in 0..5 {
+        storage.stats().await.expect("stats");
+    }
+    assert_eq!(
+        storage.stats_entries_scanned(),
+        0,
+        "stats computation must be incremental (O(1)), not a full rescan"
+    );
+}
+
+/// Op-count proxy: `neighbor_facts` must examine a bounded candidate set
+/// (top-K from the tokenized storage search), not the whole store, no matter
+/// how many memories exist.
+#[cfg(all(feature = "test-utils", feature = "embeddings"))]
+#[tokio::test]
+async fn neighbor_facts_examines_bounded_candidates() {
+    use synaptic::{AgentMemory, MemoryConfig};
+
+    const K: usize = 32; // generous upper bound on the configured candidate cap
+
+    let mut memory = AgentMemory::new(MemoryConfig::default())
+        .await
+        .expect("create memory");
+
+    // 300 fact-bearing stores: each triggers the reasoner and thus
+    // neighbor_facts. With an unbounded scan the examined count grows with
+    // store size (~299 by the end); bounded it must stay <= K.
+    for i in 0..300 {
+        memory
+            .store(
+                &format!("residence_{i}"),
+                &format!("Person{i} lives in City{i}."),
+            )
+            .await
+            .expect("store");
+    }
+
+    let examined = memory.max_neighbor_candidates_examined();
+    assert!(
+        examined > 0,
+        "instrumentation must have observed neighbor_facts runs"
+    );
+    assert!(
+        examined <= K,
+        "neighbor_facts examined {examined} candidates; must be bounded by {K} regardless of store size"
+    );
+}

--- a/tools/eval/src/bin/run_qa.rs
+++ b/tools/eval/src/bin/run_qa.rs
@@ -1,0 +1,286 @@
+//! End-to-end QA accuracy on a stratified LoCoMo subset, judged by the
+//! `codex` CLI ([`synaptic_eval::qa::CodexCliJudge`]).
+//!
+//! Usage:
+//!   cargo run --release -p synaptic-eval --bin run_qa -- \
+//!       [--subset N] [--k K] [--concurrency C] [--data PATH]
+//!
+//! Pipeline per question: recall up to K memories from an `AgentMemory`
+//! ingested with the question's full conversation, ask codex to answer from
+//! the recalled snippets only, then ask codex to grade that answer against
+//! the gold answer (YES/NO). Accuracy is reported overall and per QType.
+//!
+//! Honesty contract: every number printed comes from real codex verdicts in
+//! this process's run. Judge failures are counted and reported; accuracy is
+//! computed over completed (graded) questions only, and the completed count
+//! is always printed alongside it. Nothing is fabricated.
+
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::Arc;
+use synaptic::{AgentMemory, MemoryConfig};
+use synaptic_eval::dataset::{load_locomo, EvalQuestion, QType};
+use synaptic_eval::qa::{CodexCliJudge, Judge};
+use synaptic_eval::runner::ingest;
+
+const ALL_QTYPES: [QType; 6] = [
+    QType::SingleHop,
+    QType::MultiHop,
+    QType::Temporal,
+    QType::KnowledgeUpdate,
+    QType::OpenDomain,
+    QType::Abstention,
+];
+
+struct Args {
+    subset: usize,
+    k: usize,
+    concurrency: usize,
+    data: PathBuf,
+}
+
+fn parse_args() -> Result<Args, String> {
+    let mut args = Args {
+        subset: 150,
+        k: 10,
+        concurrency: 4,
+        data: PathBuf::from("tools/eval/data/locomo10.json"),
+    };
+    let mut it = std::env::args().skip(1);
+    while let Some(flag) = it.next() {
+        let mut val = |name: &str| it.next().ok_or_else(|| format!("missing value for {name}"));
+        match flag.as_str() {
+            "--subset" => args.subset = val("--subset")?.parse().map_err(|e| format!("{e}"))?,
+            "--k" => args.k = val("--k")?.parse().map_err(|e| format!("{e}"))?,
+            "--concurrency" => {
+                args.concurrency = val("--concurrency")?.parse().map_err(|e| format!("{e}"))?
+            }
+            "--data" => args.data = PathBuf::from(val("--data")?),
+            other => return Err(format!("unknown flag: {other}")),
+        }
+    }
+    if args.subset == 0 || args.k == 0 || args.concurrency == 0 {
+        return Err("--subset, --k and --concurrency must be > 0".to_string());
+    }
+    Ok(args)
+}
+
+/// Stratified subset: split the target size evenly across the QTypes present
+/// in the data (remainder to the first types), then pick evenly spaced
+/// questions within each type (deterministic, no RNG).
+fn stratified_subset(
+    per_type: &BTreeMap<String, Vec<(usize, EvalQuestion)>>,
+    target: usize,
+) -> Vec<(usize, EvalQuestion)> {
+    let types: Vec<&String> = per_type.keys().collect();
+    if types.is_empty() {
+        return Vec::new();
+    }
+    let base = target / types.len();
+    let rem = target % types.len();
+    let mut selected = Vec::new();
+    for (i, ty) in types.iter().enumerate() {
+        let pool = &per_type[*ty];
+        let quota = (base + usize::from(i < rem)).min(pool.len());
+        if quota == 0 {
+            continue;
+        }
+        // Evenly spaced indices across the pool.
+        for j in 0..quota {
+            let idx = j * pool.len() / quota;
+            selected.push(pool[idx].clone());
+        }
+    }
+    selected
+}
+
+struct Graded {
+    qtype: QType,
+    correct: bool,
+}
+
+#[tokio::main]
+async fn main() {
+    let args = match parse_args() {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("error: {e}");
+            std::process::exit(2);
+        }
+    };
+
+    let judge = Arc::new(CodexCliJudge::from_env());
+    if !judge.is_available() {
+        eprintln!(
+            "error: codex CLI not available (checked `codex --version`); not fabricating results"
+        );
+        std::process::exit(1);
+    }
+
+    let conversations = match load_locomo(&args.data) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: failed to load {}: {e}", args.data.display());
+            std::process::exit(1);
+        }
+    };
+    let total_questions: usize = conversations.iter().map(|c| c.questions.len()).sum();
+
+    // Group all questions by QType, keeping the owning conversation index.
+    let mut per_type: BTreeMap<String, Vec<(usize, EvalQuestion)>> = BTreeMap::new();
+    for (ci, conv) in conversations.iter().enumerate() {
+        for q in &conv.questions {
+            per_type
+                .entry(format!("{:?}", q.qtype))
+                .or_default()
+                .push((ci, q.clone()));
+        }
+    }
+    let selected = stratified_subset(&per_type, args.subset);
+    eprintln!(
+        "dataset: {} conversations, {} questions total; stratified subset: {} questions (target {})",
+        conversations.len(),
+        total_questions,
+        selected.len(),
+        args.subset
+    );
+
+    // Phase 1: ingest each needed conversation and recall for its selected
+    // questions (concurrent across conversations).
+    let mut by_conv: BTreeMap<usize, Vec<EvalQuestion>> = BTreeMap::new();
+    for (ci, q) in &selected {
+        by_conv.entry(*ci).or_default().push(q.clone());
+    }
+    let mut recall_set = tokio::task::JoinSet::new();
+    for (ci, questions) in by_conv {
+        let conv = conversations[ci].clone();
+        let k = args.k;
+        recall_set.spawn(async move {
+            let mut memory = AgentMemory::new(MemoryConfig::default())
+                .await
+                .map_err(|e| format!("memory init failed: {e}"))?;
+            ingest(&conv, &mut memory)
+                .await
+                .map_err(|e| format!("ingest of {} failed: {e}", conv.id))?;
+            eprintln!(
+                "ingested conversation {} ({} sessions)",
+                conv.id,
+                conv.sessions.len()
+            );
+            let mut out = Vec::new();
+            for q in questions {
+                let recalled: Vec<String> = memory
+                    .search(&q.text, k)
+                    .await
+                    .map_err(|e| format!("search failed: {e}"))?
+                    .into_iter()
+                    .map(|f| f.entry.value)
+                    .collect();
+                out.push((q, recalled));
+            }
+            Ok::<_, String>(out)
+        });
+    }
+    let mut jobs: Vec<(EvalQuestion, Vec<String>)> = Vec::new();
+    while let Some(res) = recall_set.join_next().await {
+        match res {
+            Ok(Ok(mut v)) => jobs.append(&mut v),
+            Ok(Err(e)) => {
+                eprintln!("error: {e}");
+                std::process::exit(1);
+            }
+            Err(e) => {
+                eprintln!("error: recall task panicked: {e}");
+                std::process::exit(1);
+            }
+        }
+    }
+
+    // Phase 2: judge with the codex CLI, bounded concurrency, progress to
+    // stderr. Failures are recorded, never converted into a verdict.
+    let n = jobs.len();
+    eprintln!(
+        "recall done; judging {n} questions with codex (concurrency {})",
+        args.concurrency
+    );
+    let mut job_iter = jobs.into_iter();
+    let mut set = tokio::task::JoinSet::new();
+    let mut done = 0usize;
+    let mut failures = 0usize;
+    let mut graded: Vec<Graded> = Vec::new();
+    let spawn_one = |set: &mut tokio::task::JoinSet<Result<Graded, String>>,
+                     judge: Arc<CodexCliJudge>,
+                     q: EvalQuestion,
+                     recalled: Vec<String>| {
+        set.spawn(async move {
+            let predicted = judge
+                .answer(&q.text, &recalled)
+                .await
+                .map_err(|e| format!("{} answer: {e}", q.id))?;
+            let correct = judge
+                .grade(&q.text, &q.gold_answer, &predicted)
+                .await
+                .map_err(|e| format!("{} grade: {e}", q.id))?;
+            Ok(Graded {
+                qtype: q.qtype,
+                correct,
+            })
+        });
+    };
+    for _ in 0..args.concurrency {
+        if let Some((q, recalled)) = job_iter.next() {
+            spawn_one(&mut set, Arc::clone(&judge), q, recalled);
+        }
+    }
+    while let Some(res) = set.join_next().await {
+        done += 1;
+        match res {
+            Ok(Ok(g)) => graded.push(g),
+            Ok(Err(e)) => {
+                failures += 1;
+                eprintln!("judge failure: {e}");
+            }
+            Err(e) => {
+                failures += 1;
+                eprintln!("judge task panicked: {e}");
+            }
+        }
+        eprint!("\rquestion {done}/{n} (failures: {failures})");
+        let _ = std::io::stderr().flush();
+        if let Some((q, recalled)) = job_iter.next() {
+            spawn_one(&mut set, Arc::clone(&judge), q, recalled);
+        }
+    }
+    eprintln!();
+
+    // Aggregate over completed (graded) questions only.
+    let completed = graded.len();
+    let correct = graded.iter().filter(|g| g.correct).count();
+    println!("== End-to-end QA accuracy (LoCoMo stratified subset, codex CLI judge) ==");
+    println!(
+        "subset target: {} | selected: {n} | completed (graded): {completed} | judge failures: {failures} | k={}",
+        args.subset, args.k
+    );
+    if completed == 0 {
+        println!("no questions completed — no accuracy to report");
+        std::process::exit(1);
+    }
+    println!(
+        "overall: {correct}/{completed} = {:.1}%",
+        100.0 * correct as f64 / completed as f64
+    );
+    for ty in ALL_QTYPES {
+        let of_type: Vec<&Graded> = graded.iter().filter(|g| g.qtype == ty).collect();
+        if of_type.is_empty() {
+            continue;
+        }
+        let c = of_type.iter().filter(|g| g.correct).count();
+        println!(
+            "  {:?}: {c}/{} = {:.1}%",
+            ty,
+            of_type.len(),
+            100.0 * c as f64 / of_type.len() as f64
+        );
+    }
+}

--- a/tools/eval/src/qa.rs
+++ b/tools/eval/src/qa.rs
@@ -372,3 +372,255 @@ impl Judge for LlmJudge {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Codex CLI judge
+// ---------------------------------------------------------------------------
+
+/// Extract the model's answer from `codex exec` stdout.
+///
+/// codex 0.144.0 prints just the final answer on stdout (banner/progress go
+/// to stderr), but this parser is defensive against the alternate format
+/// where stdout carries a banner, a `codex` marker line, the answer, and a
+/// `tokens used` trailer. Returns `None` when no answer text remains —
+/// callers must treat that as an error (fail closed).
+pub fn parse_codex_stdout(stdout: &str) -> Option<String> {
+    let lines: Vec<&str> = stdout.lines().collect();
+    // If a `codex` marker line exists, the answer is what follows the last one.
+    let start = lines
+        .iter()
+        .rposition(|l| {
+            let t = l.trim();
+            t == "codex" || t.ends_with("] codex")
+        })
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    let is_banner = |t: &str| {
+        t.starts_with("OpenAI Codex")
+            || t.starts_with("--------")
+            || t.starts_with("workdir:")
+            || t.starts_with("model:")
+            || t.starts_with("provider:")
+            || t.starts_with("approval:")
+            || t.starts_with("sandbox:")
+            || t.starts_with("reasoning ")
+            || t.starts_with("session id:")
+            || t.contains("tokens used")
+    };
+    let answer = lines[start..]
+        .iter()
+        .filter(|l| !is_banner(l.trim()))
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim()
+        .to_string();
+    if answer.is_empty() {
+        None
+    } else {
+        Some(answer)
+    }
+}
+
+/// Parse a YES/NO grading verdict out of codex stdout. `None` when the reply
+/// is not clearly YES or NO — callers must fail closed, never guess.
+pub fn parse_grade_verdict(stdout: &str) -> Option<bool> {
+    let text = parse_codex_stdout(stdout)?;
+    let word = text
+        .split_whitespace()
+        .last()?
+        .trim_matches(|c: char| !c.is_ascii_alphabetic())
+        .to_ascii_uppercase();
+    match word.as_str() {
+        "YES" => Some(true),
+        "NO" => Some(false),
+        _ => None,
+    }
+}
+
+/// Judge that shells out to the `codex` CLI (`codex exec`) for answer
+/// generation and grading. No network crate dependency and no feature gate;
+/// requires a locally installed, logged-in codex CLI. Fail-closed: any spawn
+/// failure, non-zero exit, timeout, or unparseable output is a
+/// [`QaError::Judge`].
+pub struct CodexCliJudge {
+    bin: String,
+    timeout_secs: u64,
+}
+
+impl Default for CodexCliJudge {
+    fn default() -> Self {
+        Self::from_env()
+    }
+}
+
+impl CodexCliJudge {
+    /// Env var overriding the codex binary path (default `codex`).
+    pub const ENV_BIN: &'static str = "SYNAPTIC_EVAL_CODEX_BIN";
+    /// Env var overriding the per-call timeout in seconds (default 120).
+    pub const ENV_TIMEOUT: &'static str = "SYNAPTIC_EVAL_CODEX_TIMEOUT_SECS";
+
+    /// Build from environment (`SYNAPTIC_EVAL_CODEX_BIN`,
+    /// `SYNAPTIC_EVAL_CODEX_TIMEOUT_SECS`), with defaults `codex` / 120 s.
+    pub fn from_env() -> Self {
+        let bin = std::env::var(Self::ENV_BIN)
+            .ok()
+            .filter(|b| !b.trim().is_empty())
+            .unwrap_or_else(|| "codex".to_string());
+        let timeout_secs = std::env::var(Self::ENV_TIMEOUT)
+            .ok()
+            .and_then(|t| t.trim().parse().ok())
+            .unwrap_or(120);
+        Self { bin, timeout_secs }
+    }
+
+    /// Check that the codex CLI is runnable (`codex --version` exits 0).
+    pub fn is_available(&self) -> bool {
+        std::process::Command::new(&self.bin)
+            .arg("--version")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
+    /// Run one `codex exec` call with `prompt` and return parsed stdout.
+    /// Runs on a blocking thread; enforces the timeout via the coreutils
+    /// `timeout` wrapper (exit 124 → timeout error).
+    async fn run_codex(&self, prompt: String) -> Result<String, QaError> {
+        let bin = self.bin.clone();
+        let secs = self.timeout_secs;
+        let output = tokio::task::spawn_blocking(move || {
+            std::process::Command::new("timeout")
+                .arg(secs.to_string())
+                .arg(&bin)
+                .args(["exec", "--skip-git-repo-check", &prompt])
+                .stdin(std::process::Stdio::null())
+                .output()
+        })
+        .await
+        .map_err(|e| QaError::Judge(format!("codex task join failed: {e}")))?
+        .map_err(|e| QaError::Judge(format!("failed to spawn codex CLI: {e}")))?;
+
+        if output.status.code() == Some(124) {
+            return Err(QaError::Judge(format!(
+                "codex exec timed out after {secs}s"
+            )));
+        }
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let tail: String = stderr.chars().rev().take(400).collect::<String>();
+            let tail: String = tail.chars().rev().collect();
+            return Err(QaError::Judge(format!(
+                "codex exec exited with {}: {tail}",
+                output.status
+            )));
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    }
+}
+
+#[async_trait::async_trait]
+impl Judge for CodexCliJudge {
+    async fn answer(&self, question: &str, recalled: &[String]) -> Result<String, QaError> {
+        let context = if recalled.is_empty() {
+            "(no memories recalled)".to_string()
+        } else {
+            recalled
+                .iter()
+                .enumerate()
+                .map(|(i, m)| format!("[{}] {m}", i + 1))
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+        let prompt = format!(
+            "Answer concisely using ONLY the provided memories; if not \
+             answerable from them, say 'I don't know'. Do not use any other \
+             knowledge or tools.\n\nMemories:\n{context}\n\nQuestion: \
+             {question}\nAnswer:"
+        );
+        let stdout = self.run_codex(prompt).await?;
+        parse_codex_stdout(&stdout)
+            .ok_or_else(|| QaError::Judge("codex exec produced no parseable answer".to_string()))
+    }
+
+    async fn grade(&self, question: &str, gold: &str, predicted: &str) -> Result<bool, QaError> {
+        let prompt = format!(
+            "Question: {question}\nGold answer: {gold}\nPredicted answer: \
+             {predicted}\n\nDoes the predicted answer match the gold answer \
+             in meaning? Reply exactly YES or NO."
+        );
+        let stdout = self.run_codex(prompt).await?;
+        parse_grade_verdict(&stdout).ok_or_else(|| {
+            QaError::Judge(format!(
+                "unparseable YES/NO grading verdict from codex: {:?}",
+                stdout.trim()
+            ))
+        })
+    }
+}
+
+#[cfg(test)]
+mod codex_parse_tests {
+    use super::{parse_codex_stdout, parse_grade_verdict};
+
+    #[test]
+    fn parses_plain_stdout_answer() {
+        // Real captured behavior of codex 0.144.0: stdout is just the answer.
+        assert_eq!(parse_codex_stdout("4\n").as_deref(), Some("4"));
+    }
+
+    #[test]
+    fn parses_marker_and_banner_format() {
+        // Defensive: older/alternate format with banner + `codex` marker +
+        // tokens-used trailer on stdout.
+        let sample = "\
+OpenAI Codex v0.144.0
+--------
+workdir: /tmp/x
+model: gpt-5.6-sol
+provider: openai
+approval: never
+sandbox: read-only
+--------
+[2026-07-13T01:02:03] User instructions:
+Some prompt text
+[2026-07-13T01:02:10] thinking
+Working it out
+[2026-07-13T01:02:12] codex
+7 May 2023
+[2026-07-13T01:02:12] tokens used: 1234
+";
+        assert_eq!(parse_codex_stdout(sample).as_deref(), Some("7 May 2023"));
+    }
+
+    #[test]
+    fn empty_stdout_is_none() {
+        assert_eq!(parse_codex_stdout("  \n"), None);
+        assert_eq!(parse_codex_stdout(""), None);
+    }
+
+    #[test]
+    fn multiline_answer_after_marker_is_kept() {
+        let sample = "[t] codex\nline one\nline two\n[t] tokens used: 9\n";
+        assert_eq!(
+            parse_codex_stdout(sample).as_deref(),
+            Some("line one\nline two")
+        );
+    }
+
+    #[test]
+    fn grade_verdict_yes_no() {
+        assert_eq!(parse_grade_verdict("YES\n"), Some(true));
+        assert_eq!(parse_grade_verdict("yes."), Some(true));
+        assert_eq!(parse_grade_verdict("NO"), Some(false));
+        assert_eq!(
+            parse_grade_verdict("[t] codex\nNO\n[t] tokens used: 3"),
+            Some(false)
+        );
+        assert_eq!(parse_grade_verdict("maybe"), None);
+        assert_eq!(parse_grade_verdict(""), None);
+    }
+}


### PR DESCRIPTION
Follow-ups to the agent-memory-v2 work (PR #62): fix the performance findings the eval surfaced, build the optional LLM reasoner, and produce a real QA-accuracy number. Executed with subagent-driven TDD (implementer + independent reviewer per task); honesty bar preserved (disabled paths fail closed, no stubs). Plan: `docs/superpowers/plans/agent-memory-v2-followups.md`.

## What landed

**Performance (P1/P2/P4).** Root-caused via a profiler, then fixed the hot paths:
- P1 — incremental `total_size` (removed a per-store O(n) rescan), deterministic bounded KG/neighbor candidate scans, shrunk the KG write-lock.
- P2 — read-only query-time embedding (no per-query vocab rebuild under a global write lock), a content-hash embedding cache shared across dense+rerank (invalidated on mutation, bounded), lowercase memoization, KG lock dropped before awaits.
- P4 — a character-n-gram **inverted index** in storage (keyword search is candidate-bounded, **byte-identical results** proven by an in-test full-scan reference), plus token-indexed KG candidate selection.

**Measured result (honest):** search over a 1k-entry store improved **~7× (26.6s → ~3.7s)**. Retrieval quality is unchanged (ranking-parity/byte-identical tests). **The store path is only partially fixed** — filling 10k still takes >40 min because the default `advanced_management` write pipeline does O(n)-per-store work that P1/P2/P4 didn't touch; 10k/100k store latency was **not re-measured** and 100k remains impractical. This is documented in `docs/evaluation.md` and flagged as the next perf target — no store speedup is claimed that wasn't measured.

**R1 — optional `LlmReasoner`** (feature `llm-reasoning`): LLM-driven extract/resolve/synthesize via an injectable call fn (testable offline), **fails open to the `HeuristicReasoner`** on any error/missing endpoint — never a fabricated extraction, never a hard write-path failure. Feature-off unchanged.

**Q1 — real QA-accuracy number.** A `CodexCliJudge` shells out to the `codex` CLI (gpt-5.6-sol) for answer generation + grading. Measured on a **stratified 150-question LoCoMo subset** (0 judge failures): **overall 16.7%** (Temporal 30%, SingleHop 26.7%, MultiHop 6.7%, Abstention 3.3%) — labeled a subset, not comparable to full-set published numbers. It's low, driven by the weak retrieval feeding the judge (see the inert-IDF note).

## Verification
fmt clean · clippy `--all-targets --features security,test-utils -D warnings` clean · default + `llm-reasoning` + `reranker-model` + `mcp` builds pass · lib **455** · 53 capability/perf tests · `synaptic-eval` suites · `llm_reasoner_tests` 9/9 · 2 revert spot-checks proved test teeth. `--all-features` is CI-only.

## Known / open (honest)
- **High:** store-path superlinearity remains — index/bound (or make opt-in) the `advanced_management` per-store subsystems, then re-measure 10k/100k.
- **Medium:** dense retrieval is effectively hashed-TF cosine (scoring-provider IDF inert = 1.0; ties to the SimpleEmbedder-not-fed-corpus gap) — partly explains weak recall and the low MultiHop/QA numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
