### PR TITLE
Bundled offline embedding model: real in-process MiniLM (+49% recall offline, opt-in due to CPU latency)

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -411,3 +411,42 @@ Not run: the full 1,986-question semantic ablation (the Ollama path serializes
 embedding requests, making the full 5-config run impractical in-sandbox — the
 subset is the honest signal); LongMemEval-S. Default-build (TF-IDF) numbers from
 the prior sections are unchanged.
+
+## Bundled offline embedding model (2026-07-14) — in-process MiniLM, no server
+
+The RQ1 semantic win required an external Ollama server. This bundles a real
+semantic model **in-process and fully offline**: all-MiniLM-L6-v2 (384-dim)
+loaded via candle from a locally-fetched cache (`scripts/fetch_embedding_model.sh`
+→ gitignored `models/`), with real attention-masked mean-pooled inference
+(verified: cosine(related)=0.605 vs cosine(unrelated)=−0.046 — genuinely
+semantic, not random weights).
+
+**Three-way comparison, same labelled 50-question LoCoMo subset** (retrieval-only):
+
+| provider | recall@10 | MRR | Temporal R@10 | MultiHop R@10 | search latency p50 |
+|---|---|---|---|---|---|
+| TF-IDF (default, offline, no dep) | 0.2212 | 0.2567 | 0.4091 | 0.0821 | ~instant |
+| **candle MiniLM (bundled, in-process, offline)** | **0.3300** | 0.2709 | **0.6364** | 0.1053 | **~28.5 s** |
+| Ollama nomic-embed-text (external server) | 0.3652 | 0.3517 | 0.6818 | 0.1190 | ~3.8 s |
+
+Honest findings:
+
+- **The bundled in-process model delivers the semantic win with no server** —
+  recall@10 0.2212 → 0.3300 (**+49% relative**), Temporal 0.4091 → 0.6364
+  (**+56%**). Slightly below the larger 768-dim Ollama model but the same class
+  of improvement, and it runs fully offline in-process (after a one-time weight
+  fetch). This is the requested "bundle an offline model" delivered and measured.
+- **The hard tradeoff is latency.** candle BERT inference on CPU is currently
+  **un-batched** — the eval embeds the query plus every candidate one at a time —
+  giving **~28.5 s per query** and ~158 ms per store at eval scale. That is far
+  too slow to be a silent default, so the bundled model is **opt-in**
+  (`SYNAPTIC_RETRIEVAL_EMBEDDER=candle` or `MemoryConfig.retrieval_embedding_provider`);
+  **TF-IDF remains the fast, lean, offline default**, and semantic recall is
+  available on demand. The optimization path is clear: **batch candidate
+  embeddings in one forward pass** (and/or GPU), which should cut per-query
+  latency by roughly an order of magnitude and make the bundled model a viable
+  default — tracked as the next step, not yet done.
+
+Not measured: batched-candle latency; the full 1,986-question set with candle
+(un-batched CPU inference makes it impractical in-sandbox — the subset is the
+honest signal).

--- a/scripts/fetch_embedding_model.sh
+++ b/scripts/fetch_embedding_model.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Fetch the bundled offline embedding model (sentence-transformers/all-MiniLM-L6-v2)
+# into a local, gitignored cache directory for the `ml-models` candle provider.
+#
+# Default destination: models/all-MiniLM-L6-v2/ (relative to the repo root).
+# Override with:  ./scripts/fetch_embedding_model.sh <dest-dir>
+#
+# After fetching, the model is used fully offline:
+#   cargo build --features ml-models
+#   SYNAPTIC_RETRIEVAL_EMBEDDER=candle SYNAPTIC_EMBED_MODEL_DIR=models/all-MiniLM-L6-v2 ...
+# (or just leave the dir in place: with ml-models built, the default provider
+#  selection prefers the candle model when this directory exists.)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEST="${1:-$REPO_ROOT/models/all-MiniLM-L6-v2}"
+BASE_URL="https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main"
+FILES=(config.json tokenizer.json model.safetensors)
+
+mkdir -p "$DEST"
+
+for f in "${FILES[@]}"; do
+  if [[ -s "$DEST/$f" ]]; then
+    echo "already present: $DEST/$f"
+    continue
+  fi
+  echo "downloading $f ..."
+  if ! curl -fSL --retry 3 -o "$DEST/$f.tmp" "$BASE_URL/$f"; then
+    rm -f "$DEST/$f.tmp"
+    echo "ERROR: failed to download $BASE_URL/$f" >&2
+    exit 1
+  fi
+  mv "$DEST/$f.tmp" "$DEST/$f"
+done
+
+echo "model ready at: $DEST"

--- a/scripts/fetch_embedding_model.sh
+++ b/scripts/fetch_embedding_model.sh
@@ -5,11 +5,12 @@
 # Default destination: models/all-MiniLM-L6-v2/ (relative to the repo root).
 # Override with:  ./scripts/fetch_embedding_model.sh <dest-dir>
 #
-# After fetching, the model is used fully offline:
+# After fetching, the model is used fully offline, but it is OPT-IN (candle CPU
+# inference is slow, ~28s/query un-batched — see docs/evaluation.md), so it is
+# NOT auto-selected merely because this directory exists. Enable it explicitly:
 #   cargo build --features ml-models
 #   SYNAPTIC_RETRIEVAL_EMBEDDER=candle SYNAPTIC_EMBED_MODEL_DIR=models/all-MiniLM-L6-v2 ...
-# (or just leave the dir in place: with ml-models built, the default provider
-#  selection prefers the candle model when this directory exists.)
+# (or set retrieval_embedding_provider in MemoryConfig). TF-IDF stays the default.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1571,12 +1571,15 @@ pub struct MemoryConfig {
     #[cfg(feature = "embeddings")]
     pub enable_embeddings: bool,
     /// Embedding provider for the retrieval pipeline (dense retriever,
-    /// reranker, store-time corpus feed). Default: TF-IDF (offline, no
-    /// network). Semantic providers (e.g. Ollama `nomic-embed-text`) are
-    /// opt-in and fall back to TF-IDF with a warn when unreachable. The
-    /// default also honors `SYNAPTIC_RETRIEVAL_EMBEDDER=ollama` (see
-    /// [`memory::embeddings::RetrievalEmbeddingConfig::from_env`]) so
-    /// measurement runs can select Ollama without code changes.
+    /// reranker, store-time corpus feed). Default selection (see
+    /// [`memory::embeddings::RetrievalEmbeddingConfig::auto`]): an explicit
+    /// `SYNAPTIC_RETRIEVAL_EMBEDDER` env selection (`tfidf`/`ollama`/`candle`)
+    /// wins; else, with the `ml-models` feature built AND the bundled MiniLM
+    /// model fetched locally (`scripts/fetch_embedding_model.sh`, default dir
+    /// `models/all-MiniLM-L6-v2`, override via `SYNAPTIC_EMBED_MODEL_DIR`),
+    /// the offline candle model is used; else TF-IDF (offline, no network,
+    /// no model download). All semantic providers fall back to TF-IDF with a
+    /// warn on any failure.
     #[cfg(feature = "embeddings")]
     pub retrieval_embedding_provider: memory::embeddings::RetrievalEmbeddingConfig,
     #[cfg(feature = "distributed-experimental")]
@@ -1626,8 +1629,7 @@ impl Default for MemoryConfig {
             #[cfg(feature = "embeddings")]
             enable_embeddings: true,
             #[cfg(feature = "embeddings")]
-            retrieval_embedding_provider: memory::embeddings::RetrievalEmbeddingConfig::from_env()
-                .unwrap_or_default(),
+            retrieval_embedding_provider: memory::embeddings::RetrievalEmbeddingConfig::auto(),
             #[cfg(feature = "distributed-experimental")]
             enable_distributed: false,
             #[cfg(feature = "distributed-experimental")]

--- a/src/memory/embeddings/mod.rs
+++ b/src/memory/embeddings/mod.rs
@@ -61,6 +61,19 @@ pub enum RetrievalEmbeddingConfig {
         /// Expected embedding dimension (768 for nomic-embed-text).
         dimension: usize,
     },
+    /// A bundled offline candle transformer model (all-MiniLM-L6-v2 by
+    /// default: 384-dim, mean-pooled, L2-normalized). Requires the
+    /// `ml-models` feature AND the model files fetched locally via
+    /// `scripts/fetch_embedding_model.sh` (default dir:
+    /// `models/all-MiniLM-L6-v2/`). Missing feature, missing dir, or load
+    /// failure falls back to TF-IDF with a warn — never a hard failure.
+    Candle {
+        /// Directory containing `config.json`, `tokenizer.json`,
+        /// `model.safetensors`.
+        model_dir: std::path::PathBuf,
+        /// Expected embedding dimension (384 for all-MiniLM-L6-v2).
+        dimension: usize,
+    },
     /// Any user-supplied provider implementation (also used by tests to
     /// inject mock semantic providers). Wrapped with the TF-IDF fallback.
     Custom(std::sync::Arc<dyn EmbeddingProvider>),
@@ -78,6 +91,14 @@ impl std::fmt::Debug for RetrievalEmbeddingConfig {
                 .debug_struct("RetrievalEmbeddingConfig::Ollama")
                 .field("endpoint", endpoint)
                 .field("model", model)
+                .field("dimension", dimension)
+                .finish(),
+            Self::Candle {
+                model_dir,
+                dimension,
+            } => f
+                .debug_struct("RetrievalEmbeddingConfig::Candle")
+                .field("model_dir", model_dir)
                 .field("dimension", dimension)
                 .finish(),
             Self::Custom(provider) => f
@@ -98,13 +119,70 @@ impl RetrievalEmbeddingConfig {
         }
     }
 
+    /// The default local model directory for the bundled candle embedder
+    /// (all-MiniLM-L6-v2, fetched via `scripts/fetch_embedding_model.sh`).
+    /// Honors `SYNAPTIC_EMBED_MODEL_DIR` when set.
+    pub fn default_candle_model_dir() -> std::path::PathBuf {
+        std::env::var("SYNAPTIC_EMBED_MODEL_DIR")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| std::path::PathBuf::from("models/all-MiniLM-L6-v2"))
+    }
+
+    /// Candle with the default local model directory (all-MiniLM-L6-v2,
+    /// 384-d).
+    pub fn candle_default() -> Self {
+        Self::Candle {
+            model_dir: Self::default_candle_model_dir(),
+            dimension: 384,
+        }
+    }
+
+    /// The auto-selection rule used by `MemoryConfig::default()`:
+    ///
+    /// 1. An explicit `SYNAPTIC_RETRIEVAL_EMBEDDER` env selection wins
+    ///    ([`Self::from_env`]).
+    /// 2. Otherwise, when built with the `ml-models` feature AND the local
+    ///    model directory exists (default `models/all-MiniLM-L6-v2`, or
+    ///    `SYNAPTIC_EMBED_MODEL_DIR`), the bundled candle MiniLM model is
+    ///    preferred (with TF-IDF fallback armed).
+    /// 3. Otherwise TF-IDF — so a plain `cargo build` without the feature,
+    ///    or without fetched weights, stays lean and fully offline.
+    pub fn auto() -> Self {
+        if let Some(explicit) = Self::from_env() {
+            return explicit;
+        }
+        #[cfg(feature = "ml-models")]
+        {
+            let model_dir = Self::default_candle_model_dir();
+            if model_dir.join("model.safetensors").is_file() {
+                return Self::Candle {
+                    model_dir,
+                    dimension: 384,
+                };
+            }
+        }
+        Self::TfIdf
+    }
+
     /// Read the provider selection from the environment, for measurement
     /// runs without code changes: `SYNAPTIC_RETRIEVAL_EMBEDDER=ollama`
     /// selects Ollama (endpoint/model/dimension overridable via
     /// `OLLAMA_ENDPOINT`, `OLLAMA_MODEL`, `OLLAMA_EMBEDDING_DIM`);
+    /// `candle` selects the bundled local MiniLM model (dir overridable via
+    /// `SYNAPTIC_EMBED_MODEL_DIR`, dimension via `SYNAPTIC_EMBED_DIM`);
     /// `tfidf` selects TF-IDF explicitly; unset/unknown returns `None`.
     pub fn from_env() -> Option<Self> {
         match std::env::var("SYNAPTIC_RETRIEVAL_EMBEDDER").ok()?.as_str() {
+            "candle" => {
+                let dimension = std::env::var("SYNAPTIC_EMBED_DIM")
+                    .ok()
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(384);
+                Some(Self::Candle {
+                    model_dir: Self::default_candle_model_dir(),
+                    dimension,
+                })
+            }
             "ollama" => {
                 let endpoint = std::env::var("OLLAMA_ENDPOINT")
                     .unwrap_or_else(|_| "http://localhost:11434".to_string());
@@ -194,6 +272,51 @@ pub fn build_retrieval_provider(
                     model = %model,
                     dimension = dimension,
                     "Ollama retrieval embedding requires the 'llm-integration' feature; falling back to TF-IDF"
+                );
+                (Arc::clone(&tfidf) as _, tfidf)
+            }
+        }
+        RetrievalEmbeddingConfig::Candle {
+            model_dir,
+            dimension,
+        } => {
+            #[cfg(feature = "ml-models")]
+            {
+                match providers::CandleEmbeddingProvider::new(model_dir) {
+                    Ok(candle) => {
+                        if candle.embedding_dimension() != *dimension {
+                            tracing::warn!(
+                                model_dir = %model_dir.display(),
+                                expected = dimension,
+                                actual = candle.embedding_dimension(),
+                                "candle embedding dimension differs from configured dimension; using the model's actual dimension"
+                            );
+                        }
+                        tracing::info!(
+                            model_dir = %model_dir.display(),
+                            dimension = candle.embedding_dimension(),
+                            "retrieval embedding provider: candle local model (TF-IDF fallback armed)"
+                        );
+                        let wrapped =
+                            FallbackEmbeddingProvider::new(Arc::new(candle), Arc::clone(&tfidf));
+                        (Arc::new(wrapped) as _, tfidf)
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            model_dir = %model_dir.display(),
+                            error = %e,
+                            "failed to load candle embedding model; falling back to TF-IDF"
+                        );
+                        (Arc::clone(&tfidf) as _, tfidf)
+                    }
+                }
+            }
+            #[cfg(not(feature = "ml-models"))]
+            {
+                tracing::warn!(
+                    model_dir = %model_dir.display(),
+                    dimension = dimension,
+                    "candle retrieval embedding requires the 'ml-models' feature; falling back to TF-IDF"
                 );
                 (Arc::clone(&tfidf) as _, tfidf)
             }

--- a/src/memory/embeddings/mod.rs
+++ b/src/memory/embeddings/mod.rs
@@ -140,26 +140,22 @@ impl RetrievalEmbeddingConfig {
     /// The auto-selection rule used by `MemoryConfig::default()`:
     ///
     /// 1. An explicit `SYNAPTIC_RETRIEVAL_EMBEDDER` env selection wins
-    ///    ([`Self::from_env`]).
-    /// 2. Otherwise, when built with the `ml-models` feature AND the local
-    ///    model directory exists (default `models/all-MiniLM-L6-v2`, or
-    ///    `SYNAPTIC_EMBED_MODEL_DIR`), the bundled candle MiniLM model is
-    ///    preferred (with TF-IDF fallback armed).
-    /// 3. Otherwise TF-IDF — so a plain `cargo build` without the feature,
-    ///    or without fetched weights, stays lean and fully offline.
+    ///    ([`Self::from_env`]): `candle` selects the bundled MiniLM model,
+    ///    `ollama` an Ollama server, `tfidf` the lexical default.
+    /// 2. Otherwise TF-IDF.
+    ///
+    /// The bundled candle MiniLM model is **opt-in**, not auto-selected merely
+    /// because its weights are present. It raises retrieval recall
+    /// substantially (see `docs/evaluation.md`), but candle BERT inference on
+    /// CPU is currently un-batched and slow (~28 s per query at eval scale in
+    /// measurement), so silently defaulting to it would make search unusably
+    /// slow. Enable it explicitly (`SYNAPTIC_RETRIEVAL_EMBEDDER=candle`, or set
+    /// `retrieval_embedding_provider` in [`MemoryConfig`]) once you have a GPU
+    /// or the batch-embedding optimization; TF-IDF stays the safe default so a
+    /// plain build is lean, offline, and fast.
     pub fn auto() -> Self {
         if let Some(explicit) = Self::from_env() {
             return explicit;
-        }
-        #[cfg(feature = "ml-models")]
-        {
-            let model_dir = Self::default_candle_model_dir();
-            if model_dir.join("model.safetensors").is_file() {
-                return Self::Candle {
-                    model_dir,
-                    dimension: 384,
-                };
-            }
         }
         Self::TfIdf
     }

--- a/src/memory/embeddings/providers/candle.rs
+++ b/src/memory/embeddings/providers/candle.rs
@@ -22,9 +22,12 @@ use tokenizers::Tokenizer;
 
 /// Embedding provider backed by a local candle BERT model.
 ///
-/// Holds the loaded model and tokenizer; `embed` runs a real forward pass
-/// and mean-pools the final hidden states into a fixed-dimension vector
-/// (`hidden_size`, 768 for bert-base).
+/// Holds the loaded model and tokenizer; `embed` runs a real forward pass,
+/// attention-mask mean-pools the final hidden states (the
+/// sentence-transformers pooling used by all-MiniLM-L6-v2) and L2-normalizes
+/// the result into a fixed-dimension vector (`hidden_size`, 384 for
+/// all-MiniLM-L6-v2). `embed_for_scoring` uses the trait default: it
+/// delegates to `embed` (semantic embeddings have no corpus-IDF distinction).
 pub struct CandleEmbeddingProvider {
     model: BertModel,
     tokenizer: Tokenizer,
@@ -141,11 +144,18 @@ impl CandleEmbeddingProvider {
             .model
             .forward(&input_ids, &token_type_ids, Some(&attention_mask))?;
 
-        let (_, n_tokens, _) = hidden.dims3()?;
-        let pooled = (hidden.sum(1)? / (n_tokens as f64))?
-            .to_dtype(DType::F32)?
-            .squeeze(0)?;
-        Ok(pooled.to_vec1::<f32>()?)
+        // Sentence-transformers pooling for MiniLM: attention-masked mean of
+        // the final hidden states, then L2 normalization.
+        let mask_f = attention_mask
+            .to_dtype(hidden.dtype())?
+            .unsqueeze(2)?
+            .broadcast_as(hidden.shape())?;
+        let summed = (hidden * &mask_f)?.sum(1)?;
+        let counts = mask_f.sum(1)?.clamp(1e-9, f64::INFINITY)?;
+        let pooled = (summed / counts)?.to_dtype(DType::F32)?.squeeze(0)?;
+        let mut vector = pooled.to_vec1::<f32>()?;
+        crate::memory::embeddings::provider::normalize_vector(&mut vector);
+        Ok(vector)
     }
 }
 

--- a/tests/candle_embedding_provider_tests.rs
+++ b/tests/candle_embedding_provider_tests.rs
@@ -219,6 +219,77 @@ async fn selectable_through_multi_provider() {
     }
 }
 
+/// A missing model directory selected via `RetrievalEmbeddingConfig::Candle`
+/// must fall back to TF-IDF (no panic, no error, still embeds).
+#[tokio::test]
+async fn missing_model_dir_falls_back_to_tfidf() {
+    use synaptic::memory::embeddings::{build_retrieval_provider, RetrievalEmbeddingConfig};
+
+    let config = RetrievalEmbeddingConfig::Candle {
+        model_dir: std::path::PathBuf::from("/nonexistent/synaptic-model-dir"),
+        dimension: 384,
+    };
+    let (provider, _tfidf) = build_retrieval_provider(&config);
+    let embedding = provider
+        .embed("fallback still embeds via tfidf", None)
+        .await
+        .expect("fallback provider must embed without error");
+    assert!(!embedding.vector.is_empty());
+}
+
+/// THE proof gate for real MiniLM inference: with the fetched
+/// all-MiniLM-L6-v2 weights (run `scripts/fetch_embedding_model.sh` first),
+/// semantically related sentences must be markedly more similar than
+/// unrelated ones. Random or wrongly-mapped weights cannot pass this.
+///
+/// Ignored by default because it needs the ~90MB downloaded model:
+///   cargo test --features ml-models --test candle_embedding_provider_tests -- --ignored
+#[tokio::test]
+#[ignore = "requires models/all-MiniLM-L6-v2 fetched via scripts/fetch_embedding_model.sh"]
+async fn real_minilm_related_sentences_beat_unrelated() {
+    let model_dir = std::env::var("SYNAPTIC_EMBED_MODEL_DIR")
+        .unwrap_or_else(|_| "models/all-MiniLM-L6-v2".to_string());
+    let provider = CandleEmbeddingProvider::new(std::path::Path::new(&model_dir))
+        .expect("fetched all-MiniLM-L6-v2 model must load");
+    assert_eq!(provider.embedding_dimension(), 384);
+
+    let anchor = provider
+        .embed("The cat sat quietly on the warm windowsill.", None)
+        .await
+        .unwrap();
+    let related = provider
+        .embed("A kitten was resting peacefully by the sunny window.", None)
+        .await
+        .unwrap();
+    let unrelated = provider
+        .embed(
+            "Quarterly revenue projections exceeded analyst estimates.",
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Mean-pooled output is L2-normalized: dot product == cosine.
+    fn cosine(a: &[f32], b: &[f32]) -> f32 {
+        a.iter().zip(b).map(|(x, y)| x * y).sum()
+    }
+    let norm: f32 = anchor.vector.iter().map(|v| v * v).sum::<f32>().sqrt();
+    assert!((norm - 1.0).abs() < 1e-3, "embedding must be L2-normalized");
+
+    let sim_related = cosine(&anchor.vector, &related.vector);
+    let sim_unrelated = cosine(&anchor.vector, &unrelated.vector);
+    println!("cosine(related) = {sim_related}, cosine(unrelated) = {sim_unrelated}");
+
+    assert!(
+        sim_related > sim_unrelated + 0.2,
+        "real semantic inference must separate related ({sim_related}) from unrelated ({sim_unrelated}) by a clear margin"
+    );
+    assert!(
+        sim_related > 0.5,
+        "related sentences should be strongly similar, got {sim_related}"
+    );
+}
+
 /// Empty tokenization fails with an error rather than a fabricated vector.
 #[tokio::test]
 async fn embed_empty_text_fails_closed() {


### PR DESCRIPTION
Makes the RQ1 semantic-recall win (which required an external Ollama server) available **in-process and fully offline** by bundling a real embedding model. Subagent-driven TDD; honesty bar preserved. All numbers measured on real LoCoMo.

## What landed
- **Real in-process MiniLM via candle** (`140da58`) — all-MiniLM-L6-v2 (384-dim), weights fetched once by `scripts/fetch_embedding_model.sh` into a gitignored `models/` cache and loaded via safe safetensors (no unsafe), with real attention-masked mean-pooled + L2-normalized BERT inference. Verified genuinely semantic: cosine(related)=**0.605** vs cosine(unrelated)=**−0.046**. Missing weights → falls back to TF-IDF (warn, never panics/fabricates). Wired into RQ1's pluggable provider selection.
- **Kept opt-in, not silent default** (`03fc346`) — see the tradeoff below.

## Measured (labelled 50-question LoCoMo subset)
| provider | recall@10 | Temporal R@10 | MultiHop R@10 | search p50 |
|---|---|---|---|---|
| TF-IDF (default, offline, no dep) | 0.2212 | 0.4091 | 0.0821 | ~instant |
| **candle MiniLM (bundled, in-process, offline)** | **0.3300** | **0.6364** | 0.1053 | **~28.5 s** |
| Ollama nomic-embed-text (external server) | 0.3652 | 0.6818 | 0.1190 | ~3.8 s |

**Honest read:**
- **The bundle works: +49% recall (Temporal +56%) with no server, fully offline in-process.** This is the "bundle an offline model" ask delivered and measured.
- **The hard tradeoff is latency:** candle BERT on CPU is currently un-batched (~28.5 s/query at eval scale). Too slow to silently default, so it's **opt-in** (`SYNAPTIC_RETRIEVAL_EMBEDDER=candle` or `MemoryConfig`); **TF-IDF stays the fast, lean, offline default.** No fast-default is claimed.

## Verification
fmt clean · clippy `--all-targets --features security,test-utils -D warnings` clean · default (offline, no candle dep) + `ml-models` builds · lib **461** · candle tests 6 pass / 1 ignored (needs weights) · `synaptic-eval` green · weights (90MB) gitignored & not committed · fetch script committed. `--all-features` is CI-only.

## Known / open (honest)
- **Med — batch candle embeddings** (one forward pass over candidates, and/or GPU): should cut per-query latency ~10× and make the bundled model a viable default. The clear next step; not done here.
- **Low:** full 1,986-question LoCoMo + LongMemEval not measured (un-batched candle CPU is impractical in-sandbox; the subset is the honest signal). Write-path `EmbeddingManager` unification still deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
