### PR TITLE
feat(eval): first real end-to-end QA accuracy (codex judge, concurrent, --qa-only)

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -717,3 +717,50 @@ a different lever than graph expansion — e.g. answer-aware reranking — or it
 bounded by what retrieval alone can achieve without the answer. Both branches were
 abandoned; `main` stays at the fast baseline (recall 0.5237, latency 0.60 s).
 Recorded so neither graph-expansion approach is re-attempted for MultiHop.
+
+## First end-to-end QA accuracy (real judge, 2026-07-15)
+
+Until now QA accuracy was reported as "not run" — the harness had a real judge
+(`CodexCliJudge`, shelling the logged-in `codex` CLI) and an `LlmJudge` (OpenAI-
+compatible endpoint), but `run_qa_gated` never selected the codex path. This round
+wired judge selection (`SYNAPTIC_EVAL_JUDGE=codex`), added bounded-concurrency
+judging (`SYNAPTIC_EVAL_QA_CONCURRENCY`, default 4) so a sample fits a short
+wall-clock budget, and a `--qa-only` flag (skips retrieval/ablation/growth). The
+judge answers each question using ONLY the top-`k=10` recalled memories (no world
+knowledge), then grades its own answer against the gold answer. Every number below
+is a real judge verdict — nothing fabricated; an empty/unconfigured run reports
+not-run.
+
+**Measured (static-embedding retrieval, codex judge, concurrency 4):**
+
+| sample | graded | correct | accuracy |
+|---|---|---|---|
+| 20 questions (first 4 q × 5 conversations) | 20 | 5 | 0.2500 |
+| 40 questions (first 4 q × 10 conversations) | 40 | 9 | 0.2250 |
+
+Per-QType (40-question run):
+
+| QType | graded | correct | accuracy |
+|---|---|---|---|
+| SingleHop | 1 | 1 | 1.0000 |
+| Temporal | 16 | 5 | 0.3125 |
+| MultiHop | 19 | 3 | 0.1579 |
+| OpenDomain | 4 | 0 | 0.0000 |
+
+**Honest caveats — read before citing the headline:**
+- **The subset is skewed HARD.** `--max-questions N` takes the *first* N questions
+  per conversation, which over-samples MultiHop/Temporal (35 of 40) and
+  under-samples the dominant, easiest category SingleHop (1 here vs 841 / 42% of the
+  full 1,986-question set). So **0.225 is a pessimistic, hard-weighted estimate**; a
+  representative sample would weight SingleHop far more heavily and score higher. The
+  per-QType numbers are the reliable signal, not the aggregate.
+- **QA accuracy tracks the retrieval ceiling by category.** Categories that retrieve
+  well (SingleHop R@10 0.61, Temporal 0.63) answer well; MultiHop (0.16) and
+  OpenDomain (0.00) are hard end-to-end exactly as they are hard to retrieve
+  (R@10 0.25 / 0.20) — the retrieval ceiling propagates to answers, consistent with
+  the two abandoned MultiHop rounds above.
+- **Not a full-set run.** A representative full 1,986-question QA pass is bounded by
+  sequential judge latency (hours of `codex` calls) and is not yet run; the numbers
+  here are labelled subsets. The judge is capped at k=10 recalled memories with a
+  strict "use only these" prompt, so this measures retrieval-grounded QA, not the
+  judge's own knowledge.

--- a/tools/eval/Cargo.toml
+++ b/tools/eval/Cargo.toml
@@ -14,6 +14,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
+# Bounded-concurrency judge calls in `qa::run_qa` (stream::buffer_unordered).
+futures = "0.3"
 # LLM judge client (feature `llm-reasoning` only). Same reqwest line as the
 # main crate's `llm-integration` feature.
 reqwest = { version = "0.11", features = ["json"], optional = true }

--- a/tools/eval/src/bin/run_eval.rs
+++ b/tools/eval/src/bin/run_eval.rs
@@ -107,6 +107,12 @@ async fn main() -> Result<(), String> {
     // retrieval-quality signal). `--max-conversations N` truncates to the first
     // N conversations (a labelled subset for a quick, cheaper measurement).
     let retrieval_only = args.iter().any(|a| a == "--retrieval-only");
+    // `--qa-only` runs ONLY the LLM-gated end-to-end QA phase (no retrieval
+    // metrics, no ablation ladder, no memory-growth phase). This isolates the
+    // slow judge calls so a bounded QA sample fits a short wall-clock budget;
+    // the growth phase in particular (10k sequential stores) would otherwise
+    // dominate the run before QA starts.
+    let qa_only = args.iter().any(|a| a == "--qa-only");
     let max_conversations: Option<usize> = args
         .iter()
         .position(|a| a == "--max-conversations")
@@ -163,6 +169,9 @@ async fn main() -> Result<(), String> {
 
     // 1. Retrieval quality + latency (default AgentMemory pipeline), one
     //    concurrent task per conversation (independent haystacks).
+    if qa_only {
+        return run_qa_only(&conversations, &mut w).await;
+    }
     if growth_only {
         return run_growth_and_qa(&conversations, grow_100k, &mut w).await;
     }
@@ -264,6 +273,36 @@ async fn main() -> Result<(), String> {
     w(ablation::to_markdown(&table))?;
 
     run_growth_and_qa(&conversations, grow_100k, &mut w).await
+}
+
+/// Run ONLY the LLM-gated end-to-end QA phase (`--qa-only`): skips retrieval
+/// metrics, the ablation ladder, and the memory-growth phase so a bounded QA
+/// sample fits a short wall-clock budget. Numbers come from real judge
+/// verdicts; without a configured judge this reports not-run, never a number.
+async fn run_qa_only(
+    conversations: &[EvalConversation],
+    w: &mut impl FnMut(String) -> Result<(), String>,
+) -> Result<(), String> {
+    w("== QA end-to-end accuracy (LLM-gated, --qa-only) ==".to_string())?;
+    match qa::run_qa_gated(conversations, K)
+        .await
+        .map_err(|e| e.to_string())?
+    {
+        qa::QaResult::NotRun { reason } => w(format!("QA: {reason}"))?,
+        qa::QaResult::Ran(r) => {
+            w(format!(
+                "QA: graded={} correct={} accuracy={:.4}",
+                r.questions, r.correct, r.accuracy
+            ))?;
+            for (qtype, b) in &r.by_qtype {
+                w(format!(
+                    "  {qtype}: graded={} correct={} accuracy={:.4}",
+                    b.questions, b.correct, b.accuracy
+                ))?;
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Memory-growth measurement and gated QA (phases 3 and 4).

--- a/tools/eval/src/bin/run_eval.rs
+++ b/tools/eval/src/bin/run_eval.rs
@@ -14,8 +14,16 @@
 //! under that concurrency and are reported as such.
 //!
 //! Every printed number comes from this process's real run. QA accuracy is
-//! gated: without the `llm-reasoning` feature and a configured endpoint it is
-//! reported as not-run, never fabricated.
+//! gated: without a selected, available judge it is reported as not-run,
+//! never fabricated. Select the judge via `SYNAPTIC_EVAL_JUDGE`:
+//!
+//! - `SYNAPTIC_EVAL_JUDGE=codex` — use a locally installed, logged-in
+//!   `codex` CLI (works in the default build, no feature flag needed).
+//!   `SYNAPTIC_EVAL_CODEX_BIN` overrides the binary (default `codex`);
+//!   `SYNAPTIC_EVAL_CODEX_TIMEOUT_SECS` overrides the per-call timeout
+//!   (default 120s).
+//! - `SYNAPTIC_EVAL_JUDGE=llm` or unset — requires the `llm-reasoning`
+//!   feature and `SYNAPTIC_EVAL_LLM_URL` / `SYNAPTIC_EVAL_LLM_MODEL`.
 
 use std::collections::HashSet;
 use std::io::Write;

--- a/tools/eval/src/qa.rs
+++ b/tools/eval/src/qa.rs
@@ -16,6 +16,21 @@
 //! - A judge failure mid-run (endpoint unreachable, malformed reply) aborts
 //!   the run with an error: fail closed, no partial numbers.
 //!
+//! ## Judge selection (`SYNAPTIC_EVAL_JUDGE`)
+//!
+//! [`run_qa_gated`] picks the judge based on `SYNAPTIC_EVAL_JUDGE`:
+//!
+//! - `codex` — use [`CodexCliJudge`], which shells out to a locally
+//!   installed, logged-in `codex` CLI (`codex exec`). No feature flag or
+//!   network crate required; works in the default build. Configure the
+//!   binary with `SYNAPTIC_EVAL_CODEX_BIN` (default `codex`) and the
+//!   per-call timeout with `SYNAPTIC_EVAL_CODEX_TIMEOUT_SECS` (default
+//!   120s). If the CLI is not runnable this returns [`QaResult::NotRun`]
+//!   rather than fabricating a number.
+//! - `llm` or unset — the existing behavior: with the `llm-reasoning`
+//!   feature enabled and an endpoint configured, uses [`LlmJudge`];
+//!   otherwise [`QaResult::NotRun`].
+//!
 //! ## Real judge configuration (`llm-reasoning` feature)
 //!
 //! [`LlmJudge`] talks to any OpenAI-compatible chat-completions endpoint
@@ -193,34 +208,75 @@ pub async fn run_qa(
     })
 }
 
-/// Gated QA evaluation. With the `llm-reasoning` feature enabled and an
-/// endpoint configured (see module docs for the env vars), runs [`run_qa`]
-/// with the real [`LlmJudge`]. Otherwise returns [`QaResult::NotRun`] with
-/// the reason — QA accuracy is never fabricated.
+/// Environment variable selecting which judge [`run_qa_gated`] uses:
+/// `codex` for [`CodexCliJudge`], `llm` (or unset) for [`LlmJudge`] /
+/// existing behavior.
+pub const ENV_JUDGE: &str = "SYNAPTIC_EVAL_JUDGE";
+
+/// If `SYNAPTIC_EVAL_JUDGE=codex`, run QA with [`CodexCliJudge`] and return
+/// `Some(result)` (a real report if the CLI is available, `NotRun`
+/// otherwise). Returns `None` when a different judge should be selected
+/// (env var unset or set to something else), so callers fall through to
+/// their existing behavior.
+async fn run_qa_with_codex_if_selected(
+    conversations: &[EvalConversation],
+    k: usize,
+) -> Option<Result<QaResult, QaError>> {
+    let selected = std::env::var(ENV_JUDGE).ok()?;
+    if selected.trim() != "codex" {
+        return None;
+    }
+    let judge = CodexCliJudge::from_env();
+    if !judge.is_available() {
+        return Some(Ok(QaResult::NotRun {
+            reason: format!(
+                "SYNAPTIC_EVAL_JUDGE=codex but codex CLI not runnable — \
+                 install/login the codex CLI or set {}",
+                CodexCliJudge::ENV_BIN
+            ),
+        }));
+    }
+    Some(run_qa(conversations, &judge, k).await.map(QaResult::Ran))
+}
+
+/// Gated QA evaluation. Honors `SYNAPTIC_EVAL_JUDGE=codex` (see module
+/// docs) first; otherwise, with the `llm-reasoning` feature enabled and an
+/// endpoint configured, runs [`run_qa`] with the real [`LlmJudge`].
+/// Otherwise returns [`QaResult::NotRun`] with the reason — QA accuracy is
+/// never fabricated.
 #[cfg(feature = "llm-reasoning")]
 pub async fn run_qa_gated(
     conversations: &[EvalConversation],
     k: usize,
 ) -> Result<QaResult, QaError> {
+    if let Some(result) = run_qa_with_codex_if_selected(conversations, k).await {
+        return result;
+    }
     match LlmJudge::from_env()? {
         Some(judge) => Ok(QaResult::Ran(run_qa(conversations, &judge, k).await?)),
         None => Ok(QaResult::NotRun {
             reason: "not run — requires endpoint: set SYNAPTIC_EVAL_LLM_URL (and \
-                     SYNAPTIC_EVAL_LLM_MODEL) to an OpenAI-compatible endpoint"
+                     SYNAPTIC_EVAL_LLM_MODEL) to an OpenAI-compatible endpoint, \
+                     or set SYNAPTIC_EVAL_JUDGE=codex with the codex CLI installed"
                 .to_string(),
         }),
     }
 }
 
-/// Gated QA evaluation (feature off): always [`QaResult::NotRun`].
+/// Gated QA evaluation (feature off). Honors `SYNAPTIC_EVAL_JUDGE=codex`
+/// (see module docs); otherwise always [`QaResult::NotRun`].
 #[cfg(not(feature = "llm-reasoning"))]
 pub async fn run_qa_gated(
-    _conversations: &[EvalConversation],
-    _k: usize,
+    conversations: &[EvalConversation],
+    k: usize,
 ) -> Result<QaResult, QaError> {
+    if let Some(result) = run_qa_with_codex_if_selected(conversations, k).await {
+        return result;
+    }
     Ok(QaResult::NotRun {
         reason: "not run — requires endpoint: build with feature `llm-reasoning` and \
-                 set SYNAPTIC_EVAL_LLM_URL / SYNAPTIC_EVAL_LLM_MODEL"
+                 set SYNAPTIC_EVAL_LLM_URL / SYNAPTIC_EVAL_LLM_MODEL, or set \
+                 SYNAPTIC_EVAL_JUDGE=codex with the codex CLI installed"
             .to_string(),
     })
 }
@@ -559,6 +615,109 @@ impl Judge for CodexCliJudge {
                 stdout.trim()
             ))
         })
+    }
+}
+
+#[cfg(test)]
+mod run_qa_tests {
+    use super::*;
+    use crate::dataset::{EvalConversation, EvalQuestion, QType, Session};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Deterministic judge for testing aggregation without a network or CLI.
+    /// Grades correct on odd calls, incorrect on even calls (0-indexed).
+    struct FakeJudge {
+        call: AtomicUsize,
+    }
+
+    impl FakeJudge {
+        fn new() -> Self {
+            Self {
+                call: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Judge for FakeJudge {
+        async fn answer(&self, _question: &str, _recalled: &[String]) -> Result<String, QaError> {
+            Ok("fake answer".to_string())
+        }
+
+        async fn grade(
+            &self,
+            _question: &str,
+            _gold: &str,
+            _predicted: &str,
+        ) -> Result<bool, QaError> {
+            let n = self.call.fetch_add(1, Ordering::SeqCst);
+            Ok(n % 2 == 0)
+        }
+    }
+
+    fn fixture() -> Vec<EvalConversation> {
+        vec![EvalConversation {
+            id: "conv1".to_string(),
+            sessions: vec![Session {
+                id: "s1".to_string(),
+                timestamp: None,
+                turns: vec![],
+            }],
+            questions: vec![
+                EvalQuestion {
+                    id: "q1".to_string(),
+                    text: "What color is the sky?".to_string(),
+                    qtype: QType::SingleHop,
+                    evidence_ids: vec![],
+                    gold_answer: "blue".to_string(),
+                },
+                EvalQuestion {
+                    id: "q2".to_string(),
+                    text: "What color is grass?".to_string(),
+                    qtype: QType::SingleHop,
+                    evidence_ids: vec![],
+                    gold_answer: "green".to_string(),
+                },
+            ],
+        }]
+    }
+
+    #[tokio::test]
+    async fn run_qa_aggregates_accuracy_over_fixture() {
+        let conversations = fixture();
+        let judge = FakeJudge::new();
+        let report = run_qa(&conversations, &judge, 5)
+            .await
+            .expect("run_qa should succeed with a fake judge");
+
+        assert_eq!(report.questions, 2);
+        assert_eq!(report.correct, 1);
+        assert!((report.accuracy - 0.5).abs() < f64::EPSILON);
+
+        let bucket = report
+            .by_qtype
+            .get(&qtype_key(QType::SingleHop))
+            .expect("SingleHop bucket present");
+        assert_eq!(bucket.questions, 2);
+        assert_eq!(bucket.correct, 1);
+        assert!((bucket.accuracy - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[cfg(not(feature = "llm-reasoning"))]
+    #[tokio::test]
+    async fn run_qa_gated_not_run_when_judge_env_unset() {
+        // Guard against test-order env races on this process-wide var.
+        std::env::remove_var(ENV_JUDGE);
+        let conversations = fixture();
+        let result = run_qa_gated(&conversations, 5)
+            .await
+            .expect("run_qa_gated should not error when no judge is configured");
+        match result {
+            QaResult::NotRun { reason } => {
+                assert!(reason.contains("SYNAPTIC_EVAL_JUDGE=codex"));
+            }
+            QaResult::Ran(_) => panic!("expected NotRun with no judge configured"),
+        }
     }
 }
 

--- a/tools/eval/src/qa.rs
+++ b/tools/eval/src/qa.rs
@@ -44,6 +44,7 @@
 
 use crate::dataset::{EvalConversation, QType};
 use crate::runner::ingest;
+use futures::stream::{self, StreamExt};
 use std::collections::BTreeMap;
 use synaptic::{AgentMemory, MemoryConfig};
 
@@ -134,14 +135,80 @@ fn qtype_key(qtype: QType) -> String {
     format!("{qtype:?}")
 }
 
+/// Environment variable bounding how many judge (`answer`+`grade`) pipelines
+/// run concurrently within a conversation. Parsed as `usize`, clamped to at
+/// least 1; defaults to 4 when unset or unparseable.
+pub const ENV_QA_CONCURRENCY: &str = "SYNAPTIC_EVAL_QA_CONCURRENCY";
+
+/// Read [`ENV_QA_CONCURRENCY`], defaulting to 4 and clamping to at least 1.
+fn qa_concurrency() -> usize {
+    std::env::var(ENV_QA_CONCURRENCY)
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(4)
+        .max(1)
+}
+
+/// One question with its recalled memories, ready for the judge pipeline.
+struct PendingQuestion {
+    question_id: String,
+    qtype: String,
+    question_text: String,
+    gold_answer: String,
+    recalled: Vec<String>,
+}
+
+/// Run `judge.answer` then `judge.grade` for one pending question.
+async fn judge_one(judge: &dyn Judge, item: PendingQuestion) -> Result<QaQuestionRecord, QaError> {
+    let predicted = judge.answer(&item.question_text, &item.recalled).await?;
+    let correct = judge
+        .grade(&item.question_text, &item.gold_answer, &predicted)
+        .await?;
+    Ok(QaQuestionRecord {
+        question_id: item.question_id,
+        qtype: item.qtype,
+        predicted,
+        correct,
+    })
+}
+
+/// Run the `judge.answer` + `judge.grade` pipeline for `pending` with bounded
+/// concurrency (limit `concurrency`, clamped to at least 1). Fail closed: as
+/// soon as any task returns `Err`, that error is returned; the underlying
+/// stream is not driven any further, so no partial report is produced.
+async fn judge_questions(
+    judge: &dyn Judge,
+    pending: Vec<PendingQuestion>,
+    concurrency: usize,
+) -> Result<Vec<QaQuestionRecord>, QaError> {
+    let concurrency = concurrency.max(1);
+    let mut records = Vec::with_capacity(pending.len());
+    let mut results = stream::iter(pending)
+        .map(|item| judge_one(judge, item))
+        .buffer_unordered(concurrency);
+    while let Some(result) = results.next().await {
+        records.push(result?);
+    }
+    Ok(records)
+}
+
 /// Run end-to-end QA over `conversations` with `judge`: per question, recall
 /// up to `k` memories, generate an answer, grade it against the gold answer,
 /// and aggregate accuracy. Any judge failure aborts the run (fail closed).
+///
+/// The `judge.answer` + `judge.grade` calls for a conversation's questions
+/// run with bounded concurrency (see [`ENV_QA_CONCURRENCY`]); recall
+/// (`memory.search`) stays sequential since it needs `&memory` and is fast.
+/// Results are independent of the concurrency level: `per_question` is
+/// sorted by `question_id` before returning, and the aggregate counts are
+/// order-independent, so two runs over the same inputs produce identical
+/// reports.
 pub async fn run_qa(
     conversations: &[EvalConversation],
     judge: &dyn Judge,
     k: usize,
 ) -> Result<QaReport, QaError> {
+    let concurrency = qa_concurrency();
     let mut per_question: Vec<QaQuestionRecord> = Vec::new();
     let mut by_qtype: BTreeMap<String, QTypeAccuracy> = BTreeMap::new();
 
@@ -153,6 +220,7 @@ pub async fn run_qa(
             .await
             .map_err(|e| QaError::Memory(e.to_string()))?;
 
+        let mut pending: Vec<PendingQuestion> = Vec::with_capacity(conversation.questions.len());
         for question in &conversation.questions {
             let recalled: Vec<String> = memory
                 .search(&question.text, k)
@@ -161,27 +229,27 @@ pub async fn run_qa(
                 .into_iter()
                 .map(|f| f.entry.value)
                 .collect();
-            let predicted = judge.answer(&question.text, &recalled).await?;
-            let correct = judge
-                .grade(&question.text, &question.gold_answer, &predicted)
-                .await?;
+            pending.push(PendingQuestion {
+                question_id: question.id.clone(),
+                qtype: qtype_key(question.qtype),
+                question_text: question.text.clone(),
+                gold_answer: question.gold_answer.clone(),
+                recalled,
+            });
+        }
 
+        let records = judge_questions(judge, pending, concurrency).await?;
+        for record in records {
             let bucket = by_qtype
-                .entry(qtype_key(question.qtype))
+                .entry(record.qtype.clone())
                 .or_insert(QTypeAccuracy {
                     questions: 0,
                     correct: 0,
                     accuracy: 0.0,
                 });
             bucket.questions += 1;
-            bucket.correct += usize::from(correct);
-
-            per_question.push(QaQuestionRecord {
-                question_id: question.id.clone(),
-                qtype: qtype_key(question.qtype),
-                predicted,
-                correct,
-            });
+            bucket.correct += usize::from(record.correct);
+            per_question.push(record);
         }
     }
 
@@ -192,6 +260,7 @@ pub async fn run_qa(
             bucket.correct as f64 / bucket.questions as f64
         };
     }
+    per_question.sort_by(|a, b| a.question_id.cmp(&b.question_id));
     let questions = per_question.len();
     let correct = per_question.iter().filter(|q| q.correct).count();
     Ok(QaReport {
@@ -701,6 +770,131 @@ mod run_qa_tests {
         assert_eq!(bucket.questions, 2);
         assert_eq!(bucket.correct, 1);
         assert!((bucket.accuracy - 0.5).abs() < f64::EPSILON);
+    }
+
+    fn fixture_with_n_questions(n: usize) -> Vec<EvalConversation> {
+        let questions = (0..n)
+            .map(|i| EvalQuestion {
+                id: format!("q{i:02}"),
+                text: format!("Question number {i}?"),
+                qtype: QType::SingleHop,
+                evidence_ids: vec![],
+                gold_answer: format!("answer {i}"),
+            })
+            .collect();
+        vec![EvalConversation {
+            id: "conv1".to_string(),
+            sessions: vec![Session {
+                id: "s1".to_string(),
+                timestamp: None,
+                turns: vec![],
+            }],
+            questions,
+        }]
+    }
+
+    /// Guards process-wide env var races between tests that touch
+    /// `ENV_QA_CONCURRENCY` — only one such test should run its critical
+    /// section at a time.
+    static CONCURRENCY_ENV_GUARD: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    #[tokio::test]
+    async fn run_qa_with_bounded_concurrency_matches_sequential_semantics() {
+        let _guard = CONCURRENCY_ENV_GUARD.lock().await;
+        std::env::set_var(ENV_QA_CONCURRENCY, "3");
+
+        let conversations = fixture_with_n_questions(6);
+
+        let judge_a = FakeJudge::new();
+        let report_a = run_qa(&conversations, &judge_a, 5)
+            .await
+            .expect("run_qa should succeed with concurrency > 1");
+
+        let judge_b = FakeJudge::new();
+        let report_b = run_qa(&conversations, &judge_b, 5)
+            .await
+            .expect("run_qa should succeed with concurrency > 1 (second run)");
+
+        std::env::remove_var(ENV_QA_CONCURRENCY);
+        drop(_guard);
+
+        // Same aggregate accuracy/counts as the sequential expectation:
+        // alternating correct/incorrect over 6 questions -> 3 correct.
+        assert_eq!(report_a.questions, 6);
+        assert_eq!(report_a.correct, 3);
+        assert!((report_a.accuracy - 0.5).abs() < f64::EPSILON);
+        let bucket = report_a
+            .by_qtype
+            .get(&qtype_key(QType::SingleHop))
+            .expect("SingleHop bucket present");
+        assert_eq!(bucket.questions, 6);
+        assert_eq!(bucket.correct, 3);
+
+        // Identical aggregates across two independent runs.
+        assert_eq!(report_a.questions, report_b.questions);
+        assert_eq!(report_a.correct, report_b.correct);
+        assert_eq!(report_a.accuracy, report_b.accuracy);
+
+        // per_question is sorted by question_id, deterministically, in both
+        // runs — proving concurrency doesn't scramble output order.
+        let ids_a: Vec<&str> = report_a
+            .per_question
+            .iter()
+            .map(|q| q.question_id.as_str())
+            .collect();
+        let ids_b: Vec<&str> = report_b
+            .per_question
+            .iter()
+            .map(|q| q.question_id.as_str())
+            .collect();
+        assert_eq!(ids_a, ids_b);
+        let mut sorted_ids = ids_a.clone();
+        sorted_ids.sort();
+        assert_eq!(ids_a, sorted_ids, "per_question must be sorted by id");
+    }
+
+    /// Judge whose `grade` fails on one specific question, to prove
+    /// concurrent `run_qa` still fails closed (returns `Err`, no partial
+    /// report) rather than swallowing the error or reporting it as
+    /// incorrect.
+    struct FailingJudge;
+
+    #[async_trait::async_trait]
+    impl Judge for FailingJudge {
+        async fn answer(&self, _question: &str, _recalled: &[String]) -> Result<String, QaError> {
+            Ok("fake answer".to_string())
+        }
+
+        async fn grade(
+            &self,
+            question: &str,
+            _gold: &str,
+            _predicted: &str,
+        ) -> Result<bool, QaError> {
+            if question.contains("number 3") {
+                Err(QaError::Judge("simulated grading failure".to_string()))
+            } else {
+                Ok(true)
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn run_qa_fails_closed_on_judge_error_under_concurrency() {
+        let _guard = CONCURRENCY_ENV_GUARD.lock().await;
+        std::env::set_var(ENV_QA_CONCURRENCY, "4");
+
+        let conversations = fixture_with_n_questions(6);
+        let judge = FailingJudge;
+        let result = run_qa(&conversations, &judge, 5).await;
+
+        std::env::remove_var(ENV_QA_CONCURRENCY);
+        drop(_guard);
+
+        assert!(
+            result.is_err(),
+            "a single failing judge call must fail the whole run"
+        );
     }
 
     #[cfg(not(feature = "llm-reasoning"))]


### PR DESCRIPTION
## Summary
Produces the project's **first real end-to-end QA accuracy number** — previously always reported "not run". The harness already had a complete `CodexCliJudge` (shells the logged-in `codex` CLI) but `run_qa_gated` never selected it. This wires it up, makes judging concurrent so a sample is tractable, and measures.

## Changes
- `687ebf7` — select `CodexCliJudge` via `SYNAPTIC_EVAL_JUDGE=codex` (works in the default build; no `llm-reasoning` feature needed). Fail-closed: codex selected but unavailable → `NotRun`, never fabricated. (reviewed MERGEABLE)
- `34deca6` — bounded-concurrency QA judging (`SYNAPTIC_EVAL_QA_CONCURRENCY`, default 4) via `buffer_unordered`; fail-closed on first judge error, deterministic (id-sorted results). Codex verified to tolerate parallel calls. (reviewed MERGEABLE)
- `b1bdbe8` — `--qa-only` flag: runs ONLY the gated QA phase (skips retrieval/ablation/growth) with per-qtype breakdown, so a bounded sample fits a short wall-clock budget. (final review MERGEABLE)
- `65925c1` — docs: measured QA numbers.

## Measured (static retrieval, codex judge, concurrency 4)
| sample | graded | correct | accuracy |
|---|---|---|---|
| 20 q | 20 | 5 | 0.2500 |
| 40 q | 40 | 9 | 0.2250 |

Per-QType (40 q): SingleHop 1/1, Temporal 5/16 (0.31), MultiHop 3/19 (0.16), OpenDomain 0/4 (0.00).

## Honesty
Every number is a real judge verdict; unconfigured → not-run, never fabricated. Caveats stated in the doc: the `--max-questions` subset over-samples hard MultiHop/Temporal and under-samples the dominant SingleHop, so **0.225 is a pessimistic, hard-weighted estimate**; the per-QType signal is the reliable read, and it tracks the retrieval ceiling by category. A representative full 1,986-q run is bounded by sequential judge latency and is not yet done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)