### PR TITLE
feat(retrieval): over-fetch rerank pool — +6.3% recall@10 (MultiHop +11%)

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -804,3 +804,52 @@ answers, **retrieval-bound = 0.667, judge-bound = 0.333**.
 
 Instrumentation only; no fabricated numbers. Same subset caveats as the QA section
 above (first-N sampling skews toward hard categories).
+
+## Reranking headroom + over-fetch win (2026-07-15)
+
+The QA loss diagnostic (above) showed ~1/3 of failures were judge-bound (gold
+retrieved but not answered). Investigating *why gold that's retrieved doesn't help*
+surfaced a structural bug and a large measured headroom.
+
+**Recall@k curve (full 1,986-q set, one limit-50 search per question):**
+
+| category | recall@10 | recall@20 | recall@50 |
+|---|---|---|---|
+| overall | 0.558 | 0.624 | **0.702** |
+| MultiHop | 0.274 | 0.353 | **0.472** |
+| OpenDomain | 0.243 | 0.313 | 0.376 |
+| SingleHop | 0.646 | 0.712 | 0.782 |
+| Temporal | 0.672 | 0.747 | 0.796 |
+
+The gold evidence is in the top-50 candidate pool far more often than it reaches the
+top-10 — a **+0.144 overall gap (MultiHop +0.199, +73% relative)**. That is a
+*ranking* problem, not a recall problem: the evidence is retrieved but ranked below
+the cutoff.
+
+**Root cause:** `fuse_results` truncated the fused pool to `limit` (=10) BEFORE
+composite scoring and the reranker ran, so the (already semantic) `HeuristicReranker`
+only reordered the final 10 — it could never pull a gold result from rank 11–50 into
+the top-10.
+
+**Fix (over-fetch):** fuse/composite/rerank over a wider pool
+(`rerank_pool_size`, default 50), truncate to the caller's `limit` LAST.
+
+**Measured full-set result (over-fetch vs baseline):**
+
+| category | baseline R@10 | over-fetch R@10 | delta |
+|---|---|---|---|
+| overall | 0.5237 | **0.5565** | +0.0328 (+6.3%) |
+| MultiHop | 0.2475 | 0.2737 | +0.0262 (+11%) |
+| Temporal | 0.6072 | 0.6716 | +0.0644 |
+| OpenDomain | 0.2026 | 0.2327 | +0.0301 |
+| SingleHop | 0.6147 | 0.6459 | +0.0312 |
+| MRR | 0.4058 | 0.4219 | +0.0161 |
+
+Every category improved — including MultiHop, which two graph-expansion rounds could
+NOT move: it was a ranking problem all along. Latency cost: recall p50 0.60 s → 0.76 s
+(+27%; the reranker now scores 50 candidates instead of 10), still sub-second; store
+latency unchanged (~10 ms).
+
+**Remaining headroom:** the reranker captures recall@10 = 0.556 of the 0.702 pool
+ceiling. Closing more of that gap needs a stronger reranker (the pool is now available
+to it); the `--recall-curve` mode measures the ceiling any reranker can chase.

--- a/src/memory/retrieval/pipeline.rs
+++ b/src/memory/retrieval/pipeline.rs
@@ -157,6 +157,17 @@ pub struct PipelineConfig {
     /// `score *= 1.0 + temporal_boost`. Default `0.3`.
     #[serde(default = "default_temporal_boost")]
     pub temporal_boost: f64,
+    /// Size of the candidate pool that survives fusion and is handed to
+    /// composite scoring and the reranker, BEFORE the final truncation to
+    /// the caller's requested `limit`. Without over-fetch, fusion would
+    /// truncate to `limit` first, so the reranker could only ever reorder
+    /// the final `limit` candidates and could never promote a gold result
+    /// sitting just outside the top-`limit` (e.g. rank 11-50). Default `50`
+    /// (matches `max_per_signal`, so the reranker sees everything each
+    /// signal returned). The effective pool used is
+    /// `rerank_pool_size.max(limit)`.
+    #[serde(default = "default_rerank_pool_size")]
+    pub rerank_pool_size: usize,
 }
 
 fn default_enable_query_understanding() -> bool {
@@ -165,6 +176,10 @@ fn default_enable_query_understanding() -> bool {
 
 fn default_temporal_boost() -> f64 {
     0.3
+}
+
+fn default_rerank_pool_size() -> usize {
+    50
 }
 
 impl Default for PipelineConfig {
@@ -186,6 +201,7 @@ impl Default for PipelineConfig {
             composite_weights: CompositeWeights::default(),
             enable_query_understanding: default_enable_query_understanding(),
             temporal_boost: default_temporal_boost(),
+            rerank_pool_size: default_rerank_pool_size(),
         }
     }
 }
@@ -286,6 +302,13 @@ impl PipelineConfig {
         self.composite_weights = weights;
         self
     }
+
+    /// Builder method to set the rerank over-fetch pool size (see
+    /// [`PipelineConfig::rerank_pool_size`]).
+    pub fn with_rerank_pool_size(mut self, rerank_pool_size: usize) -> Self {
+        self.rerank_pool_size = rerank_pool_size;
+        self
+    }
 }
 
 /// Strategies for fusing results from multiple signals
@@ -382,8 +405,15 @@ impl HybridRetriever {
             super::query_understanding::QueryPlan::passthrough(query)
         };
 
+        // Over-fetch pool: composite scoring and the reranker operate over
+        // up to `pool` candidates, not just `limit`, so the reranker can
+        // promote a gold result that fusion ranked just outside the final
+        // `limit`. The caller-facing result is truncated to `limit` only at
+        // the very end, after reranking.
+        let pool = self.config.rerank_pool_size.max(limit);
+
         let fused = if plan.is_passthrough() {
-            self.collect_and_fuse(query, limit).await?
+            self.collect_and_fuse(query, pool).await?
         } else {
             tracing::debug!(
                 sub_queries = plan.sub_queries.len(),
@@ -395,7 +425,7 @@ impl HybridRetriever {
             // and union the results, keeping each memory's best fused score.
             let mut best: HashMap<String, (MemoryFragment, f64)> = HashMap::new();
             for sub_query in &plan.sub_queries {
-                for (memory, score) in self.collect_and_fuse(sub_query, limit).await? {
+                for (memory, score) in self.collect_and_fuse(sub_query, pool).await? {
                     match best.entry(memory.entry.key.clone()) {
                         std::collections::hash_map::Entry::Occupied(mut e) => {
                             if score > e.get().1 {
@@ -429,7 +459,7 @@ impl HybridRetriever {
                     .unwrap_or(std::cmp::Ordering::Equal)
                     .then_with(|| a.0.entry.key.cmp(&b.0.entry.key))
             });
-            unioned.truncate(limit);
+            unioned.truncate(pool);
             unioned
         };
 
@@ -439,7 +469,7 @@ impl HybridRetriever {
 
         // Optional reranking stage over the top-K: reorders by cross-features
         // computed against the query; preserves scores and candidates.
-        let fused_results: Vec<MemoryFragment> = match self.reranker {
+        let mut fused_results: Vec<MemoryFragment> = match self.reranker {
             Some(ref reranker) => {
                 let reranked = reranker.rerank(query, composite).await?;
                 tracing::debug!(reranker = reranker.name(), "Rerank stage applied");
@@ -447,6 +477,11 @@ impl HybridRetriever {
             }
             None => composite.into_iter().map(|s| s.memory).collect(),
         };
+
+        // Final truncation to the caller's requested limit. This happens
+        // LAST, after over-fetch, composite scoring, and reranking have all
+        // had a chance to operate over the wider `pool`.
+        fused_results.truncate(limit);
 
         tracing::info!(final_count = fused_results.len(), "Hybrid search completed");
 

--- a/src/memory/retrieval/pipeline.rs
+++ b/src/memory/retrieval/pipeline.rs
@@ -165,7 +165,9 @@ pub struct PipelineConfig {
     /// sitting just outside the top-`limit` (e.g. rank 11-50). Default `50`
     /// (matches `max_per_signal`, so the reranker sees everything each
     /// signal returned). The effective pool used is
-    /// `rerank_pool_size.max(limit)`.
+    /// `rerank_pool_size.max(limit)`. Note: fusion cannot produce more
+    /// distinct candidates than the signals fetched, so a value above
+    /// `max_per_signal` is effectively capped by what each signal returns.
     #[serde(default = "default_rerank_pool_size")]
     pub rerank_pool_size: usize,
 }

--- a/tests/rerank_overfetch_tests.rs
+++ b/tests/rerank_overfetch_tests.rs
@@ -1,0 +1,163 @@
+//! Tests for the rerank over-fetch pool: `fuse_results` used to truncate the
+//! candidate pool to `limit` BEFORE composite scoring and reranking, so the
+//! reranker could only ever reorder the final `limit` candidates and could
+//! never promote a gold result sitting just outside the top-`limit` (e.g.
+//! rank 11-50). `PipelineConfig::rerank_pool_size` controls how wide a pool
+//! survives fusion into composite scoring + reranking before the caller's
+//! `limit` is applied as the final step.
+
+// Test code: unwrap/panic on failure is the intended behaviour.
+#![allow(clippy::unwrap_used, clippy::panic)]
+
+use async_trait::async_trait;
+use std::sync::Arc;
+use synaptic::error::Result;
+use synaptic::memory::retrieval::pipeline::{
+    HybridRetriever, PipelineConfig, RetrievalPipeline, RetrievalSignal, ScoredMemory,
+};
+use synaptic::memory::retrieval::rerank::Reranker;
+use synaptic::memory::types::{MemoryEntry, MemoryFragment, MemoryType};
+
+/// A deterministic stub pipeline that returns a fixed, pre-ranked list of
+/// `n` candidates with strictly descending scores `1.0, 0.99, 0.98, ...`.
+/// Candidate at 0-based index `i` is `mem_i`; `gold` is placed at a chosen
+/// index so tests can control exactly where fusion ranks it.
+struct StubPipeline {
+    n: usize,
+    gold_index: usize,
+}
+
+#[async_trait]
+impl RetrievalPipeline for StubPipeline {
+    async fn search(
+        &self,
+        _query: &str,
+        limit: usize,
+        _config: Option<&PipelineConfig>,
+    ) -> Result<Vec<ScoredMemory>> {
+        let mut results = Vec::new();
+        for i in 0..self.n.min(limit) {
+            let key = if i == self.gold_index {
+                "mem_gold".to_string()
+            } else {
+                format!("mem_{i}")
+            };
+            let entry = MemoryEntry::new(
+                key,
+                format!("distractor content number {i}"),
+                MemoryType::LongTerm,
+            );
+            let score = 1.0 - (i as f64) * 0.01;
+            let fragment = MemoryFragment::new(entry, score);
+            results.push(ScoredMemory::new(
+                fragment,
+                score,
+                RetrievalSignal::DenseVector,
+            ));
+        }
+        Ok(results)
+    }
+
+    fn name(&self) -> &'static str {
+        "stub"
+    }
+
+    fn signal_type(&self) -> RetrievalSignal {
+        RetrievalSignal::DenseVector
+    }
+}
+
+/// A reranker stub that always promotes `mem_gold` to the very top of
+/// whatever candidate set it is given, leaving the relative order of every
+/// other candidate untouched. This isolates the test from the heuristic
+/// reranker's actual scoring logic: it only needs to prove that WHEN the
+/// reranker wants to promote a low-ranked candidate, it can only do so if
+/// that candidate survived fusion into the pool it's handed.
+struct PromoteGoldReranker;
+
+#[async_trait]
+impl Reranker for PromoteGoldReranker {
+    async fn rerank(
+        &self,
+        _query: &str,
+        mut candidates: Vec<ScoredMemory>,
+    ) -> Result<Vec<ScoredMemory>> {
+        candidates.sort_by(|a, b| {
+            let a_gold = a.memory.entry.key == "mem_gold";
+            let b_gold = b.memory.entry.key == "mem_gold";
+            b_gold
+                .cmp(&a_gold)
+                .then_with(|| a.memory.entry.key.cmp(&b.memory.entry.key))
+        });
+        Ok(candidates)
+    }
+
+    fn name(&self) -> &str {
+        "promote-gold"
+    }
+}
+
+/// With the default over-fetch pool (50) and `limit = 10`, a gold candidate
+/// that fusion ranks at position 15 (i.e. outside the naive top-10) still
+/// survives into the reranker's candidate set and gets promoted into the
+/// final top-10.
+#[tokio::test]
+async fn rerank_promotes_below_limit_candidate_with_overfetch() {
+    let gold_index = 14; // 0-based rank 14 => rank 15, outside top-10.
+    let pipeline = Arc::new(StubPipeline { n: 50, gold_index });
+
+    let config = PipelineConfig::default(); // rerank_pool_size = 50
+    let retriever = HybridRetriever::new(config)
+        .add_pipeline(pipeline)
+        .with_reranker(Arc::new(PromoteGoldReranker));
+
+    let results = retriever.search("distractor content", 10).await.unwrap();
+
+    assert!(results.len() <= 10, "must respect caller limit");
+    assert!(
+        results.iter().any(|f| f.entry.key == "mem_gold"),
+        "gold candidate at fusion rank 15 should be promoted into the final \
+         top-10 by the reranker when the pool is wide enough to include it"
+    );
+}
+
+/// Same fixture, but with `rerank_pool_size` shrunk to equal `limit` (10):
+/// the effective pool is `max(rerank_pool_size, limit) = 10`, so the gold
+/// candidate at fusion rank 15 never survives into the pool the reranker
+/// sees, and cannot be promoted into the final result. This proves the
+/// over-fetch, not the reranker's promotion logic, is what creates the
+/// headroom.
+#[tokio::test]
+async fn rerank_cannot_promote_below_pool_candidate_without_overfetch() {
+    let gold_index = 14;
+    let pipeline = Arc::new(StubPipeline { n: 50, gold_index });
+
+    let config = PipelineConfig::default().with_rerank_pool_size(10);
+    let retriever = HybridRetriever::new(config)
+        .add_pipeline(pipeline)
+        .with_reranker(Arc::new(PromoteGoldReranker));
+
+    let results = retriever.search("distractor content", 10).await.unwrap();
+
+    assert!(results.len() <= 10);
+    assert!(
+        !results.iter().any(|f| f.entry.key == "mem_gold"),
+        "gold candidate at fusion rank 15 must NOT appear when the pool is \
+         truncated to the caller's limit before reranking"
+    );
+}
+
+/// Baseline sanity check: `search` never returns more than `limit` results,
+/// regardless of how wide the over-fetch pool is.
+#[tokio::test]
+async fn search_respects_caller_limit() {
+    let pipeline = Arc::new(StubPipeline {
+        n: 50,
+        gold_index: 0,
+    });
+    let config = PipelineConfig::default();
+    let retriever = HybridRetriever::new(config).add_pipeline(pipeline);
+
+    let results = retriever.search("distractor content", 5).await.unwrap();
+    assert!(results.len() <= 5);
+}

--- a/tools/eval/src/bin/run_eval.rs
+++ b/tools/eval/src/bin/run_eval.rs
@@ -113,6 +113,10 @@ async fn main() -> Result<(), String> {
     // the growth phase in particular (10k sequential stores) would otherwise
     // dominate the run before QA starts.
     let qa_only = args.iter().any(|a| a == "--qa-only");
+    // `--recall-curve` measures recall@{10,20,50} from a single limit-50 search
+    // per question. It answers whether below-rank-10 gold is in the candidate
+    // pool (reranking headroom) or absent (first-stage recall problem). No judge.
+    let recall_curve = args.iter().any(|a| a == "--recall-curve");
     let max_conversations: Option<usize> = args
         .iter()
         .position(|a| a == "--max-conversations")
@@ -169,6 +173,9 @@ async fn main() -> Result<(), String> {
 
     // 1. Retrieval quality + latency (default AgentMemory pipeline), one
     //    concurrent task per conversation (independent haystacks).
+    if recall_curve {
+        return run_recall_curve(&conversations, &mut w).await;
+    }
     if qa_only {
         return run_qa_only(&conversations, &mut w).await;
     }
@@ -273,6 +280,73 @@ async fn main() -> Result<(), String> {
     w(ablation::to_markdown(&table))?;
 
     run_growth_and_qa(&conversations, grow_100k, &mut w).await
+}
+
+/// Measure the recall@k curve (`--recall-curve`): one limit-50 search per
+/// question, then recall@10/@20/@50 computed from that single ranked list. A
+/// large gap between recall@10 and recall@50 means below-rank-10 gold IS in the
+/// candidate pool (a reranker over a wider pool could recover it); a flat curve
+/// means the gold isn't retrieved at all (a first-stage recall problem).
+async fn run_recall_curve(
+    conversations: &[EvalConversation],
+    w: &mut impl FnMut(String) -> Result<(), String>,
+) -> Result<(), String> {
+    const KS: [usize; 3] = [10, 20, 50];
+    const KMAX: usize = 50;
+    // (n, sum_recall@10, sum_recall@20, sum_recall@50) per qtype + overall.
+    let mut overall = [0.0f64; 3];
+    let mut n_total = 0usize;
+    let mut by_qtype: std::collections::BTreeMap<String, (usize, [f64; 3])> =
+        std::collections::BTreeMap::new();
+
+    for conversation in conversations {
+        let mut memory = AgentMemory::new(MemoryConfig::default())
+            .await
+            .map_err(|e| e.to_string())?;
+        runner::ingest(conversation, &mut memory)
+            .await
+            .map_err(|e| e.to_string())?;
+        for question in &conversation.questions {
+            if question.evidence_ids.is_empty() {
+                continue; // no labeled gold → not a recall data point
+            }
+            let outcome = runner::run_question(question, &memory, KMAX)
+                .await
+                .map_err(|e| e.to_string())?;
+            let relevant: HashSet<String> = question.evidence_ids.iter().cloned().collect();
+            let entry = by_qtype
+                .entry(format!("{:?}", question.qtype))
+                .or_insert((0, [0.0; 3]));
+            entry.0 += 1;
+            n_total += 1;
+            for (i, &k) in KS.iter().enumerate() {
+                let r = recall_at_k(&outcome.retrieved_ids, &relevant, k);
+                overall[i] += r;
+                entry.1[i] += r;
+            }
+        }
+    }
+
+    w("== recall@k curve (single limit-50 search per question) ==".to_string())?;
+    if n_total == 0 {
+        w("no questions with labeled evidence".to_string())?;
+        return Ok(());
+    }
+    w(format!(
+        "overall n={n_total} recall@10={:.4} recall@20={:.4} recall@50={:.4}",
+        overall[0] / n_total as f64,
+        overall[1] / n_total as f64,
+        overall[2] / n_total as f64
+    ))?;
+    for (qtype, (n, sums)) in &by_qtype {
+        w(format!(
+            "  {qtype}: n={n} recall@10={:.4} recall@20={:.4} recall@50={:.4}",
+            sums[0] / *n as f64,
+            sums[1] / *n as f64,
+            sums[2] / *n as f64
+        ))?;
+    }
+    Ok(())
 }
 
 /// Run ONLY the LLM-gated end-to-end QA phase (`--qa-only`): skips retrieval


### PR DESCRIPTION
## Summary
A measured, structural retrieval win. The QA loss diagnostic showed ~1/3 of failures were judge-bound; investigating *why retrieved gold doesn't surface* found the pipeline truncated the fused pool to `limit=10` BEFORE composite scoring + reranking — so the (already semantic) reranker only reordered the final 10 and could never promote a gold result from rank 11–50.

**Measured headroom first (recall@k curve, full set):** recall@10 0.558 vs recall@50 **0.702** (+0.144; MultiHop 0.274→0.472). The gold is in the pool, ranked below the cutoff — a ranking problem.

**Fix:** over-fetch to `rerank_pool_size` (default 50), run composite+rerank over the pool, truncate to `limit` LAST.

## Result (full 1,986-q set, over-fetch vs baseline)
| category | baseline | over-fetch | delta |
|---|---|---|---|
| overall R@10 | 0.5237 | **0.5565** | +0.033 (+6.3%) |
| MultiHop | 0.2475 | 0.2737 | +0.026 (+11%) |
| Temporal | 0.6072 | 0.6716 | +0.064 |
| OpenDomain | 0.2026 | 0.2327 | +0.030 |
| SingleHop | 0.6147 | 0.6459 | +0.031 |
| MRR | 0.4058 | 0.4219 | +0.016 |

Every category improved — including MultiHop, which two graph-expansion rounds could NOT move (it was a ranking problem, not connectivity). Latency: recall p50 0.60→0.76 s (+27%, reranker scores 50 vs 10; still sub-second); store latency unchanged.

## Notes
- Adds `PipelineConfig.rerank_pool_size` (default 50) + builder; `--recall-curve` eval mode (recall@10/20/50 from one limit-50 search) to measure the ceiling.
- Remaining headroom: reranker captures 0.556 of the 0.702 pool ceiling — a stronger reranker (now fed the pool) could chase more.
- Tests prove a below-top-10 candidate surfaces WITH over-fetch and NOT without; all existing retrieval/multihop/latency suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)