### PR TITLE
feat(retrieval): opt-in cross-encoder reranker — +27% recall@10 / +35% MRR (subset)

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -887,3 +887,45 @@ env-overridable per deployment (`SYNAPTIC_RERANK_W_TERM|EMBED|GRAPH|RECENCY`).
 **Cumulative retrieval gain this session:** recall@10 0.5237 (pre-over-fetch) → 0.5565
 (over-fetch) → **0.5691** (embedding-dominant rerank); MultiHop 0.2475 → 0.3001
 (**+21%**), reached entirely through ranking, not connectivity.
+
+## Cross-encoder reranker (opt-in, 2026-07-15)
+
+The embedding-weight sweep peaked at recall@10 0.5691; closing more of the 0.702
+pool ceiling needs a stronger reranker *architecture*. A candle BERT cross-encoder
+(`CrossEncoderReranker`, `cross-encoder/ms-marco-MiniLM-L-6-v2`) already existed in
+the tree behind the `reranker-model` feature but was never wired or measured. This
+round makes it opt-in (`SYNAPTIC_RERANKER=cross-encoder`, model dir via
+`SYNAPTIC_RERANKER_MODEL_DIR`; the fast heuristic reranker stays the default; fetch
+with `scripts/fetch_embedding_model.sh --cross-encoder`). Unlike bi-encoder cosine
+(query and candidate embedded separately), a cross-encoder tokenizes the
+`(query, candidate)` pair jointly through BERT and reads a relevance logit — far more
+accurate, far more expensive.
+
+**Head-to-head, identical 100-question LoCoMo subset** (over-fetch pool of 50,
+static first-stage embeddings; only the reranker differs):
+
+| metric | heuristic (default) | cross-encoder | delta |
+|---|---|---|---|
+| recall@10 | 0.4330 | **0.5483** | +0.115 (+27%) |
+| MRR | 0.3775 | **0.5092** | +0.132 (+35%) |
+| MultiHop R@10 | 0.2756 | 0.3251 | +0.050 (+18%) |
+| OpenDomain R@10 | 0.2143 | 0.3571 | +0.143 (+67%) |
+| Temporal R@10 | 0.6628 | 0.8372 | +0.174 (+26%) |
+| recall latency p50 | 0.76 s | 6.34 s | 8.3× |
+
+Every category improves; the +0.132 MRR shows the cross-encoder ranks gold markedly
+higher (it recovers most of the recall@10→recall@50 pool gap). Cost is the catch:
+**6.3 s/query on CPU** (50 sequential BERT forward passes per query) — hence opt-in,
+not default.
+
+**Honest caveats:**
+- This is a **100-question subset** (first 10 q/conversation), skewed toward
+  MultiHop/Temporal — the absolute numbers are not the full-set figure (the heuristic
+  scores 0.433 here vs 0.5691 full-set because of the category mix). The **relative**
+  head-to-head is the reliable signal: same questions, same pool, only the reranker
+  changes.
+- **No full-set cross-encoder number:** at 6.3 s/query a full 1,986-q run is ~60–80
+  min of CPU, impractical in this environment. Batched inference (score N pairs per
+  forward pass) or a GPU (`cuda` feature) would make it tractable — future work.
+- Default retrieval is unchanged; this is strictly an opt-in quality/latency trade for
+  deployments that can afford it (or run on GPU).

--- a/scripts/fetch_embedding_model.sh
+++ b/scripts/fetch_embedding_model.sh
@@ -5,8 +5,9 @@
 # Usage:
 #   ./scripts/fetch_embedding_model.sh                 # MiniLM (candle, ml-models)
 #   ./scripts/fetch_embedding_model.sh --potion        # potion-base-8M (static-embeddings)
-#   ./scripts/fetch_embedding_model.sh --all           # both
-#   ./scripts/fetch_embedding_model.sh [--potion] <dest-dir>   # override destination
+#   ./scripts/fetch_embedding_model.sh --cross-encoder # ms-marco-MiniLM-L6-v2 (reranker-model)
+#   ./scripts/fetch_embedding_model.sh --all           # all of the above
+#   ./scripts/fetch_embedding_model.sh [--potion|--cross-encoder] <dest-dir>   # override destination
 #
 # Models:
 # - sentence-transformers/all-MiniLM-L6-v2 (~87 MB) for the `ml-models` candle
@@ -21,6 +22,13 @@
 #   selects it. A plain `cargo build` (feature off) stays TF-IDF. Override the
 #   dir with SYNAPTIC_STATIC_MODEL_DIR, or force selection with
 #   SYNAPTIC_RETRIEVAL_EMBEDDER=static.
+# - cross-encoder/ms-marco-MiniLM-L-6-v2 (~87 MB) for the `reranker-model`
+#   candle cross-encoder reranker. OPT-IN:
+#     cargo build --features reranker-model
+#     SYNAPTIC_RERANKER=cross-encoder SYNAPTIC_RERANKER_MODEL_DIR=models/ms-marco-MiniLM-L6-v2 ...
+#   Unset or `SYNAPTIC_RERANKER=heuristic` (default) keeps the deterministic
+#   HeuristicReranker; a binary built without `reranker-model` also falls
+#   back to it (with a warning) if cross-encoder is requested.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -47,14 +55,19 @@ fetch() {
 
 MINILM_URL="https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main"
 POTION_URL="https://huggingface.co/minishlab/potion-base-8M/resolve/main"
+CROSS_ENCODER_URL="https://huggingface.co/cross-encoder/ms-marco-MiniLM-L-6-v2/resolve/main"
 
 case "${1:-}" in
   --potion)
     fetch "$POTION_URL" "${2:-$REPO_ROOT/models/potion-base-8M}"
     ;;
+  --cross-encoder)
+    fetch "$CROSS_ENCODER_URL" "${2:-$REPO_ROOT/models/ms-marco-MiniLM-L6-v2}"
+    ;;
   --all)
     fetch "$MINILM_URL" "$REPO_ROOT/models/all-MiniLM-L6-v2"
     fetch "$POTION_URL" "$REPO_ROOT/models/potion-base-8M"
+    fetch "$CROSS_ENCODER_URL" "$REPO_ROOT/models/ms-marco-MiniLM-L6-v2"
     ;;
   *)
     fetch "$MINILM_URL" "${1:-$REPO_ROOT/models/all-MiniLM-L6-v2}"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,17 +319,28 @@ impl AgentMemory {
             // Deterministic heuristic reranker over the top-K: cross-features
             // (term overlap, embedding agreement, graph proximity, recency)
             // reorder the fused + composite-scored results.
-            let reranker = memory::retrieval::HeuristicReranker::new(
-                Some(Arc::clone(&provider)),
-                knowledge_graph.clone(),
-            )
-            .with_weights(memory::retrieval::HeuristicRerankWeights::from_env());
+            // Reranker selection: `SYNAPTIC_RERANKER=cross-encoder` opts into
+            // the candle BERT cross-encoder (feature `reranker-model`);
+            // anything else (including unset) keeps today's default
+            // heuristic reranker. The cross-encoder attempt fails closed —
+            // a missing/unloadable model or a binary built without the
+            // feature falls back to the heuristic reranker with a warning,
+            // so the pipeline is never left without a reranker.
+            let heuristic_reranker: Arc<dyn memory::retrieval::Reranker> = Arc::new(
+                memory::retrieval::HeuristicReranker::new(
+                    Some(Arc::clone(&provider)),
+                    knowledge_graph.clone(),
+                )
+                .with_weights(memory::retrieval::HeuristicRerankWeights::from_env()),
+            );
+            let reranker: Arc<dyn memory::retrieval::Reranker> =
+                memory::retrieval::select_cross_encoder_reranker().unwrap_or(heuristic_reranker);
             let mut hybrid = memory::retrieval::HybridRetriever::new(pipeline_config)
                 .add_pipeline(Arc::clone(&dense_vector))
                 .add_pipeline(Arc::clone(&keyword))
                 .add_pipeline(Arc::new(graph))
                 .add_pipeline(Arc::new(temporal))
-                .with_reranker(Arc::new(reranker));
+                .with_reranker(reranker);
             // Multi-hop graph expansion (HippoRAG-style): seeds with the
             // dense + keyword retrievers' top hits and expands along KG
             // relation edges so 2-hop-reachable answers surface. Toggleable

--- a/src/memory/retrieval/mod.rs
+++ b/src/memory/retrieval/mod.rs
@@ -25,7 +25,10 @@ pub use pipeline::{
 // Re-export reranking stage
 #[cfg(feature = "reranker-model")]
 pub use rerank::CrossEncoderReranker;
-pub use rerank::{HeuristicRerankWeights, HeuristicReranker, Reranker};
+pub use rerank::{
+    select_cross_encoder_reranker, HeuristicRerankWeights, HeuristicReranker, Reranker,
+    SYNAPTIC_RERANKER_ENV, SYNAPTIC_RERANKER_MODEL_DIR_ENV,
+};
 
 // Re-export concrete strategies
 pub use strategies::{GraphRetriever, KeywordRetriever, TemporalRetriever};

--- a/src/memory/retrieval/rerank.rs
+++ b/src/memory/retrieval/rerank.rs
@@ -348,6 +348,65 @@ impl Reranker for HeuristicReranker {
     }
 }
 
+/// Environment variable selecting the pipeline reranker implementation.
+/// Recognised values: `heuristic` (default, also used when unset or
+/// unrecognised) and `cross-encoder` (requires the `reranker-model`
+/// feature; falls back to `heuristic` with a warning otherwise).
+pub const SYNAPTIC_RERANKER_ENV: &str = "SYNAPTIC_RERANKER";
+
+/// Environment variable giving the local model directory used by the
+/// cross-encoder reranker when selected via [`SYNAPTIC_RERANKER_ENV`].
+pub const SYNAPTIC_RERANKER_MODEL_DIR_ENV: &str = "SYNAPTIC_RERANKER_MODEL_DIR";
+
+/// Default local model directory for the cross-encoder reranker, relative
+/// to the process working directory.
+pub const DEFAULT_RERANKER_MODEL_DIR: &str = "models/ms-marco-MiniLM-L6-v2";
+
+/// Attempt to build a [`CrossEncoderReranker`] from the `reranker-model`
+/// directory named by [`SYNAPTIC_RERANKER_MODEL_DIR_ENV`] (or
+/// [`DEFAULT_RERANKER_MODEL_DIR`] if unset).
+///
+/// Returns `None` (with a `tracing::warn!`) when:
+/// - `SYNAPTIC_RERANKER` does not ask for `cross-encoder`, or
+/// - the `reranker-model` feature is not compiled in, or
+/// - the model fails to load (missing/malformed files).
+///
+/// This never panics: callers should fall back to [`HeuristicReranker`] on
+/// `None` so the pipeline always has a working reranker.
+pub fn select_cross_encoder_reranker() -> Option<Arc<dyn Reranker>> {
+    let selection = std::env::var(SYNAPTIC_RERANKER_ENV).unwrap_or_default();
+    if selection != "cross-encoder" {
+        return None;
+    }
+
+    #[cfg(feature = "reranker-model")]
+    {
+        let model_dir = std::env::var(SYNAPTIC_RERANKER_MODEL_DIR_ENV)
+            .unwrap_or_else(|_| DEFAULT_RERANKER_MODEL_DIR.to_string());
+        match CrossEncoderReranker::new(&model_dir) {
+            Ok(reranker) => Some(Arc::new(reranker) as Arc<dyn Reranker>),
+            Err(error) => {
+                tracing::warn!(
+                    model_dir = %model_dir,
+                    %error,
+                    "SYNAPTIC_RERANKER=cross-encoder requested but the model could not be \
+                     loaded; falling back to HeuristicReranker"
+                );
+                None
+            }
+        }
+    }
+
+    #[cfg(not(feature = "reranker-model"))]
+    {
+        tracing::warn!(
+            "SYNAPTIC_RERANKER=cross-encoder requested but this binary was built without the \
+             `reranker-model` feature; falling back to HeuristicReranker"
+        );
+        None
+    }
+}
+
 #[cfg(feature = "reranker-model")]
 pub use cross_encoder::CrossEncoderReranker;
 
@@ -596,5 +655,33 @@ mod weights_env_tests {
         assert_eq!(weights.recency, 0.0);
 
         clear_env();
+    }
+}
+
+#[cfg(test)]
+mod reranker_selection_tests {
+    use super::{select_cross_encoder_reranker, SYNAPTIC_RERANKER_ENV};
+    use std::sync::Mutex;
+
+    /// Guards `SYNAPTIC_RERANKER` so selection tests don't race with each
+    /// other (or with other suites) under parallel test execution.
+    static ENV_GUARD: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn unset_selects_heuristic_path() {
+        let _guard = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var(SYNAPTIC_RERANKER_ENV);
+
+        assert!(select_cross_encoder_reranker().is_none());
+    }
+
+    #[test]
+    fn explicit_heuristic_selects_heuristic_path() {
+        let _guard = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var(SYNAPTIC_RERANKER_ENV, "heuristic");
+
+        assert!(select_cross_encoder_reranker().is_none());
+
+        std::env::remove_var(SYNAPTIC_RERANKER_ENV);
     }
 }


### PR DESCRIPTION
## Summary
Weight-tuning peaked at recall@10 0.5691; closing more of the 0.702 pool ceiling needs a stronger reranker *architecture*. A candle BERT cross-encoder (`CrossEncoderReranker`, `cross-encoder/ms-marco-MiniLM-L-6-v2`) already existed behind the `reranker-model` feature but was never wired or measured. This makes it opt-in and measures it.

## Changes
- `27d5771` — wire `SYNAPTIC_RERANKER=cross-encoder` (+ `SYNAPTIC_RERANKER_MODEL_DIR`) selection; fail-closed to the default `HeuristicReranker` on model-load failure OR feature-absent (warn, never panic, never rerankerless). Default (unset/`heuristic`) byte-identical. `scripts/fetch_embedding_model.sh --cross-encoder` fetches the model.
- docs — measured comparison.

## Head-to-head (identical 100-q LoCoMo subset, only the reranker differs)
| metric | heuristic | cross-encoder | delta |
|---|---|---|---|
| recall@10 | 0.4330 | **0.5483** | +0.115 (+27%) |
| MRR | 0.3775 | **0.5092** | +0.132 (+35%) |
| OpenDomain R@10 | 0.2143 | 0.3571 | +0.143 (+67%) |
| Temporal R@10 | 0.6628 | 0.8372 | +0.174 |
| MultiHop R@10 | 0.2756 | 0.3251 | +0.050 |
| latency p50 | 0.76 s | 6.34 s | 8.3× |

## Honesty
- **Subset, not full-set**: first-10-q/conversation, skewed toward MultiHop/Temporal — the *relative* head-to-head (same questions/pool) is the reliable signal, not the absolute numbers. Full-set cross-encoder (~60–80 min CPU) not run; batched inference or GPU (`cuda`) is future work.
- Opt-in only; default retrieval unchanged. Pure quality/latency trade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)