### PR TITLE
feat(retrieval): PRF pool augmentation — first win on multi-evidence completeness

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -1105,3 +1105,40 @@ the missing evidence into the candidate set: iterative retrieve-until-complete, 
 decomposition into sub-questions that each retrieve their own evidence and union the pools.
 That is a different retrieval loop (multi-query / set-cover), not a scoring change. The MMR
 branch was abandoned (off-by-default feature, no measured benefit; nothing merged).
+
+## PRF pool augmentation: gathering missing multi-evidence (2026-07-16)
+
+The MMR negative result (#83) showed the multi-evidence problem is pool ABSENCE, not
+misranking — no reordering can surface evidence that first-stage retrieval never pooled.
+The fix must GATHER the missing evidence into the candidate set. Pseudo-relevance
+feedback (PRF, opt-in `SYNAPTIC_RETRIEVAL_PRF=1`; default off): after the first retrieval,
+mine the top-`prf_top_m` turns for salient terms not in the query, expand the query with
+them, retrieve once more, and union into the candidate pool — then the existing
+over-fetch reranker ranks the enlarged pool.
+
+**Full-set completeness, PRF on vs off** (the target metric is full@50 = whole evidence
+set in the pool):
+
+| evidence | full@50 off | full@50 PRF | Δ | full@10 off | full@10 PRF |
+|---|---|---|---|---|---|
+| 1 | 0.7575 | 0.7627 | +0.005 | 0.6369 | 0.6440 |
+| 2 | 0.3305 | 0.3933 | **+0.063 (+19%)** | 0.1799 | 0.1883 |
+| 3 | 0.1928 | 0.2651 | **+0.072 (+37%)** | 0.0602 | 0.0723 |
+| 4+ | 0.0000 | 0.0396 | **from ZERO** | 0.0000 | 0.0000 |
+| overall | 0.6438 | 0.6604 | +0.017 | 0.5252 | 0.5323 |
+
+**PRF is the first mechanism this session to attack pool absence, and it works.** It
+raises full@50 (pool coverage) for every multi-evidence bucket — the 4+-evidence bucket
+going 0.000→0.040 is the proof, since those complete evidence sets were provably never in
+the pool under any reranking (MMR, cross-encoder, graph expansion all could not touch
+them). PRF also strictly improves overall partial recall@10 (0.5702→0.5776) and full@10
+(0.5252→0.5323) — no regression.
+
+**Why the full@10 gains lag the full@50 gains:** PRF gets the evidence INTO the pool, but
+it still has to RANK into the top-10 — which is where a stronger reranker compounds (PRF
+gathers, the cross-encoder ranks). The two are complementary levers on the same problem.
+
+**Cost / status:** one extra retrieval round → ~1.8x recall latency (subset p50 0.77s→1.37s),
+so PRF is OPT-IN (default off), like the cross-encoder — enable it for multi-evidence-heavy
+workloads. Measure with `run_eval --completeness` (now concurrent) and
+`SYNAPTIC_RETRIEVAL_PRF=1`.

--- a/src/memory/retrieval/pipeline.rs
+++ b/src/memory/retrieval/pipeline.rs
@@ -15,6 +15,18 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 
+/// Lowercase alphanumeric tokenizer shared by the PRF expansion step.
+/// Splits on any non-alphanumeric boundary and preserves duplicates so
+/// callers can compute term frequency (mirrors the tokenizer used by
+/// [`crate::memory::retrieval::rerank::HeuristicReranker`], which needs only
+/// a term set).
+fn tokenize_terms(text: &str) -> Vec<String> {
+    text.split(|c: char| !c.is_alphanumeric())
+        .filter(|t| !t.is_empty())
+        .map(|t| t.to_lowercase())
+        .collect()
+}
+
 /// Trait for pluggable retrieval strategies
 ///
 /// Implementors provide different retrieval mechanisms that can be
@@ -170,6 +182,31 @@ pub struct PipelineConfig {
     /// `max_per_signal` is effectively capped by what each signal returns.
     #[serde(default = "default_rerank_pool_size")]
     pub rerank_pool_size: usize,
+    /// Enable pseudo-relevance feedback (PRF): after the first retrieval,
+    /// mine salient terms from the top `prf_top_m` fused results, expand the
+    /// query with them, retrieve AGAIN with the expanded query, and union
+    /// the second retrieval's results into the candidate pool (best fused
+    /// score wins per memory). This targets multi-evidence questions whose
+    /// complementary evidence shares little vocabulary with the original
+    /// query but shares vocabulary with the evidence the query DOES surface
+    /// directly — a single query can miss it, but the expanded query can
+    /// pull it into the pool for the reranker to consider. Exactly one PRF
+    /// round runs (bounded, deterministic); it is skipped when no expansion
+    /// terms are found. Default `false` (see [`Self::ENV_PRF`] for an env
+    /// override).
+    #[serde(default = "default_prf_enabled")]
+    pub prf_enabled: bool,
+    /// Number of top fused results (by fused score, ties broken by
+    /// ascending key) mined for PRF expansion terms. Default `5`.
+    #[serde(default = "default_prf_top_m")]
+    pub prf_top_m: usize,
+    /// Number of expansion terms appended to the query for the PRF round,
+    /// chosen by term frequency across the `prf_top_m` seed results
+    /// (descending frequency, ties broken alphabetically). Terms already in
+    /// the original query, shorter than 3 characters, or purely numeric are
+    /// excluded as a crude stopword/noise guard. Default `10`.
+    #[serde(default = "default_prf_terms")]
+    pub prf_terms: usize,
 }
 
 fn default_enable_query_understanding() -> bool {
@@ -182,6 +219,24 @@ fn default_temporal_boost() -> f64 {
 
 fn default_rerank_pool_size() -> usize {
     50
+}
+
+fn default_prf_enabled() -> bool {
+    std::env::var(PipelineConfig::ENV_PRF)
+        .ok()
+        .map(|v| {
+            let v = v.trim().to_lowercase();
+            v == "1" || v == "true"
+        })
+        .unwrap_or(false)
+}
+
+fn default_prf_top_m() -> usize {
+    5
+}
+
+fn default_prf_terms() -> usize {
+    10
 }
 
 impl Default for PipelineConfig {
@@ -204,11 +259,36 @@ impl Default for PipelineConfig {
             enable_query_understanding: default_enable_query_understanding(),
             temporal_boost: default_temporal_boost(),
             rerank_pool_size: default_rerank_pool_size(),
+            prf_enabled: default_prf_enabled(),
+            prf_top_m: default_prf_top_m(),
+            prf_terms: default_prf_terms(),
         }
     }
 }
 
 impl PipelineConfig {
+    /// Environment variable that, when truthy (`1` or `true`, case
+    /// insensitive), enables PRF by default (see [`Self::prf_enabled`]).
+    pub const ENV_PRF: &'static str = "SYNAPTIC_RETRIEVAL_PRF";
+
+    /// Builder method to enable/disable pseudo-relevance feedback.
+    pub fn with_prf_enabled(mut self, enabled: bool) -> Self {
+        self.prf_enabled = enabled;
+        self
+    }
+
+    /// Builder method to set the number of top seed results mined for PRF
+    /// expansion terms.
+    pub fn with_prf_top_m(mut self, prf_top_m: usize) -> Self {
+        self.prf_top_m = prf_top_m;
+        self
+    }
+
+    /// Builder method to set the number of PRF expansion terms.
+    pub fn with_prf_terms(mut self, prf_terms: usize) -> Self {
+        self.prf_terms = prf_terms;
+        self
+    }
     /// Create a configuration optimized for semantic search
     pub fn semantic_focus() -> Self {
         let mut config = Self::default();
@@ -465,6 +545,13 @@ impl HybridRetriever {
             unioned
         };
 
+        // Pseudo-relevance feedback (PRF): mine salient terms from the top
+        // fused results, retrieve again with the expanded query, and union
+        // the second retrieval into the pool. Off by default; a no-op when
+        // disabled or when `fused` is empty, so behaviour is byte-identical
+        // to the pre-PRF pipeline unless explicitly enabled.
+        let fused = self.apply_prf(query, pool, fused).await?;
+
         // Apply the composite relevance × recency × importance score
         // (see `CompositeWeights`).
         let composite = self.apply_composite_scoring(fused).await?;
@@ -666,6 +753,98 @@ impl HybridRetriever {
             .take(limit)
             .map(|(memory, rrf, _raw)| (memory, rrf))
             .collect())
+    }
+
+    /// Pseudo-relevance feedback: one bounded expansion round.
+    ///
+    /// When `config.prf_enabled` is set and `fused` is non-empty, mines the
+    /// top `prf_top_m` fused results (by fused score, ties broken by
+    /// ascending key) for their most frequent terms (excluding terms already
+    /// in the original query, terms shorter than 3 characters, and purely
+    /// numeric terms), takes the top `prf_terms` by frequency (ties broken
+    /// alphabetically), and — if any expansion terms were found — retrieves
+    /// again with `"{query} {expansion_terms}"`, unioning the result into
+    /// `fused` with each memory's best (max) fused score. Returns `fused`
+    /// unchanged when PRF is disabled, `fused` is empty, or no expansion
+    /// terms are found.
+    async fn apply_prf(
+        &self,
+        query: &str,
+        pool: usize,
+        mut fused: Vec<(MemoryFragment, f64)>,
+    ) -> Result<Vec<(MemoryFragment, f64)>> {
+        if !self.config.prf_enabled || fused.is_empty() {
+            return Ok(fused);
+        }
+
+        // Deterministic top-M seed set: fused score descending, ties broken
+        // by ascending key.
+        let mut ranked: Vec<&(MemoryFragment, f64)> = fused.iter().collect();
+        ranked.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.0.entry.key.cmp(&b.0.entry.key))
+        });
+
+        let query_terms: std::collections::HashSet<String> =
+            tokenize_terms(query).into_iter().collect();
+
+        let mut term_freq: HashMap<String, usize> = HashMap::new();
+        for (memory, _) in ranked.into_iter().take(self.config.prf_top_m) {
+            for term in tokenize_terms(&memory.entry.value) {
+                if term.len() < 3
+                    || query_terms.contains(&term)
+                    || term.chars().all(|c| c.is_ascii_digit())
+                {
+                    continue;
+                }
+                *term_freq.entry(term).or_insert(0) += 1;
+            }
+        }
+
+        let mut ranked_terms: Vec<(String, usize)> = term_freq.into_iter().collect();
+        ranked_terms.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        let expansion_terms: Vec<String> = ranked_terms
+            .into_iter()
+            .take(self.config.prf_terms)
+            .map(|(term, _)| term)
+            .collect();
+
+        if expansion_terms.is_empty() {
+            return Ok(fused);
+        }
+
+        let expanded_query = format!("{query} {}", expansion_terms.join(" "));
+        tracing::debug!(
+            expanded_query = %expanded_query,
+            expansion_terms = expansion_terms.len(),
+            "PRF expansion applied"
+        );
+
+        let expanded_fused = self.collect_and_fuse(&expanded_query, pool).await?;
+
+        let mut best: HashMap<String, (MemoryFragment, f64)> = HashMap::new();
+        for (memory, score) in fused.drain(..).chain(expanded_fused) {
+            match best.entry(memory.entry.key.clone()) {
+                std::collections::hash_map::Entry::Occupied(mut e) => {
+                    if score > e.get().1 {
+                        e.get_mut().1 = score;
+                    }
+                }
+                std::collections::hash_map::Entry::Vacant(e) => {
+                    e.insert((memory, score));
+                }
+            }
+        }
+
+        let mut unioned: Vec<(MemoryFragment, f64)> = best.into_values().collect();
+        unioned.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.0.entry.key.cmp(&b.0.entry.key))
+        });
+        unioned.truncate(pool);
+        Ok(unioned)
     }
 
     /// Apply the composite relevance × recency × importance score after

--- a/tests/prf_retrieval_tests.rs
+++ b/tests/prf_retrieval_tests.rs
@@ -1,0 +1,180 @@
+//! Tests for pseudo-relevance feedback (PRF) query expansion.
+//!
+//! Multi-evidence questions often fail because their complete evidence set
+//! is not in the retrieved candidate pool at all: a single query surfaces
+//! the turn most similar to the query but misses complementary evidence
+//! that shares little vocabulary with the query itself. PRF mines salient
+//! terms from the top results of the FIRST retrieval, expands the query
+//! with them, retrieves AGAIN, and unions the second retrieval into the
+//! pool — this can pull in evidence the first query alone could not reach.
+
+// Test code: unwrap/panic on failure is the intended behaviour.
+#![allow(clippy::unwrap_used, clippy::panic)]
+
+use async_trait::async_trait;
+use std::sync::Arc;
+use synaptic::error::Result;
+use synaptic::memory::retrieval::pipeline::{
+    HybridRetriever, PipelineConfig, RetrievalPipeline, RetrievalSignal, ScoredMemory,
+};
+use synaptic::memory::types::{MemoryEntry, MemoryFragment, MemoryType};
+
+/// A deterministic stub pipeline whose per-query score for each candidate is
+/// the fraction of the QUERY's tokens found in the candidate's content
+/// (case-insensitive, alphanumeric tokenization). This lets a test control
+/// exactly which candidates the pipeline "finds" for a given query string,
+/// so PRF's second (expanded) query can surface a candidate the first query
+/// could not.
+struct QueryAwarePipeline {
+    candidates: Vec<(&'static str, &'static str)>,
+}
+
+fn tokenize(text: &str) -> std::collections::HashSet<String> {
+    text.split(|c: char| !c.is_alphanumeric())
+        .filter(|t| !t.is_empty())
+        .map(|t| t.to_lowercase())
+        .collect()
+}
+
+#[async_trait]
+impl RetrievalPipeline for QueryAwarePipeline {
+    async fn search(
+        &self,
+        query: &str,
+        limit: usize,
+        _config: Option<&PipelineConfig>,
+    ) -> Result<Vec<ScoredMemory>> {
+        let query_terms = tokenize(query);
+        let mut results = Vec::new();
+        for (key, content) in &self.candidates {
+            let content_terms = tokenize(content);
+            let hits = query_terms
+                .iter()
+                .filter(|t| content_terms.contains(*t))
+                .count();
+            let score = if query_terms.is_empty() {
+                0.0
+            } else {
+                hits as f64 / query_terms.len() as f64
+            };
+            let entry =
+                MemoryEntry::new(key.to_string(), content.to_string(), MemoryType::LongTerm);
+            let fragment = MemoryFragment::new(entry, score);
+            results.push(ScoredMemory::new(
+                fragment,
+                score,
+                RetrievalSignal::DenseVector,
+            ));
+        }
+        results.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.memory.entry.key.cmp(&b.memory.entry.key))
+        });
+        results.truncate(limit);
+        Ok(results)
+    }
+
+    fn name(&self) -> &'static str {
+        "query-aware-stub"
+    }
+
+    fn signal_type(&self) -> RetrievalSignal {
+        RetrievalSignal::DenseVector
+    }
+}
+
+/// The query is "alpha beta shared". `mem_a` matches all three query terms
+/// AND contains a distinctive term ("zzzdistinct", repeated so it is the
+/// clear top PRF expansion term). `mem_gold_b` shares NO terms with the
+/// original query at all — it shares only "zzzdistinct" with `mem_a` — so a
+/// single-query retrieval cannot find it (its raw score is 0.0, below
+/// `min_score`, and RRF fusion filters it out entirely). PRF should mine
+/// "zzzdistinct" out of `mem_a` (the top seed result), expand the query with
+/// it, retrieve again, and pull `mem_gold_b` into the pool.
+fn build_retriever(prf_enabled: bool) -> HybridRetriever {
+    let pipeline = Arc::new(QueryAwarePipeline {
+        candidates: vec![
+            ("mem_a", "alpha beta zzzdistinct zzzdistinct shared"),
+            ("mem_gold_b", "zzzdistinct completely unrelated payload"),
+            ("mem_noise_1", "totally unrelated filler content one"),
+            ("mem_noise_2", "totally unrelated filler content two"),
+        ],
+    });
+
+    let config = PipelineConfig::default()
+        .with_prf_enabled(prf_enabled)
+        .with_prf_top_m(1)
+        .with_prf_terms(1);
+
+    HybridRetriever::new(config).add_pipeline(pipeline)
+}
+
+#[tokio::test]
+async fn prf_disabled_misses_complementary_evidence() {
+    let retriever = build_retriever(false);
+    let results = retriever.search("alpha beta shared", 10).await.unwrap();
+
+    assert!(
+        results.iter().any(|f| f.entry.key == "mem_a"),
+        "the directly-matching turn must still be found"
+    );
+    assert!(
+        !results.iter().any(|f| f.entry.key == "mem_gold_b"),
+        "without PRF, evidence sharing no terms with the query must be absent"
+    );
+}
+
+#[tokio::test]
+async fn prf_enabled_pulls_in_complementary_evidence() {
+    let retriever = build_retriever(true);
+    let results = retriever.search("alpha beta shared", 10).await.unwrap();
+
+    assert!(
+        results.iter().any(|f| f.entry.key == "mem_a"),
+        "the directly-matching turn must still be found"
+    );
+    assert!(
+        results.iter().any(|f| f.entry.key == "mem_gold_b"),
+        "PRF must expand the query with a term mined from the top seed \
+         result and pull complementary evidence into the pool"
+    );
+}
+
+/// With PRF disabled, behaviour must be identical to the pre-PRF pipeline:
+/// running the same query/limit twice yields the exact same ordered result.
+#[tokio::test]
+async fn prf_disabled_is_a_no_op() {
+    let retriever = build_retriever(false);
+    let first = retriever.search("alpha beta shared", 10).await.unwrap();
+    let second = retriever.search("alpha beta shared", 10).await.unwrap();
+
+    let first_keys: Vec<_> = first.iter().map(|f| f.entry.key.clone()).collect();
+    let second_keys: Vec<_> = second.iter().map(|f| f.entry.key.clone()).collect();
+    assert_eq!(
+        first_keys, second_keys,
+        "no-op PRF must be deterministic/identical"
+    );
+    assert_eq!(
+        first_keys,
+        vec!["mem_a"],
+        "PRF disabled must match the pre-PRF single-query result set \
+         (noise/gold candidates score 0.0 against this query and are \
+         filtered by min_score)"
+    );
+}
+
+/// PRF is disabled by default (no env override), so `PipelineConfig::default()`
+/// must be a byte-identical no-op relative to a pre-PRF baseline config.
+#[test]
+fn prf_default_is_disabled() {
+    // SAFETY: no other test in this process reads/writes this variable
+    // concurrently as part of its assertions; this only guards against a
+    // developer's local shell exporting SYNAPTIC_RETRIEVAL_PRF.
+    std::env::remove_var(PipelineConfig::ENV_PRF);
+    let config = PipelineConfig::default();
+    assert!(!config.prf_enabled);
+    assert_eq!(config.prf_top_m, 5);
+    assert_eq!(config.prf_terms, 10);
+}

--- a/tools/eval/src/bin/run_eval.rs
+++ b/tools/eval/src/bin/run_eval.rs
@@ -291,45 +291,67 @@ async fn main() -> Result<(), String> {
     run_growth_and_qa(&conversations, grow_100k, &mut w).await
 }
 
-/// Measure STRICT full-evidence recall (`--completeness`): per question, does
-/// the top-k contain ALL of its evidence turns (full), and what fraction (partial)?
+/// Per-question completeness record: `(evidence_count, partial@10, full@10, full@50)`.
+type CompletenessRec = (usize, f64, usize, usize);
+
+/// Completeness records for one conversation. `full@10` uses a PRODUCTION
+/// limit-10 search (so any final-stage selection like MMR / iterative expansion
+/// is exercised); `full@50` uses a limit-50 search (the candidate-pool ceiling).
+async fn completeness_one_conversation(
+    conversation: EvalConversation,
+) -> Result<Vec<CompletenessRec>, String> {
+    let mut memory = AgentMemory::new(MemoryConfig::default())
+        .await
+        .map_err(|e| e.to_string())?;
+    runner::ingest(&conversation, &mut memory)
+        .await
+        .map_err(|e| e.to_string())?;
+    let mut recs = Vec::new();
+    for question in &conversation.questions {
+        let n_ev = question.evidence_ids.len();
+        if n_ev == 0 {
+            continue;
+        }
+        let prod = runner::run_question(question, &memory, 10)
+            .await
+            .map_err(|e| e.to_string())?;
+        let pool = runner::run_question(question, &memory, 50)
+            .await
+            .map_err(|e| e.to_string())?;
+        let relevant: HashSet<&String> = question.evidence_ids.iter().collect();
+        let top10: HashSet<&String> = prod.retrieved_ids.iter().take(10).collect();
+        let top50: HashSet<&String> = pool.retrieved_ids.iter().take(50).collect();
+        let hits10 = relevant.iter().filter(|e| top10.contains(*e)).count();
+        let full10 = usize::from(hits10 == n_ev);
+        let full50 = usize::from(relevant.iter().all(|e| top50.contains(*e)));
+        let partial10 = hits10 as f64 / n_ev as f64;
+        recs.push((n_ev, partial10, full10, full50));
+    }
+    Ok(recs)
+}
+
+/// Measure STRICT full-evidence recall (`--completeness`): does the top-k contain
+/// ALL of a question's evidence turns (full), and what fraction (partial)?
 /// Bucketed by evidence-count so multi-evidence undersupply is visible. One
-/// limit-50 search per question; no judge. `full@k` = every evidence id present
-/// in the first k; `partial@k` = mean fraction of evidence ids present.
+/// concurrent task per conversation; no judge.
 async fn run_completeness(
     conversations: &[EvalConversation],
     w: &mut impl FnMut(String) -> Result<(), String>,
 ) -> Result<(), String> {
-    const KMAX: usize = 50;
     // bucket key by evidence count: 1, 2, 3, "4+". Value: (n, partial@10 sum,
     // full@10 count, full@50 count).
     let mut buckets: std::collections::BTreeMap<String, (usize, f64, usize, usize)> =
         std::collections::BTreeMap::new();
     let mut overall = (0usize, 0.0f64, 0usize, 0usize);
 
-    for conversation in conversations {
-        let mut memory = AgentMemory::new(MemoryConfig::default())
-            .await
-            .map_err(|e| e.to_string())?;
-        runner::ingest(conversation, &mut memory)
-            .await
-            .map_err(|e| e.to_string())?;
-        for question in &conversation.questions {
-            let n_ev = question.evidence_ids.len();
-            if n_ev == 0 {
-                continue;
-            }
-            let outcome = runner::run_question(question, &memory, KMAX)
-                .await
-                .map_err(|e| e.to_string())?;
-            let relevant: HashSet<&String> = question.evidence_ids.iter().collect();
-            let top10: HashSet<&String> = outcome.retrieved_ids.iter().take(10).collect();
-            let top50: HashSet<&String> = outcome.retrieved_ids.iter().take(50).collect();
-            let hits10 = relevant.iter().filter(|e| top10.contains(*e)).count();
-            let full10 = usize::from(hits10 == n_ev);
-            let full50 = usize::from(relevant.iter().all(|e| top50.contains(*e)));
-            let partial10 = hits10 as f64 / n_ev as f64;
-
+    let handles: Vec<_> = conversations
+        .iter()
+        .cloned()
+        .map(|c| tokio::spawn(completeness_one_conversation(c)))
+        .collect();
+    for handle in handles {
+        let recs = handle.await.map_err(|e| e.to_string())??;
+        for (n_ev, partial10, full10, full50) in recs {
             let key = if n_ev >= 4 {
                 "4+".to_string()
             } else {


### PR DESCRIPTION
## Summary
The MMR negative result (#83) proved the multi-evidence problem is pool ABSENCE (missing evidence isn't in the pool, so no reordering can surface it). This gathers it in: pseudo-relevance feedback (PRF, opt-in `SYNAPTIC_RETRIEVAL_PRF=1`, default off) mines terms from the top retrieved turns, expands the query, retrieves again, and unions into the pool.

Also makes `--completeness` concurrent (full set now runs in ~7 min) + full@10 from a production limit-10 search.

## Result — full-set completeness, PRF on vs off (target = full@50, pool coverage)
| evidence | full@50 off | full@50 PRF | Δ |
|---|---|---|---|
| 2 | 0.331 | 0.393 | +0.063 (+19%) |
| 3 | 0.193 | 0.265 | +0.072 (+37%) |
| **4+** | **0.000** | **0.040** | **from zero** |
| overall | 0.644 | 0.660 | +0.017 |

**First mechanism this session to move pool absence.** The 4+-evidence bucket 0.000→0.040 is the proof — those complete sets were never poolable by any reranking. Also strictly improves overall partial recall@10 (0.570→0.578) and full@10 (0.525→0.532); no regression.

full@10 gains lag full@50 because the newly-pooled evidence still has to RANK into the top-10 — where the cross-encoder compounds (PRF gathers, cross-encoder ranks; complementary levers).

## Cost / status
One extra retrieval round → ~1.8x recall latency (subset p50 0.77s→1.37s), so PRF is opt-in (default off), like the cross-encoder. Reviewed MERGEABLE: no-op when off (byte-identical), deterministic union, bounded, env-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)