### PR TITLE
feat(eval): citation-support verification + codex retry + README refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,27 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 An AI agent memory system in Rust: key/value memory with a knowledge graph,
-vector embeddings, hybrid (keyword + semantic) retrieval, temporal tracking,
-and optional feature-gated security primitives.
+vector embeddings, and a multi-stage retrieval pipeline — hybrid
+(keyword + semantic) retrieval with RRF fusion, over-fetch reranking,
+pseudo-relevance-feedback (PRF) pool augmentation, and an optional GPU
+cross-encoder reranker — plus temporal tracking and optional feature-gated
+security primitives.
+
+Retrieval quality and end-to-end answer accuracy are measured on the LoCoMo
+long-term-memory benchmark (real dataset, real numbers, honest caveats) — see
+[docs/evaluation.md](docs/evaluation.md). Highlights (full 1,986-question set
+unless noted): retrieval recall@10 **0.61** (best config), and an **agentic
+answer-guided retrieval** eval mode that lifts end-to-end QA accuracy to
+**0.50** on a labelled subset (a codex-CLI judge; see caveats) while abstaining
+("I don't know") rather than confabulating when the evidence is absent — a
+faithfulness property measured explicitly.
 
 This is a development library (version 0.2.0, not published to crates.io).
 The table below states honestly which parts are stable, which are beta, and
 which are experimental. There are no simulated or fake fallback code paths:
 features that are not really implemented return errors (fail closed) instead
-of pretending to work.
+of pretending to work. No quality/performance number appears here that is not
+backed by a measured run in [docs/evaluation.md](docs/evaluation.md).
 
 ## Module Maturity
 
@@ -21,7 +34,8 @@ of pretending to work.
 | Storage backends | stable | Memory, file (Sled); SQL (PostgreSQL) behind `sql-storage` |
 | Knowledge graph | stable | Node merging, relationship detection, traversal; tested |
 | Embeddings | stable | Deterministic local embeddings; used by hybrid retrieval |
-| Search / hybrid retrieval | beta | Tokenized keyword + vector search fused with Reciprocal Rank Fusion (RRF); HNSW ANN index used for related-memory counting |
+| Search / hybrid retrieval | beta | Tokenized keyword + vector + graph + temporal retrievers fused with Reciprocal Rank Fusion (RRF), composite scoring, and a deterministic reranker over an over-fetched candidate pool. Optional: PRF pool augmentation (`SYNAPTIC_RETRIEVAL_PRF`), multi-hop graph expansion, semantic embeddings (`static-embeddings` / `ml-models` / Ollama), and a candle BERT cross-encoder reranker (`reranker-model`, GPU via `cuda`). Measured on LoCoMo — see [docs/evaluation.md](docs/evaluation.md) |
+| Evaluation harness (`tools/eval`) | beta | Real LoCoMo/LongMemEval loaders; retrieval metrics (recall/precision/MRR, `--recall-curve`, `--completeness`), memory-growth, and LLM-gated end-to-end QA (`--qa-only`, `--agentic-qa`) with abstention/faithfulness metrics. Every printed number is a real run; QA is gated on a configured judge, never fabricated |
 | Checkpoint / restore | beta | Non-destructive restore (snapshot-validate-swap); tested |
 | Analytics | beta | Basic behavioral/performance analytics behind `analytics` |
 | Security: auth (`security`) | beta | Real argon2 password hashing, TOTP MFA, constant-time API key comparison (`subtle`), deny-by-default policy engine, zeroized keys. Opt-in feature flag |
@@ -87,23 +101,62 @@ Security features are **opt-in** and gated:
 - `zero-knowledge-proofs` — Poseidon + Groth16 proofs
 - `homomorphic-encryption` — TFHE FheInt64 (sum/average only; other encrypted ops fail closed)
 
+Retrieval-quality features (opt-in; the default build stays lean and offline
+with a lexical/TF-IDF embedder):
+
+- `static-embeddings` — fast pure-Rust model2vec static embeddings (best
+  speed/quality default; fetch the model with `scripts/fetch_embedding_model.sh --potion`)
+- `ml-models` — candle transformer embeddings (MiniLM); heavier, CPU-slow
+- `reranker-model` — candle BERT cross-encoder reranker (ms-marco-MiniLM);
+  strongest ranking, opt-in (`SYNAPTIC_RERANKER=cross-encoder`), GPU-recommended
+- `cuda` — candle CUDA backend so `ml-models`/`reranker-model` run on a GPU
+
 Other optional features: `sql-storage`, `multimodal`, `external-integrations`,
 `cross-platform`, `observability`, and `distributed-experimental` (explicitly
 experimental, see maturity table). Convenience groups: `full`, `full-experimental`, `minimal`.
 
-## Performance
+## Performance & Evaluation
 
-Measured benchmark results (with methodology and caveats) live in
-[docs/performance.md](docs/performance.md). Retrieval-quality evaluation on
-the LoCoMo long-term-memory benchmark — recall/precision/MRR, latency, memory
-growth, and a per-capability ablation — lives in
+Measured micro-benchmarks (with methodology and caveats) live in
+[docs/performance.md](docs/performance.md). The full retrieval-quality and
+end-to-end QA evaluation on the **LoCoMo** long-term-memory benchmark lives in
 [docs/evaluation.md](docs/evaluation.md). No other performance or quality
 numbers in this repository should be treated as validated.
+
+Headline measured results (see the doc for methodology and the many caveats):
+
+| metric | value | notes |
+|---|---|---|
+| retrieval recall@10 (full 1,986-q set) | 0.5237 → **0.6104** | baseline → best config (over-fetch + embedding rerank + cross-encoder) |
+| MultiHop recall@10 | 0.2475 → **0.3739** | +51%, via ranking (not graph connectivity) |
+| search latency p50 | **~0.46–0.76 s** | after a 9.5× pipeline-latency fix |
+| end-to-end QA accuracy (40-q subset, codex judge) | 0.375 → **0.50** | single-shot → agentic answer-guided retrieval |
+| faithfulness: abstains on unanswerable q | **~90%** | agentic + grounding; confabulates rather than guesses only ~10% |
+
+Run the harness (LLM-free retrieval metrics need no judge):
+
+```bash
+cargo build --release -p synaptic-eval --bin run_eval --features synaptic/static-embeddings
+SYNAPTIC_RETRIEVAL_EMBEDDER=static SYNAPTIC_STATIC_MODEL_DIR=models/potion-base-8M \
+  ./target/release/run_eval tools/eval/data/locomo10.json --retrieval-only
+```
+
+End-to-end QA (`--qa-only` / `--agentic-qa`) requires a configured judge
+(`SYNAPTIC_EVAL_JUDGE=codex` with the `codex` CLI, or an OpenAI-compatible
+endpoint); without one, QA is reported as not-run — never fabricated. The
+GPU cross-encoder and agentic modes are documented in `docs/evaluation.md`.
+
+**Honesty note:** QA accuracy is measured on labelled subsets (the full
+1,986-question judge run is bounded by sequential judge latency) and the codex
+judge is nondeterministic (~±0.03); the headline deltas are far beyond that
+noise. Retrieval metrics are full-set. Weight-tuned settings (reranker weights,
+PRF) are tuned on LoCoMo and may not transfer; the structural over-fetch fix
+does.
 
 ## Testing
 
 ```bash
-cargo test --lib                                   # library unit tests (440+)
+cargo test --lib                                   # library unit tests (465+)
 cargo test                                          # default-feature test suite
 cargo test --features "security test-utils"        # include security suites
 ```

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -1327,3 +1327,39 @@ citation), which citation-*existence* cannot catch. True enforced grounding need
 citation-*support* verification (does the cited memory entail the answer? — an entailment
 check), a natural follow-up. As shipped, grounding is a strong opt-in faithfulness lever:
 prompt-required citations move agentic confabulation from ~22% toward single-shot's ~6%.
+
+## Citation-support verification + honest limits of structural grounding (2026-07-17)
+
+Structural grounding (#89) overrode answers with NO valid citation, but couldn't catch a
+HALLUCINATED-but-valid citation (a real in-context memory that doesn't actually support the
+answer). Added an entailment check (opt-in `SYNAPTIC_EVAL_GROUND_VERIFY=1`): after a grounded
+answer with a valid citation, ask the judge whether the cited memory actually supports the
+answer; if not, override to "I don't know" (`support_overrides` counted). Also hardened the
+codex judge to RETRY transient upstream errors (model-at-capacity / rate limits) with backoff
+so a single blip no longer aborts a whole eval run.
+
+**Measured (agentic + PRF + grounding + verify, codex judge):**
+
+| | grounded only | grounded + verify |
+|---|---|---|
+| abstention confabulation | ~10% | ~7% (within noise) |
+| `support_overrides` (abstention 30q) | — | **0** |
+| answerable accuracy (20q) | 0.55 | 0.45 (within noise) |
+| `support_overrides` (answerable 20q) | — | **1** |
+| over_abstention | 0 | 0 |
+
+**Honest finding: the structural override gates are nearly INERT on LoCoMo.** Both
+`ungrounded_overrides` (citation existence, #89) and `support_overrides` (citation support,
+this change) fire ~0-1 times per 30-50 questions. The faithfulness improvements this whole
+sub-arc (agentic 100% → ~10% confabulation on unanswerable questions) came from the PROMPT —
+asking the model to cite/verify makes it reason about grounding and abstain honestly, rather
+than producing catchable violations. The residual confabulations cite plausible-looking
+memories the verify-judge accepts, so citation-support verification does not measurably reduce
+them here. The entailment check is a CORRECT, fail-closed safety layer (off by default) that
+would matter more for models/datasets that hallucinate unsupporting citations at higher rates
+— but on LoCoMo, prompt-level grounding is what does the work, and verification adds an extra
+judge call for ~no measured benefit. Kept as opt-in; not recommended by default.
+
+The codex-retry hardening, by contrast, is unconditionally useful: transient "model at
+capacity" errors were aborting whole runs, and retry-with-backoff makes the QA/agentic
+measurements robust to upstream flakiness.

--- a/tools/eval/src/bin/run_eval.rs
+++ b/tools/eval/src/bin/run_eval.rs
@@ -553,12 +553,21 @@ async fn run_agentic_qa_only(
     }
     let max_rounds = qa::agentic_max_rounds();
     let grounded = qa::grounded_enabled();
-    let report = qa::run_agentic_qa(conversations, &judge, K, max_rounds, grounded)
-        .await
-        .map_err(|e| e.to_string())?;
+    let ground_verify = qa::ground_verify_enabled();
+    let report = qa::run_agentic_qa(
+        conversations,
+        &judge,
+        K,
+        max_rounds,
+        grounded,
+        ground_verify,
+    )
+    .await
+    .map_err(|e| e.to_string())?;
     w(format!(
         "QA: graded={} correct={} accuracy={:.4} max_rounds={} mean_rounds_used={:.2} \
-         gold_added_by_followup_fraction={:.4} grounded={} ungrounded_overrides={}",
+         gold_added_by_followup_fraction={:.4} grounded={} ungrounded_overrides={} \
+         ground_verify={} support_overrides={}",
         report.questions,
         report.correct,
         report.accuracy,
@@ -566,7 +575,9 @@ async fn run_agentic_qa_only(
         report.mean_rounds_used,
         report.gold_added_by_followup_fraction,
         report.grounded,
-        report.ungrounded_overrides
+        report.ungrounded_overrides,
+        report.ground_verify,
+        report.support_overrides
     ))?;
     for (qtype, b) in &report.by_qtype {
         w(format!(

--- a/tools/eval/src/qa.rs
+++ b/tools/eval/src/qa.rs
@@ -868,6 +868,31 @@ impl CodexCliJudge {
     /// Runs on a blocking thread; enforces the timeout via the coreutils
     /// `timeout` wrapper (exit 124 → timeout error).
     async fn run_codex(&self, prompt: String) -> Result<String, QaError> {
+        // Transient upstream errors ("model at capacity", rate limits) are
+        // retried with backoff so a single blip does not abort a whole eval
+        // run. Non-transient errors (bad exit, timeout) fail immediately.
+        const MAX_ATTEMPTS: usize = 4;
+        let mut last_err = QaError::Judge("codex exec produced no result".to_string());
+        for attempt in 0..MAX_ATTEMPTS {
+            match self.run_codex_once(prompt.clone()).await {
+                Ok(out) => return Ok(out),
+                Err((e, transient)) => {
+                    last_err = e;
+                    if !transient || attempt + 1 == MAX_ATTEMPTS {
+                        return Err(last_err);
+                    }
+                    // Backoff: 2s, 4s, 8s.
+                    let backoff = 2u64 << attempt;
+                    tokio::time::sleep(std::time::Duration::from_secs(backoff)).await;
+                }
+            }
+        }
+        Err(last_err)
+    }
+
+    /// One `codex exec` attempt. The `bool` in the error is `true` when the
+    /// failure looks transient (upstream capacity / rate limit) and worth a retry.
+    async fn run_codex_once(&self, prompt: String) -> Result<String, (QaError, bool)> {
         let bin = self.bin.clone();
         let secs = self.timeout_secs;
         let output = tokio::task::spawn_blocking(move || {
@@ -879,22 +904,34 @@ impl CodexCliJudge {
                 .output()
         })
         .await
-        .map_err(|e| QaError::Judge(format!("codex task join failed: {e}")))?
-        .map_err(|e| QaError::Judge(format!("failed to spawn codex CLI: {e}")))?;
+        .map_err(|e| (QaError::Judge(format!("codex task join failed: {e}")), false))?
+        .map_err(|e| (QaError::Judge(format!("failed to spawn codex CLI: {e}")), false))?;
 
         if output.status.code() == Some(124) {
-            return Err(QaError::Judge(format!(
-                "codex exec timed out after {secs}s"
-            )));
+            return Err((
+                QaError::Judge(format!("codex exec timed out after {secs}s")),
+                false,
+            ));
         }
         if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            let tail: String = stderr.chars().rev().take(400).collect::<String>();
+            let combined = format!(
+                "{}{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            let lower = combined.to_lowercase();
+            let transient = lower.contains("at capacity")
+                || lower.contains("try a different model")
+                || lower.contains("rate limit")
+                || lower.contains("429")
+                || lower.contains("503")
+                || lower.contains("overloaded");
+            let tail: String = combined.chars().rev().take(400).collect::<String>();
             let tail: String = tail.chars().rev().collect();
-            return Err(QaError::Judge(format!(
-                "codex exec exited with {}: {tail}",
-                output.status
-            )));
+            return Err((
+                QaError::Judge(format!("codex exec exited with {}: {tail}", output.status)),
+                transient,
+            ));
         }
         Ok(String::from_utf8_lossy(&output.stdout).into_owned())
     }

--- a/tools/eval/src/qa.rs
+++ b/tools/eval/src/qa.rs
@@ -910,6 +910,47 @@ impl CodexCliJudge {
         parse_codex_stdout(&stdout)
             .ok_or_else(|| QaError::Judge("codex exec produced no parseable output".to_string()))
     }
+
+    /// Citation-support verification (see [`ENV_GROUND_VERIFY`]): ask whether
+    /// `cited_memories` — the content of the memories the judge cited as
+    /// support for `answer` — actually support that answer. Fail-closed: a
+    /// spawn/timeout/exit error propagates as `Err` rather than being treated
+    /// as "supported"; callers must never assume support on a judge error.
+    pub async fn verify_support(
+        &self,
+        answer: &str,
+        cited_memories: &[String],
+    ) -> Result<bool, QaError> {
+        let prompt = build_verify_support_prompt(answer, cited_memories);
+        let stdout = self.run_codex(prompt).await?;
+        parse_grade_verdict(&stdout).ok_or_else(|| {
+            QaError::Judge(format!(
+                "unparseable YES/NO support verdict from codex: {:?}",
+                stdout.trim()
+            ))
+        })
+    }
+}
+
+/// Build the prompt for [`CodexCliJudge::verify_support`]: the cited
+/// memories' content and the answer they were cited to support, asking the
+/// judge for a strict YES/NO on whether the memories directly support the
+/// answer.
+fn build_verify_support_prompt(answer: &str, cited_memories: &[String]) -> String {
+    let memories = if cited_memories.is_empty() {
+        "(no cited memories)".to_string()
+    } else {
+        cited_memories
+            .iter()
+            .enumerate()
+            .map(|(i, m)| format!("[{}] {m}", i + 1))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    format!(
+        "Here are memories:\n{memories}\n\nAnswer: {answer}\n\nDo these memories \
+         directly support that answer? Reply exactly YES or NO."
+    )
 }
 
 #[async_trait::async_trait]
@@ -1008,6 +1049,36 @@ pub fn grounded_enabled() -> bool {
     }
 }
 
+/// Env var enabling CITATION-SUPPORT VERIFICATION on top of structural
+/// grounding (default off, byte-identical behavior when unset). Truthy
+/// values (`1`, `true`, matched case-insensitively) turn it on. Structural
+/// grounding ([`ENV_GROUNDED`]) only checks that a cited index is *valid*
+/// (points at a real context memory); it cannot catch a hallucinated-but-
+/// valid citation, where the judge cites a real memory that does not
+/// actually support the answer it gave. When both `ENV_GROUNDED` and this
+/// flag are on, [`run_one_agentic_question`] asks the judge a second,
+/// independent question — [`CodexCliJudge::verify_support`] — for every
+/// grounded answer that survives the citation-validity gate: do the cited
+/// memories actually support this answer? An unsupported verdict overrides
+/// the answer to "I don't know", same as an invalid citation would. This has
+/// no effect unless [`grounded_enabled`] is also true, and costs one extra
+/// `codex exec` call per such answer.
+pub const ENV_GROUND_VERIFY: &str = "SYNAPTIC_EVAL_GROUND_VERIFY";
+
+/// Read [`ENV_GROUND_VERIFY`]: `true` when set to a truthy value
+/// (`1`/`true`, case-insensitive), `false` when unset or anything else.
+/// Default off, so existing grounded runs are unaffected unless the flag is
+/// explicitly set. Has no effect unless [`grounded_enabled`] is also true.
+pub fn ground_verify_enabled() -> bool {
+    match std::env::var(ENV_GROUND_VERIFY) {
+        Ok(v) => {
+            let v = v.trim().to_ascii_lowercase();
+            v == "1" || v == "true"
+        }
+        Err(_) => false,
+    }
+}
+
 /// Extract cited context indices from the tail of an `ANSWER:` reply, e.g.
 /// `"Paris SOURCES: [1, 2]"`, `"Paris SOURCES: [3]"`, `"Paris SOURCES: 1 2"`.
 /// Lenient by design (see module docs on leniency): accepts bracketed or
@@ -1073,6 +1144,26 @@ fn grounding_gate(answer: &str, sources: &[usize], context_len: usize) -> (Strin
         return (answer.to_string(), false);
     }
     if has_valid_citation(sources, context_len) {
+        (answer.to_string(), false)
+    } else {
+        ("I don't know".to_string(), true)
+    }
+}
+
+/// The citation-support verification gate: given a (possibly already-
+/// abstaining) `answer` that already survived [`grounding_gate`] (i.e. it is
+/// either an abstention or carries a valid citation), and whether the judge
+/// confirmed the cited memories actually `supported` that answer, decide the
+/// final answer text and whether an override occurred. Mirrors
+/// [`grounding_gate`]'s shape: already-abstaining answers are never touched,
+/// and a non-abstaining answer the judge found unsupported is overridden to
+/// "I don't know" — a valid-but-hallucinated citation is no better than a
+/// missing one.
+fn verification_gate(answer: &str, supported: bool) -> (String, bool) {
+    if is_abstention(answer) {
+        return (answer.to_string(), false);
+    }
+    if supported {
         (answer.to_string(), false)
     } else {
         ("I don't know".to_string(), true)
@@ -1244,6 +1335,12 @@ pub struct AgenticQuestionRecord {
     /// confident-but-uncited answer to "I don't know" for this question.
     /// Always `false` when grounding is off.
     pub ungrounded_override: bool,
+    /// Whether citation-support verification (see [`ENV_GROUND_VERIFY`])
+    /// overrode a confident, validly-cited-but-unsupported answer to "I
+    /// don't know" for this question. Always `false` when grounding or
+    /// verification is off, or when the grounding gate already overrode
+    /// (or abstained) this answer.
+    pub support_override: bool,
 }
 
 /// Measured agentic QA report.
@@ -1282,6 +1379,14 @@ pub struct AgenticReport {
     /// grounding gate because they had no valid citation into the provided
     /// context. Always `0` when `grounded` is `false`.
     pub ungrounded_overrides: usize,
+    /// Whether citation-support verification (see [`ENV_GROUND_VERIFY`]) was
+    /// enabled for this run. Has no effect unless `grounded` is also `true`.
+    pub ground_verify: bool,
+    /// Count of answers overridden to "I don't know" by citation-support
+    /// verification because the cited memories, though a valid citation,
+    /// were judged not to actually support the answer. Always `0` when
+    /// `ground_verify` is `false` (or `grounded` is `false`).
+    pub support_overrides: usize,
 }
 
 /// The two records produced by [`run_one_agentic_question`] for a single
@@ -1313,6 +1418,7 @@ async fn run_one_agentic_question(
     k: usize,
     max_rounds: usize,
     grounded: bool,
+    ground_verify: bool,
 ) -> Result<AgenticQuestionOutcome, QaError> {
     let seed_fragments = memory.search(&question.text, k).await.map_err(mem_err)?;
     let seed_keys: Vec<String> = seed_fragments.iter().map(|f| f.entry.key.clone()).collect();
@@ -1381,12 +1487,38 @@ async fn run_one_agentic_question(
     // actually in the provided context — override it to "I don't know"
     // rather than grade a fabricated answer as-is. See `grounding_gate` and
     // `parse_sources` for the (deliberately lenient) parsing rules.
+    let (text, sources) = if grounded {
+        split_answer_and_sources(&raw_answer)
+    } else {
+        (raw_answer, Vec::new())
+    };
     let (predicted, ungrounded_override) = if grounded {
-        let (text, sources) = split_answer_and_sources(&raw_answer);
         grounding_gate(&text, &sources, context.len())
     } else {
-        (raw_answer, false)
+        (text, false)
     };
+
+    // Citation-support verification (only when both grounding and
+    // verification are enabled, and only for answers that survived the
+    // grounding gate unchanged — i.e. already-abstaining answers or answers
+    // with a valid citation): ask the judge whether the CITED memories
+    // actually support the answer, and override to "I don't know" if not.
+    // This is what catches a hallucinated-but-valid citation that
+    // `grounding_gate` alone cannot (it only checks citation *validity*, not
+    // whether the citation actually supports the claim). See
+    // `verification_gate` and `CodexCliJudge::verify_support`.
+    let (predicted, support_override) =
+        if grounded && ground_verify && !ungrounded_override && !is_abstention(&predicted) {
+            let cited_contents: Vec<String> = sources
+                .iter()
+                .filter(|&&n| n >= 1 && n <= context.len())
+                .map(|&n| context[n - 1].1.clone())
+                .collect();
+            let supported = judge.verify_support(&predicted, &cited_contents).await?;
+            verification_gate(&predicted, supported)
+        } else {
+            (predicted, false)
+        };
 
     let correct = judge
         .grade(&question.text, &question.gold_answer, &predicted)
@@ -1414,6 +1546,7 @@ async fn run_one_agentic_question(
             has_gold,
             abstained,
             ungrounded_override,
+            support_override,
         },
         cross_tab: QaQuestionRecord {
             question_id: question.id.clone(),
@@ -1451,6 +1584,7 @@ pub async fn run_agentic_qa(
     k: usize,
     max_rounds: usize,
     grounded: bool,
+    ground_verify: bool,
 ) -> Result<AgenticReport, QaError> {
     let max_rounds = max_rounds.max(1);
     let concurrency = qa_concurrency();
@@ -1469,7 +1603,15 @@ pub async fn run_agentic_qa(
         let memory_ref = &memory;
         let mut outcomes = stream::iter(conversation.questions.iter())
             .map(|question| {
-                run_one_agentic_question(memory_ref, judge, question, k, max_rounds, grounded)
+                run_one_agentic_question(
+                    memory_ref,
+                    judge,
+                    question,
+                    k,
+                    max_rounds,
+                    grounded,
+                    ground_verify,
+                )
             })
             .buffer_unordered(concurrency);
         while let Some(outcome) = outcomes.next().await {
@@ -1526,6 +1668,7 @@ pub async fn run_agentic_qa(
         .iter()
         .filter(|q| q.ungrounded_override)
         .count();
+    let support_overrides = per_question.iter().filter(|q| q.support_override).count();
 
     Ok(AgenticReport {
         k,
@@ -1545,6 +1688,8 @@ pub async fn run_agentic_qa(
         faithfulness,
         grounded,
         ungrounded_overrides,
+        ground_verify,
+        support_overrides,
     })
 }
 
@@ -1809,6 +1954,65 @@ mod agentic_qa_tests {
         assert!(!grounded_enabled());
 
         std::env::remove_var(ENV_GROUNDED);
+    }
+
+    #[test]
+    fn ground_verify_enabled_defaults_off_and_parses_truthy() {
+        std::env::remove_var(ENV_GROUND_VERIFY);
+        assert!(!ground_verify_enabled());
+
+        std::env::set_var(ENV_GROUND_VERIFY, "1");
+        assert!(ground_verify_enabled());
+
+        std::env::set_var(ENV_GROUND_VERIFY, "true");
+        assert!(ground_verify_enabled());
+
+        std::env::set_var(ENV_GROUND_VERIFY, "TRUE");
+        assert!(ground_verify_enabled());
+
+        std::env::set_var(ENV_GROUND_VERIFY, "0");
+        assert!(!ground_verify_enabled());
+
+        std::env::remove_var(ENV_GROUND_VERIFY);
+    }
+
+    #[test]
+    fn verification_gate_keeps_supported_answer() {
+        let (answer, overridden) = verification_gate("Paris", true);
+        assert_eq!(answer, "Paris");
+        assert!(!overridden);
+    }
+
+    #[test]
+    fn verification_gate_overrides_unsupported_answer() {
+        let (answer, overridden) = verification_gate("Paris", false);
+        assert_eq!(answer, "I don't know");
+        assert!(overridden);
+    }
+
+    #[test]
+    fn verification_gate_leaves_existing_abstention_untouched_and_not_counted() {
+        let (answer, overridden) = verification_gate("I don't know", false);
+        assert_eq!(answer, "I don't know");
+        assert!(
+            !overridden,
+            "an already-abstaining answer must not be counted as a support override"
+        );
+    }
+
+    #[test]
+    fn verify_support_prompt_contains_answer_and_cited_memories() {
+        let prompt =
+            build_verify_support_prompt("Paris", &["The capital of France is Paris.".to_string()]);
+        assert!(prompt.contains("Answer: Paris"));
+        assert!(prompt.contains("The capital of France is Paris."));
+        assert!(prompt.contains("YES or NO"));
+    }
+
+    #[test]
+    fn verify_support_prompt_handles_no_cited_memories() {
+        let prompt = build_verify_support_prompt("Paris", &[]);
+        assert!(prompt.contains("(no cited memories)"));
     }
 }
 


### PR DESCRIPTION
## Summary
Three changes closing out the faithfulness arc.

1. **Citation-support verification** (`SYNAPTIC_EVAL_GROUND_VERIFY=1`, opt-in): after a grounded answer with a valid citation, ask the judge whether the cited memory actually SUPPORTS the answer; if not, override to "I don't know" (`support_overrides`). Fail-closed (judge error propagates, never assumes "supported"). Catches hallucinated-but-valid citations that citation-existence (#89) can't.

2. **Codex judge retry** (unconditional win): transient upstream errors ("model at capacity" / rate limit / 429 / 503 / overloaded) now retry with 2/4/8s backoff instead of aborting the whole run. Timeouts and real errors still fail immediately; never fabricates success.

3. **README refresh**: reflects the retrieval pipeline (RRF + over-fetch rerank + PRF + optional GPU cross-encoder), the eval harness modes, new feature flags, and a measured LoCoMo results table with caveats.

## Honest measured finding
Citation-support verification is nearly **INERT on LoCoMo** — `support_overrides` fires ~0-1 per 30-50 questions, no measurable net effect (abstention confab ~10%→~7% within noise; answerable accuracy within noise; over_abstention 0). Both structural gates (existence #89 + support, this PR) confirm: **the faithfulness gains came from the citation PROMPT** (the model self-corrects and abstains), not the structural override. Verification is a correct, fail-closed safety layer for models/datasets that hallucinate unsupporting citations more; not recommended by default on LoCoMo. Documented in docs/evaluation.md.

Reviewed MERGEABLE (retry can't fake success; verify fail-closed; off-path byte-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)