### PR TITLE
docs(eval): head-to-head vs Mem0 + reproducible comparison harness

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -1363,3 +1363,48 @@ judge call for ~no measured benefit. Kept as opt-in; not recommended by default.
 The codex-retry hardening, by contrast, is unconditionally useful: transient "model at
 capacity" errors were aborting whole runs, and retry-with-backoff makes the QA/agentic
 measurements robust to upstream flakiness.
+
+## Head-to-head vs Mem0 (open-source memory system, 2026-07-17)
+
+Ran the popular open-source memory system [Mem0](https://github.com/mem0ai/mem0)
+through the SAME LoCoMo questions, the SAME codex answer/grade prompts, and the SAME
+abstention/faithfulness classification as this repo's harness (see
+`tools/eval/comparisons/`), so the numbers sit on the same footing on the answering side.
+
+**QA accuracy — identical 40-question subset, identical codex judge:**
+
+| system | QA accuracy |
+|---|---|
+| Mem0 (local qwen-7B ingestion) | 0.250 |
+| this repo, single-shot retrieval | 0.375 |
+| this repo, agentic answer-guided retrieval | **0.500** |
+
+**Faithfulness — 50 provably-unanswerable (Abstention) questions:**
+
+| system | abstained (honest "I don't know") | confabulated |
+|---|---|---|
+| Mem0 | 44/50 (88%) | 12% |
+| this repo, single-shot | 47/50 (94%) | 6% |
+| this repo, agentic (after abstention fix) | ~90% | ~10% |
+
+**Honest reading (caveats matter here more than the numbers):**
+- Under **matched local conditions** (both systems answering with the same codex judge
+  in the same environment), this repo outperforms Mem0 on QA accuracy — 1.5× even
+  single-shot, 2× with agentic retrieval. Mem0's single-shot retrieve-then-answer maps
+  to our single-shot (0.375 vs 0.250); agentic (0.50) is our differentiator (Mem0 does
+  not do iterative answer-guided retrieval).
+- **BUT Mem0's ingestion here used a local qwen-7B, not the GPT-4 its published LoCoMo
+  numbers (~66%) assume.** Mem0's memory quality depends heavily on the extraction LLM,
+  so this is NOT a claim of beating Mem0's best case — it is "competitive-to-better in a
+  matched local setup." A genuine architectural point in this repo's favor: its
+  memory-building uses no LLM (heuristic extraction + embeddings), so it is not
+  bottlenecked by the ingestion model's quality the way Mem0 is.
+- **Faithfulness is largely a wash.** Both systems answer with the same codex judge and
+  the same "say I don't know if not answerable" prompt, so abstention is driven mostly by
+  the shared answerer, not the memory system — the ~6-point gap (94% vs 88%) just reflects
+  Mem0 occasionally retrieving plausible-but-irrelevant facts that nudge the judge to
+  answer. This repo's faithfulness *work* was about fixing its OWN agentic mode (which
+  confabulated 100% before the fix), not about being dramatically more faithful than Mem0.
+- Retrieval `recall` is not compared (different memory unit: Mem0 stores extracted facts,
+  not turns). Small subsets; codex judge is nondeterministic (~±0.03). Zep/Graphiti and
+  Letta not tested (heavier setup) — this is one real head-to-head, not a field survey.

--- a/tools/eval/comparisons/README.md
+++ b/tools/eval/comparisons/README.md
@@ -1,0 +1,33 @@
+# Head-to-head comparison harness (Mem0)
+
+`mem0_eval.py` runs the open-source [Mem0](https://github.com/mem0ai/mem0) memory
+system through the SAME LoCoMo questions, the SAME codex answer/grade prompts, and
+the SAME abstention/faithfulness classification as this repo's Rust eval harness —
+so Mem0's QA accuracy and confabulation rate can be put directly beside ours.
+
+## What it does (apples-to-apples on the ANSWERING side)
+- Ingests each LoCoMo conversation into Mem0 (fact extraction), isolated per
+  conversation via `user_id`.
+- Retrieves top-k memories per question with Mem0's `search`.
+- Answers + grades with the SAME `codex exec` prompts our harness uses
+  (`tools/eval/src/qa.rs`), and classifies abstention with the same phrase set.
+
+## Setup
+```bash
+uv venv mem0env --python 3.12
+uv pip install --python mem0env/bin/python mem0ai ollama qdrant-client
+ollama pull qwen2.5:7b-instruct   # Mem0's extraction LLM (local)
+# nomic-embed-text for embeddings (already used by this repo's Ollama path)
+./mem0env/bin/python mem0_eval.py <n_conversations> <questions_per_conv> [qtype]
+```
+
+## HONEST CAVEATS (read before citing)
+- **Mem0's ingestion here uses a LOCAL qwen2.5-7B, not the GPT-4 its published
+  LoCoMo numbers (~66%) assume.** Mem0's memory quality depends heavily on the
+  extraction LLM, so this is a MATCHED-LOCAL comparison, NOT Mem0's best case.
+- Retrieval `recall` is NOT compared (Mem0 stores extracted facts with its own
+  IDs, not the original turns our recall metric keys on). Only end-to-end QA +
+  faithfulness are comparable.
+- Small subsets; the codex judge is nondeterministic (~±0.03).
+- Zep/Graphiti and Letta are not included (they need a server + graph DB / more
+  setup); this is one real head-to-head, not a full field survey.

--- a/tools/eval/comparisons/mem0_eval.py
+++ b/tools/eval/comparisons/mem0_eval.py
@@ -1,0 +1,109 @@
+import json, os, re, subprocess, sys, time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from mem0 import Memory
+
+DATA = "/home/n/Code/rust-synaptic/tools/eval/data/locomo10.json"
+K = 10
+CATS = {"1":"MultiHop","2":"Temporal","3":"OpenDomain","4":"SingleHop","5":"Abstention"}
+ABSTAIN = ["i don't know","i do not know","no information","not mentioned","not available",
+           "cannot determine","can't determine","no answer","not enough information",
+           "not specified","no relevant","isn't mentioned","doesn't say","does not say"]
+ABSTAIN_WORDS = {"unknown","none"}
+
+def is_abstention(a):
+    l=a.lower()
+    if any(p in l for p in ABSTAIN): return True
+    return any(w in ABSTAIN_WORDS for w in re.split(r'[^a-z0-9]+', l))
+
+def parse_codex(out):
+    lines=out.splitlines()
+    start=0
+    for i,l in enumerate(lines):
+        t=l.strip()
+        if t=="codex" or t.endswith("] codex"): start=i+1
+    def banner(t):
+        return (t.startswith("OpenAI Codex") or t.startswith("--------") or t.startswith("workdir:")
+                or t.startswith("model:") or t.startswith("provider:") or t.startswith("approval:")
+                or t.startswith("sandbox:") or t.startswith("reasoning ") or t.startswith("session id:")
+                or "tokens used" in t)
+    return "\n".join(l for l in lines[start:] if not banner(l.strip())).strip()
+
+def codex(prompt, attempts=4):
+    for a in range(attempts):
+        try:
+            r=subprocess.run(["timeout","120","codex","exec","--skip-git-repo-check",prompt],
+                             capture_output=True,text=True)
+        except Exception as e:
+            if a+1==attempts: raise
+            time.sleep(2<<a); continue
+        combined=(r.stdout+r.stderr).lower()
+        if r.returncode!=0:
+            if ("at capacity" in combined or "try a different model" in combined or "rate limit" in combined
+                or "429" in combined or "503" in combined or "overloaded" in combined) and a+1<attempts:
+                time.sleep(2<<a); continue
+            raise RuntimeError("codex failed: "+r.stderr[-300:])
+        return parse_codex(r.stdout)
+    raise RuntimeError("codex exhausted")
+
+def answer(q, mems):
+    ctx="\n".join(f"[{i+1}] {m}" for i,m in enumerate(mems)) if mems else "(no memories recalled)"
+    return codex(f"Answer concisely using ONLY the provided memories; if not answerable from them, "
+                 f"say 'I don't know'. Do not use any other knowledge or tools.\n\nMemories:\n{ctx}\n\n"
+                 f"Question: {q}\nAnswer:")
+
+def grade(q, gold, pred):
+    v=codex(f"Question: {q}\nGold answer: {gold}\nPredicted answer: {pred}\n\n"
+            f"Does the predicted answer match the gold answer in meaning? Reply exactly YES or NO.")
+    return v.strip().upper().startswith("YES") or "YES" in v.strip().upper()[:6]
+
+def mem_config():
+    return {"llm":{"provider":"ollama","config":{"model":"qwen2.5:7b-instruct","ollama_base_url":"http://localhost:11434","temperature":0.0}},
+            "embedder":{"provider":"ollama","config":{"model":"nomic-embed-text:latest","ollama_base_url":"http://localhost:11434","embedding_dims":768}},
+            "vector_store":{"provider":"qdrant","config":{"embedding_model_dims":768,"path":"/tmp/mem0qd/locomo","collection_name":"locomo"}}}
+
+def main():
+    n_conv=int(sys.argv[1]) if len(sys.argv)>1 else 3
+    per=int(sys.argv[2]) if len(sys.argv)>2 else 4
+    qfilter=sys.argv[3] if len(sys.argv)>3 else None  # e.g. "abstention"
+    data=json.load(open(DATA))[:n_conv]
+    os.environ["MEM0_TELEMETRY"]="False"
+
+    recs=[]  # (category, correct, abstained)
+    m=Memory.from_config(mem_config())
+    for ci,c in enumerate(data):
+        coll=f"conv{ci}"
+        conv=c["conversation"]
+        # ingest sessions
+        marker=f"/tmp/mem0qd/.done_{coll}"
+        if not os.path.exists(marker):
+            si=1
+            while f"session_{si}" in conv:
+                turns=conv[f"session_{si}"]
+                msgs=[{"role":"user" if t["speaker"]==conv["speaker_a"] else "assistant",
+                       "content":f'{t["speaker"]}: {t["text"]}'} for t in turns]
+                try: m.add(msgs, user_id=coll, infer=True)
+                except Exception as e: print(f"  add err conv{ci} s{si}: {str(e)[:100]}")
+                si+=1
+            open(marker,"w").write("1")
+            print(f"conv{ci}: ingested {si-1} sessions", flush=True)
+        qa=c.get("qa") or []
+        qs=[q for q in qa if (qfilter is None or CATS.get(str(q.get("category")),"").lower()==qfilter)][:per]
+        def do(q):
+            mems=[x.get("memory") for x in m.search(q["question"], filters={"user_id":coll}, limit=K).get("results",[])]
+            pred=answer(q["question"], mems)
+            ab=is_abstention(pred)
+            corr=grade(q["question"], str(q.get("answer")), pred)
+            return (CATS.get(str(q.get("category")),"?"), corr, ab)
+        with ThreadPoolExecutor(max_workers=3) as ex:
+            for f in as_completed([ex.submit(do,q) for q in qs]):
+                recs.append(f.result())
+        print(f"conv{ci}: {len([r for r in recs])} done", flush=True)
+
+    tot=len(recs); corr=sum(1 for _,c,_ in recs if c)
+    print(f"\n=== MEM0 RESULT: graded={tot} correct={corr} accuracy={corr/tot:.4f} ===")
+    bycat={}
+    for cat,c,ab in recs: bycat.setdefault(cat,[0,0,0]); bycat[cat][0]+=1; bycat[cat][1]+=int(c); bycat[cat][2]+=int(ab)
+    for cat,(t,cc,ab) in sorted(bycat.items()):
+        print(f"  {cat}: n={t} acc={cc/t:.4f} abstained={ab}")
+
+if __name__=="__main__": main()


### PR DESCRIPTION
## Summary
Ran the open-source **Mem0** memory system through the SAME LoCoMo questions, SAME codex answer/grade prompts, and SAME abstention/faithfulness metrics as this repo's harness (`tools/eval/comparisons/mem0_eval.py`), for a real apples-to-apples on the answering side.

## QA accuracy (identical 40-q subset + judge)
| system | accuracy |
|---|---|
| Mem0 (local qwen-7B ingest) | 0.250 |
| ours single-shot | 0.375 |
| ours agentic | **0.500** |

## Faithfulness (50 unanswerable questions)
| system | abstained | confabulated |
|---|---|---|
| Mem0 | 88% | 12% |
| ours single-shot | 94% | 6% |
| ours agentic (fixed) | ~90% | ~10% |

## Honest caveats (in the doc + harness README)
- **Mem0 ran on local qwen-7B, not the GPT-4 its published ~66% assumes** — matched-local comparison, NOT Mem0's best case. Real architectural point in our favor: our ingestion uses no LLM, so it isn't bottlenecked by extractor quality.
- **Faithfulness is largely a wash** — both answer with the same codex judge + prompt, so abstention is driven by the shared answerer, not the memory system. Our faithfulness *work* was fixing our OWN agentic mode (100%→~10% confabulation), not beating Mem0.
- Recall not compared (different memory unit). Small subsets, codex noise. Zep/Letta not tested (heavier setup) — one head-to-head, not a field survey.

Adds the reproducible Python harness + README so anyone can re-run (or swap in GPT-4 for Mem0's ingestion to test its best case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)