### PR TITLE
docs(eval): GPU cross-encoder confirms MultiHop ranking lever (recall@10 0.316→0.397)

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -1670,3 +1670,27 @@ It also sharpens *why* the agentic loop works where deterministic gather doesn't
 the *specific* missing fact ("SEARCH: what is Beth's job"), whereas any deterministic expansion
 ("more about Beth") is too coarse. The working MultiHop levers remain **ranking** (cross-encoder →
 0.374) and **LLM-guided agentic gather** (QA 0.500); deterministic gather is now exhausted too.
+
+### MultiHop: GPU cross-encoder exploits the ranking gap (confirmed, 2026-07-19)
+
+Having ruled out gather (again), we exercised the *ranking* lever the entity-bridge diagnostic had
+just re-exposed: the same PRF pool has recall@50 = 0.516 but recall@10 = 0.316 — 0.200 of MultiHop
+gold is *pooled but ranked below the top-10 cutoff*. Reordering that pool with the GPU cross-encoder
+(`SYNAPTIC_RERANKER=cross-encoder`, `ms-marco-MiniLM-L-6-v2`, candle CUDA on the RTX A3000 —
+`--features "synaptic/static-embeddings synaptic/reranker-model synaptic/cuda"`) against the
+*identical* PRF pool:
+
+| | recall@10 | recall@20 | recall@50 |
+|---|---|---|---|
+| baseline (PRF) | 0.316 | 0.394 | **0.516** |
+| + GPU cross-encoder | **0.3968** | 0.4580 | **0.5159** |
+
+**Positive — and it is *pure reordering*.** recall@50 is unchanged (0.516 → 0.5159, same pool), so
+the entire +0.081 recall@10 (+26%) comes from ranking already-pooled gold into the top-10 — the
+mirror image of the entity-bridge failure (which moved the pool and got nothing). This reproduces and
+slightly exceeds the earlier full-set cross-encoder MultiHop figure (0.3739) on the current PRF
+baseline. Net for MultiHop retrieval, the ledger is unambiguous: every gain since 0.2475 has come
+from **ranking** (over-fetch #75, embedding-dominant rerank #76, cross-encoder #80, and this
+confirmation), and **zero** from any of the four deterministic-gather attempts (similarity edges,
+coreference edges, entity-bridge, MMR). The remaining MultiHop headroom above 0.397 is the pool gap
+(0.484 never pooled), addressable only by LLM-guided agentic gather, not by reordering.

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -1640,3 +1640,33 @@ at the retrieval-precision / weak-answerer level. The throughline across the who
 with a frontier answerer measures fact-retrieval capabilities and masks the rest**; each capability
 must be validated on an instrument that isolates *what it changes*, and doing so honestly shows one
 neutral (reflection), one clear win (forgetting), and one strong-answerer-masked (bi-temporal).
+
+### MultiHop: entity-bridge gather — abandoned (measured negative, 2026-07-19)
+
+A fresh attempt at the MultiHop *pool-absence* gap (recall@50 = 0.516, so ~48% of MultiHop gold is
+never even pooled). Diagnostic first (`--recall-curve --qtype multihop`): recall@10 0.316 / @20 0.394
+/ @50 0.516 — a large ranking gap (0.316→0.516, gold pooled but below top-10) *and* a large pool
+gap (0.484 never pooled). We targeted the pool gap with a NEW deterministic lever distinct from the
+already-exhausted graph expansion: **entity-bridge gather** — extract named entities (capitalized
+spans) from the top seed hits, run a *focused* retrieval per entity, and union into the pool
+(opt-in, discounted). Hypothesis: a multi-hop bridge fact ("Beth is a doctor") shares no vocabulary
+with the query ("what does Alice's sister do?") but is reachable via a bridge entity ("Beth")
+surfaced by the seed retrieval.
+
+Measured (full-set MultiHop, 282 q):
+
+| | recall@10 | recall@20 | recall@50 |
+|---|---|---|---|
+| baseline (PRF) | 0.316 | 0.394 | **0.516** |
+| + entity-bridge | 0.319 | 0.398 | **0.509** |
+
+**Negative — abandoned (not shipped).** recall@10/@20 moved +0.003 (noise); recall@50 went *down*
+0.007. A per-entity retrieval returns many entity-*general* turns ("everything mentioning Beth"),
+which fill and self-poison the bounded pool, displacing gold faster than they add the one specific
+connecting fact. This is the **third independent confirmation** of the prior finding
+([[multihop-needs-coreference-edges]] in the project notes; PRs #82/#83/#86): gathering *more*
+entity/similarity-related content adds noise > gold, whether via KG edges or focused re-retrieval.
+It also sharpens *why* the agentic loop works where deterministic gather doesn't — an LLM identifies
+the *specific* missing fact ("SEARCH: what is Beth's job"), whereas any deterministic expansion
+("more about Beth") is too coarse. The working MultiHop levers remain **ranking** (cross-encoder →
+0.374) and **LLM-guided agentic gather** (QA 0.500); deterministic gather is now exhausted too.


### PR DESCRIPTION
## What

Ran the MultiHop recall curve with the GPU cross-encoder reranker (`SYNAPTIC_RERANKER=cross-encoder`, ms-marco-MiniLM-L-6-v2, candle CUDA on the RTX A3000) against the **same PRF pool** used in the entity-bridge diagnostic.

| | recall@10 | recall@20 | recall@50 |
|---|---|---|---|
| baseline (PRF) | 0.316 | 0.394 | **0.516** |
| + GPU cross-encoder | **0.3968** | 0.4580 | **0.5159** |

## Why it matters

recall@50 is **unchanged** (same pool) → the entire +0.081 recall@10 (+26%) is **pure reordering** of already-pooled gold into the top-10. This is the exact mirror image of the entity-bridge gather failure (PR #104: moved the pool, gained nothing), and reproduces/exceeds the earlier full-set cross-encoder figure (0.3739).

**Ledger:** every MultiHop retrieval gain since 0.2475 has come from *ranking*; zero from any of the four deterministic-gather attempts. Remaining headroom above 0.397 is the pool gap, addressable only by LLM-guided agentic gather.

> **Note:** stacks on #104 (entity-bridge negative result). Merge #104 first, or merge this and close #104 — both doc sections are included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)