### PR TITLE
Write-time fact distillation (opt-in; default Off — A/B shows facts-primary hurts QA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,16 @@ unless noted): retrieval recall@10 **0.61** (best config); an **agentic
 answer-guided retrieval** eval mode that lifts end-to-end QA accuracy to
 **0.50** on a labelled subset (a codex-CLI judge; see caveats) while abstaining
 ("I don't know") rather than confabulating when the evidence is absent — a
-faithfulness property measured explicitly; and **write-time fact extraction**
-(`MemoryConfig::store_extracted_facts`) that lifts QA from 0.325/0.450 (raw
-turns) to **0.475/0.500** on a matched 40-question slice — tying
-[Mem0](https://github.com/mem0ai/mem0) (0.500) when both answer from the same
-judge, i.e. our retrieval was never the gap; the raw-turn representation was.
-Honest head-to-heads vs Mem0 and Graphiti (Zep) — including a result that
-*reversed* an earlier under-tested claim — are documented with all caveats in
-[docs/evaluation.md](docs/evaluation.md).
+faithfulness property measured explicitly. **Write-time fact distillation** is
+implemented as an opt-in write path (`MemoryConfig::distillation`, default
+**Off**): in an offline facts-only construction with a frontier extractor it
+tied [Mem0](https://github.com/mem0ai/mem0) (0.500) on a 40-question slice, but
+a matched end-to-end A/B of the *shipped* facts-primary path (raw turns
+excluded from search) with an accessible local extractor measured it to **hurt**
+QA (0.505 → 0.258 on 198 questions) — so it ships default-off. Honest
+head-to-heads vs Mem0 and Graphiti (Zep), and this negative distillation
+result — each *reversing* an earlier under-tested claim — are documented with
+all caveats in [docs/evaluation.md](docs/evaluation.md).
 
 This is a development library (version 0.2.0, not published to crates.io).
 The table below states honestly which parts are stable, which are beta, and
@@ -41,7 +43,8 @@ backed by a measured run in [docs/evaluation.md](docs/evaluation.md).
 | Memory store/retrieve (`AgentMemory`) | stable | Core store/retrieve/update with tests; in-memory and file (Sled) backends |
 | Storage backends | stable | Memory, file (Sled); SQL (PostgreSQL) behind `sql-storage` |
 | Knowledge graph | stable | Node merging, relationship detection, traversal; tested |
-| Intelligent write path (`MemoryReasoner`) | beta | On store, the active reasoner extracts facts/entities/relations from the value: entities & relations feed the knowledge graph; with `MemoryConfig::store_extracted_facts` (default off) each fact is also persisted as its own retrievable memory (`<key>::fact<N>`). Deterministic `HeuristicReasoner` by default (offline); `LlmReasoner` (OpenAI-compatible endpoint) under `llm-reasoning`, with heuristic fallback. Measured to lift LoCoMo QA to Mem0 parity — see [docs/evaluation.md](docs/evaluation.md) |
+| Intelligent write path (`MemoryReasoner`) | beta | On store, the active reasoner extracts facts/entities/relations from the value: entities & relations feed the knowledge graph. Deterministic `HeuristicReasoner` by default (offline); `LlmReasoner` (OpenAI-compatible endpoint) under `llm-reasoning`, with heuristic fallback. |
+| Write-time distillation (`MemoryConfig::distillation`) | experimental, **default off** | When `On` (or the deprecated `store_extracted_facts = true`) each extracted fact is persisted as its own retrievable memory (`<key>::fact<N>`) and raw turns are excluded from `search` (facts-primary). A matched LoCoMo A/B measured this to **hurt** QA with an accessible extractor (0.505 → 0.258) — opt-in only. See [docs/evaluation.md](docs/evaluation.md) |
 | Embeddings | stable | Deterministic local embeddings; used by hybrid retrieval |
 | Search / hybrid retrieval | beta | Tokenized keyword + vector + graph + temporal retrievers fused with Reciprocal Rank Fusion (RRF), composite scoring, and a deterministic reranker over an over-fetched candidate pool. Optional: PRF pool augmentation (`SYNAPTIC_RETRIEVAL_PRF`), multi-hop graph expansion, semantic embeddings (`static-embeddings` / `ml-models` / Ollama), and a candle BERT cross-encoder reranker (`reranker-model`, GPU via `cuda`). Measured on LoCoMo — see [docs/evaluation.md](docs/evaluation.md) |
 | Evaluation harness (`tools/eval`) | beta | Real LoCoMo/LongMemEval loaders; retrieval metrics (recall/precision/MRR, `--recall-curve`, `--completeness`), memory-growth, and LLM-gated end-to-end QA (`--qa-only`, `--agentic-qa`) with abstention/faithfulness metrics. Every printed number is a real run; QA is gated on a configured judge, never fabricated |
@@ -124,9 +127,14 @@ with a lexical/TF-IDF embedder):
   `SYNAPTIC_LLM_MODEL`), with deterministic heuristic fallback. Without it the
   offline `HeuristicReasoner` is used
 
-Write-time fact extraction is a runtime config, not a feature flag: set
-`MemoryConfig::store_extracted_facts = true` to persist each extracted fact as a
-retrievable memory (default off; works with either reasoner).
+Write-time distillation is a runtime config, not a feature flag: set
+`MemoryConfig::distillation = DistillationMode::On` (or the deprecated
+`store_extracted_facts = true`) to persist each extracted fact as a retrievable
+memory and serve facts-primary. **Default is `Off`** — a matched LoCoMo A/B
+measured facts-primary distillation to hurt QA with an accessible extractor
+(see [docs/evaluation.md](docs/evaluation.md)); enable only with a strong, fast
+extractor you have measured on your own workload. Quality scales with the active
+reasoner (`LlmReasoner` under `llm-reasoning`, else `HeuristicReasoner`).
 
 Other optional features: `sql-storage`, `multimodal`, `external-integrations`,
 `cross-platform`, `observability`, and `distributed-experimental` (explicitly

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -1770,3 +1770,54 @@ documented above) is the opt-in lever against this and was left OFF here to meas
 nondeterministic run-to-run (~±0.03 on small samples; far tighter at n=1986), and grades adversarial
 abstention strictly (a correctly-refused question can still be marked wrong if the phrasing diverges
 from the expected form), which depresses the Abstention row.
+
+## Write-time distillation A/B: facts-primary retrieval HURTS (negative result, 2026-07-21)
+
+We built write-time fact distillation as a real, default write path (spec/plan under
+`docs/superpowers/`): when an LLM endpoint + knowledge graph are configured, `store()` distills each
+turn into fact-memories (`{key}::fact{i}`) that become the primary retrievable units, and the raw
+turn is tagged `raw_source` and excluded from default `search` (`MemoryConfig::distillation`,
+`retrieval_excludes_raw_sources`). The hypothesis (from the earlier Mem0-parity result) was that
+distilled facts retrieve cleaner than raw turns. **A matched A/B refuted this for the accessible
+configuration, so distillation ships default-OFF (opt-in).**
+
+**Setup.** Same conversation (LoCoMo conv 0), same codex judge + retrieval (PRF + GPU cross-encoder);
+only the write path differs. Arm A ingests raw turns (`distillation: Off`). Arm B distills
+facts-primary (`--distill`, `On`), extracting with a local `qwen2.5:7b-instruct` (Ollama, GPU). The
+matched set is the 198 questions both arms graded.
+
+| category | Arm A (raw) | Arm B (7B distill) | Δ |
+|---|---|---|---|
+| **Overall** | **0.5051** | **0.2576** | **−0.2475** |
+| SingleHop | 0.729 | 0.257 | −0.471 |
+| Temporal | 0.784 | 0.486 | −0.297 |
+| MultiHop | 0.188 | 0.062 | −0.125 |
+| OpenDomain | 0.385 | 0.308 | −0.077 |
+| Abstention | 0.196 | 0.196 | +0.000 |
+
+**Distillation nearly halved accuracy.** The driver is abstention: it **doubled** (103 vs 44 "I
+don't know" on the 198). The judge grades the actual answer text, so this is a real retrieval/answer
+loss, not a scoring artifact. (The `gold_in_context` recall metric reads 0.000 for Arm B — an
+*instrumentation artifact*: it credits raw-turn `evidence_id`s, which distillation replaces with
+`::fact` keys, so recall is not meaningful under facts-primary. Accuracy is the valid signal.)
+
+**Two mechanisms (from a direct qwen-vs-codex extraction diagnostic on the answer-losing turns):**
+1. **Extractor quality is real.** For "When did Melanie run a charity race?", codex extracted
+   *"Melanie ran a charity race … last Saturday"* (answer preserved) while qwen dropped it entirely.
+   A frontier extractor would beat the 7B's 0.258. But a frontier extractor is **impractically slow
+   for the write path** — codex-via-CLI is ~15 s/turn × multiple calls/turn (extract + per-fact
+   resolve); a single-conversation ingest did not finish in 1 h, so the full codex A/B was infeasible.
+2. **Facts-primary loses context regardless of extractor.** Raw turns are ingested with a
+   `[session-date]` prefix; extracted facts drop it, so temporal questions (gold "7 May 2023"; the
+   turn says "yesterday") lose their date anchor even with a perfect extractor. Excluding raw removes
+   the verbatim fallback. This is a design-level floor a better extractor cannot fully overcome.
+
+**Decision (honesty bar).** Distillation defaults to **`Off`**. The machinery is complete, tested,
+and reviewed, and is available opt-in (`MemoryConfig::distillation = On`, or the deprecated
+`store_extracted_facts = true`) for deployments with a strong, fast extractor that measure it for
+their own workload. It is **not** shipped default-on because the only end-to-end measurement shows
+harm. Caveats: single-conversation matched set (n=198); local 7B extractor; a frontier extractor was
+not measured end-to-end (infeasibly slow here). The finding that generalizes: **facts-primary
+retrieval that excludes raw turns trades away verbatim recall (dates, exact details) that LoCoMo QA
+depends on** — distillation should *augment* raw retrieval, not replace it, and only with an
+extraction step faithful enough to not drop answer-bearing detail.

--- a/docs/superpowers/plans/2026-07-20-write-time-distillation.md
+++ b/docs/superpowers/plans/2026-07-20-write-time-distillation.md
@@ -1,0 +1,997 @@
+# Write-Time Fact Distillation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make LLM-distilled facts the primary retrievable units on the default write path when an LLM endpoint is configured, with raw turns retained but excluded from default search — the measured Mem0-parity condition.
+
+**Architecture:** A `DistillationMode` config enum (`Auto`/`On`/`Off`) resolves at construction, via a pure `DistillationPolicy` resolver, into a live on/off decision from the reasoner kind + KG/embeddings availability. When live, `reason_over_store` stores each extracted fact as `{key}::fact{i}` and tags the raw turn `raw_source` **only after ≥1 fact lands**; `search` drops `raw_source`-tagged memories by default. The eval harness gains a config hook so the same full-LoCoMo run can A/B raw-turn vs facts-primary ingestion.
+
+**Tech Stack:** Rust, `synaptic` crate (`src/lib.rs`, `src/memory/reasoning/`), `synaptic-eval` (`tools/eval/`), Tokio async, `cargo test`.
+
+## Global Constraints
+
+- Honesty bar: no fabricated numbers; report negative results; ship distillation default-on ONLY if the full-LoCoMo A/B shows Arm B (distillation) ≥ Arm A (baseline).
+- Best-effort subsystem: distillation failure sets a `degradations.*` field, logs, and never aborts the write.
+- No behavior change for no-LLM / no-KG deployments: a store there must remain byte-for-byte equivalent to today (raw turns untagged and searchable).
+- Backwards compatibility: `store_extracted_facts: bool` stays as a deprecated alias mapped to the new enum.
+- Failure-ordering invariant: the raw turn is tagged `raw_source` only AFTER ≥1 fact is successfully stored — never before.
+- PR-only merge flow: repo ruleset requires PRs; a NEW branch per PR iteration.
+- All distillation code is behind `#[cfg(feature = "embeddings")]`, matching the existing write-path reasoning (`src/lib.rs:245`, `:692`).
+- Field/const naming: mirror the superseded pattern verbatim — `RAW_SOURCE_FIELD = "raw_source"` (const), `retrieval_excludes_raw_sources: bool` (config), exactly parallel to `SUPERSEDED_FIELD = "superseded_at"` / `retrieval_excludes_superseded`.
+
+## File Structure
+
+- `src/memory/reasoning/distillation.rs` (new): `DistillationMode` enum, `ResolvedReasonerKind` enum, `DistillationPolicy` resolver — pure logic, no store/IO. One responsibility: decide whether distillation is live and whether `On` is a misconfiguration.
+- `src/memory/reasoning/mod.rs` (modify): `pub mod distillation;` + re-exports.
+- `src/lib.rs` (modify): config fields (`distillation`, `retrieval_excludes_raw_sources`), constructor records `ResolvedReasonerKind` + computes live-flag, `reason_over_store` tags raw after facts land, `search` filter, `RAW_SOURCE_FIELD` const, `mark_raw_source` helper.
+- `tools/eval/src/runner.rs` (modify): `ingest` already stores raw turns; no change needed beyond config (facts happen inside `store`).
+- `tools/eval/src/qa.rs` (modify): thread a `MemoryConfig` factory into `run_agentic_qa_impl` so the A/B can choose the write path.
+- `tools/eval/src/bin/run_eval.rs` (modify): `--distill` flag selecting the facts-primary config for the agentic-QA run.
+- `docs/evaluation.md` (modify): A/B result section.
+- `README.md` (modify): note distillation auto-activates with an LLM endpoint.
+
+---
+
+### Task 1: `DistillationPolicy` resolver (pure logic)
+
+**Files:**
+- Create: `src/memory/reasoning/distillation.rs`
+- Modify: `src/memory/reasoning/mod.rs`
+- Test: inline `#[cfg(test)]` module in `distillation.rs`
+
+**Interfaces:**
+- Produces:
+  - `pub enum DistillationMode { Auto, On, Off }` (derives `Debug, Clone, Copy, PartialEq, Eq`; `Default` → `Auto`)
+  - `pub enum ResolvedReasonerKind { Llm, Heuristic }` (derives `Debug, Clone, Copy, PartialEq, Eq`)
+  - `pub struct DistillationDecision { pub live: bool }` (derives `Debug, Clone, Copy, PartialEq, Eq`)
+  - `pub fn resolve_distillation(mode: DistillationMode, reasoner: ResolvedReasonerKind, prerequisites_met: bool, llm_feature_enabled: bool) -> Result<DistillationDecision, String>` — returns `Err(msg)` for the `On` misconfiguration case (prereqs met + feature enabled + reasoner is Heuristic, i.e. an endpoint was expected but did not resolve).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/memory/reasoning/distillation.rs` with only the test module first:
+
+```rust
+//! Distillation policy: decides whether write-time fact distillation is live
+//! from the configured mode, the resolved reasoner kind, and whether the write
+//! path prerequisites (knowledge graph + embeddings) are available. Pure logic,
+//! no store or IO, so it is unit-testable in isolation.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Auto: live only with an LLM reasoner AND prerequisites.
+    #[test]
+    fn auto_llm_with_prereqs_is_live() {
+        let d = resolve_distillation(
+            DistillationMode::Auto,
+            ResolvedReasonerKind::Llm,
+            true,
+            true,
+        )
+        .unwrap();
+        assert!(d.live);
+    }
+
+    #[test]
+    fn auto_heuristic_is_off() {
+        let d = resolve_distillation(
+            DistillationMode::Auto,
+            ResolvedReasonerKind::Heuristic,
+            true,
+            false,
+        )
+        .unwrap();
+        assert!(!d.live);
+    }
+
+    #[test]
+    fn auto_llm_without_prereqs_is_off() {
+        let d = resolve_distillation(
+            DistillationMode::Auto,
+            ResolvedReasonerKind::Llm,
+            false,
+            true,
+        )
+        .unwrap();
+        assert!(!d.live);
+    }
+
+    // Off: never live, regardless of everything else.
+    #[test]
+    fn off_is_never_live() {
+        let d = resolve_distillation(
+            DistillationMode::Off,
+            ResolvedReasonerKind::Llm,
+            true,
+            true,
+        )
+        .unwrap();
+        assert!(!d.live);
+    }
+
+    // On: hard error when prerequisites are absent.
+    #[test]
+    fn on_without_prereqs_errors() {
+        let err = resolve_distillation(
+            DistillationMode::On,
+            ResolvedReasonerKind::Heuristic,
+            false,
+            false,
+        );
+        assert!(err.is_err());
+    }
+
+    // On + feature enabled but reasoner resolved Heuristic = endpoint expected
+    // but unresolved = misconfiguration = hard error.
+    #[test]
+    fn on_llm_feature_but_heuristic_reasoner_errors() {
+        let err = resolve_distillation(
+            DistillationMode::On,
+            ResolvedReasonerKind::Heuristic,
+            true,
+            true,
+        );
+        assert!(err.is_err());
+    }
+
+    // On without the llm feature (heuristic is the only possible reasoner):
+    // proceed live with a warning rather than erroring.
+    #[test]
+    fn on_no_llm_feature_is_live_with_heuristic() {
+        let d = resolve_distillation(
+            DistillationMode::On,
+            ResolvedReasonerKind::Heuristic,
+            true,
+            false,
+        )
+        .unwrap();
+        assert!(d.live);
+    }
+
+    #[test]
+    fn on_llm_with_prereqs_is_live() {
+        let d = resolve_distillation(
+            DistillationMode::On,
+            ResolvedReasonerKind::Llm,
+            true,
+            true,
+        )
+        .unwrap();
+        assert!(d.live);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail (compile error)**
+
+Run: `cargo test -p synaptic --features embeddings distillation:: 2>&1 | tail -20`
+Expected: FAIL — `resolve_distillation`, `DistillationMode`, etc. not found.
+
+- [ ] **Step 3: Write the implementation**
+
+Prepend to `src/memory/reasoning/distillation.rs` (above the test module):
+
+```rust
+/// How write-time fact distillation is activated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DistillationMode {
+    /// Live when an LLM reasoner is resolved and the write-path prerequisites
+    /// (knowledge graph + embeddings) are available; off otherwise. Default.
+    #[default]
+    Auto,
+    /// Require distillation. A hard error at construction when prerequisites are
+    /// absent, or when the `llm-reasoning` feature is enabled but no endpoint
+    /// resolved (a heuristic reasoner where an LLM was expected). In a build
+    /// without the feature, proceeds live with a heuristic reasoner and a
+    /// one-time warning.
+    On,
+    /// Never distill (escape hatch; today's raw-value-only behavior).
+    Off,
+}
+
+/// Which reasoner the constructor resolved for the write path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolvedReasonerKind {
+    Llm,
+    Heuristic,
+}
+
+/// Outcome of resolving the distillation policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DistillationDecision {
+    /// Whether the write path should distill facts and tag raw sources.
+    pub live: bool,
+}
+
+/// Resolve whether distillation is live. `prerequisites_met` is
+/// `enable_knowledge_graph && embeddings-available`; `llm_feature_enabled` is
+/// whether the `llm-reasoning` cargo feature is compiled in. Returns `Err` only
+/// for the `On` misconfiguration cases, where the caller should fail construction.
+pub fn resolve_distillation(
+    mode: DistillationMode,
+    reasoner: ResolvedReasonerKind,
+    prerequisites_met: bool,
+    llm_feature_enabled: bool,
+) -> Result<DistillationDecision, String> {
+    match mode {
+        DistillationMode::Off => Ok(DistillationDecision { live: false }),
+        DistillationMode::Auto => Ok(DistillationDecision {
+            live: prerequisites_met && reasoner == ResolvedReasonerKind::Llm,
+        }),
+        DistillationMode::On => {
+            if !prerequisites_met {
+                return Err(
+                    "DistillationMode::On requires enable_knowledge_graph and the \
+                     embeddings feature, but they are not available"
+                        .to_string(),
+                );
+            }
+            // Feature enabled but reasoner came back Heuristic => an endpoint was
+            // expected (SYNAPTIC_LLM_URL/_MODEL) but did not resolve.
+            if llm_feature_enabled && reasoner == ResolvedReasonerKind::Heuristic {
+                return Err(
+                    "DistillationMode::On with the llm-reasoning feature requires a \
+                     configured LLM endpoint (SYNAPTIC_LLM_URL / SYNAPTIC_LLM_MODEL), \
+                     but none resolved"
+                        .to_string(),
+                );
+            }
+            Ok(DistillationDecision { live: true })
+        }
+    }
+}
+```
+
+Add to `src/memory/reasoning/mod.rs` (near the other `pub mod` lines):
+
+```rust
+pub mod distillation;
+pub use distillation::{
+    resolve_distillation, DistillationDecision, DistillationMode, ResolvedReasonerKind,
+};
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p synaptic --features embeddings distillation:: 2>&1 | tail -20`
+Expected: PASS — 8 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/memory/reasoning/distillation.rs src/memory/reasoning/mod.rs
+git commit -m "feat(reasoning): DistillationPolicy resolver for write-time distillation"
+```
+
+---
+
+### Task 2: Config fields + deprecated alias + constructor wiring
+
+**Files:**
+- Modify: `src/lib.rs` (MemoryConfig struct ~1705, Default impl ~1757, constructor reasoner block ~245, struct fields ~120)
+- Test: inline `#[cfg(test)]` in `src/lib.rs` (the module that already holds `store_extracted_facts_*` tests, ~1800)
+
+**Interfaces:**
+- Consumes: `DistillationMode`, `ResolvedReasonerKind`, `resolve_distillation` from Task 1.
+- Produces:
+  - `MemoryConfig.distillation: memory::reasoning::DistillationMode`
+  - `MemoryConfig.retrieval_excludes_raw_sources: bool` (default `true`)
+  - `MemoryConfig.store_extracted_facts: bool` retained (deprecated; `true` forces `On`)
+  - `AgentMemory` private fields: `distillation_live: bool`, `resolved_reasoner_kind: ResolvedReasonerKind`
+  - `const RAW_SOURCE_FIELD: &'static str = "raw_source"` on `AgentMemory`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the test module in `src/lib.rs` (near `store_extracted_facts_off_by_default_keeps_raw_only`, ~1800):
+
+```rust
+#[tokio::test]
+async fn distillation_defaults_to_auto_off_without_llm() {
+    // Default build has no LLM endpoint => Auto resolves to not-live.
+    let mem = AgentMemory::new(MemoryConfig::default()).await.unwrap();
+    assert!(!mem.distillation_live, "Auto must be off without an LLM reasoner");
+}
+
+#[tokio::test]
+async fn store_extracted_facts_alias_forces_on() {
+    // Deprecated alias: store_extracted_facts=true behaves as DistillationMode::On.
+    // With KG+embeddings present and no llm feature endpoint, On is live (heuristic).
+    let config = MemoryConfig {
+        store_extracted_facts: true,
+        enable_knowledge_graph: true,
+        ..Default::default()
+    };
+    let mem = AgentMemory::new(config).await.unwrap();
+    assert!(mem.distillation_live, "store_extracted_facts=true must make distillation live");
+}
+
+#[tokio::test]
+async fn retrieval_excludes_raw_sources_defaults_true() {
+    let config = MemoryConfig::default();
+    assert!(config.retrieval_excludes_raw_sources);
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p synaptic --features embeddings distillation_defaults_to_auto_off_without_llm 2>&1 | tail -20`
+Expected: FAIL — `distillation_live` field and `distillation` config field do not exist.
+
+- [ ] **Step 3: Implement config + constructor**
+
+3a. Add struct fields to `MemoryConfig` (after `retrieval_excludes_superseded`, ~1711):
+
+```rust
+    /// Write-time fact distillation activation (see
+    /// [`memory::reasoning::DistillationMode`]). Default `Auto`: live when an
+    /// LLM reasoner is configured and the knowledge graph + embeddings are
+    /// available, off otherwise (raw-value behavior unchanged).
+    pub distillation: memory::reasoning::DistillationMode,
+    /// Facts-primary retrieval: when `true`, `search` drops memories tagged as
+    /// raw sources (the original turns distillation summarized), so retrieval
+    /// surfaces distilled facts rather than raw turns. Default `true`. Only has
+    /// an effect when distillation is live (untagged raw turns are unaffected).
+    pub retrieval_excludes_raw_sources: bool,
+```
+
+Update the doc comment on `store_extracted_facts` (~1695) to mark it deprecated:
+
+```rust
+    /// DEPRECATED — use [`MemoryConfig::distillation`]. When `true`, forces
+    /// `DistillationMode::On` (facts stored as `<key>::fact<N>` memories). Kept
+    /// for backwards compatibility; slated for removal in a future major.
+    /// Default `false`.
+    pub store_extracted_facts: bool,
+```
+
+3b. Add to the `Default for MemoryConfig` impl (after `retrieval_excludes_superseded: false,`, ~1758):
+
+```rust
+            distillation: memory::reasoning::DistillationMode::Auto,
+            retrieval_excludes_raw_sources: true,
+```
+
+3c. Add private fields to the `AgentMemory` struct (near `storing_facts: bool,`, ~120):
+
+```rust
+    #[cfg(feature = "embeddings")]
+    distillation_live: bool,
+    #[cfg(feature = "embeddings")]
+    resolved_reasoner_kind: memory::reasoning::ResolvedReasonerKind,
+```
+
+3d. In the constructor, right after the `reasoner` block (~260), compute the kind + live flag. The reasoner block currently discards which branch it took, so set the kind inside it. Replace the reasoner block (~245-260) with:
+
+```rust
+        #[cfg(feature = "embeddings")]
+        let (reasoner, resolved_reasoner_kind): (
+            Arc<dyn memory::reasoning::MemoryReasoner>,
+            memory::reasoning::ResolvedReasonerKind,
+        ) = {
+            let heuristic: Arc<dyn memory::reasoning::MemoryReasoner> =
+                Arc::new(memory::reasoning::HeuristicReasoner::new(Arc::new(
+                    memory::embeddings::TfIdfProvider::default(),
+                )));
+            #[cfg(feature = "llm-reasoning")]
+            {
+                match memory::reasoning::LlmReasoner::from_env() {
+                    Some(llm) => (
+                        Arc::new(llm) as Arc<dyn memory::reasoning::MemoryReasoner>,
+                        memory::reasoning::ResolvedReasonerKind::Llm,
+                    ),
+                    None => (heuristic, memory::reasoning::ResolvedReasonerKind::Heuristic),
+                }
+            }
+            #[cfg(not(feature = "llm-reasoning"))]
+            {
+                (heuristic, memory::reasoning::ResolvedReasonerKind::Heuristic)
+            }
+        };
+```
+
+3e. After the config's `store_extracted_facts`→mode reconciliation and the reasoner block, compute the decision. Add this after the reasoner block (still `#[cfg(feature = "embeddings")]`), where `config` is the incoming `MemoryConfig` (confirm the binding name in the constructor; it is the `config` parameter):
+
+```rust
+        #[cfg(feature = "embeddings")]
+        let distillation_live = {
+            // Deprecated alias: store_extracted_facts=true forces On.
+            let mode = if config.store_extracted_facts {
+                memory::reasoning::DistillationMode::On
+            } else {
+                config.distillation
+            };
+            let prerequisites_met = config.enable_knowledge_graph;
+            let llm_feature_enabled = cfg!(feature = "llm-reasoning");
+            match memory::reasoning::resolve_distillation(
+                mode,
+                resolved_reasoner_kind,
+                prerequisites_met,
+                llm_feature_enabled,
+            ) {
+                Ok(decision) => {
+                    if decision.live
+                        && resolved_reasoner_kind
+                            == memory::reasoning::ResolvedReasonerKind::Heuristic
+                    {
+                        tracing::warn!(
+                            "write-time distillation is live with the heuristic reasoner; \
+                             the measured LoCoMo lift requires an LLM endpoint \
+                             (SYNAPTIC_LLM_URL / SYNAPTIC_LLM_MODEL)"
+                        );
+                    }
+                    decision.live
+                }
+                Err(msg) => {
+                    return Err(crate::error::MemoryError::Configuration { message: msg });
+                }
+            }
+        };
+```
+
+3f. Add both fields to the `Self { ... }` struct construction at the end of the constructor (near `storing_facts: false,`, ~458):
+
+```rust
+            #[cfg(feature = "embeddings")]
+            distillation_live,
+            #[cfg(feature = "embeddings")]
+            resolved_reasoner_kind,
+```
+
+Note: if the constructor is not `#[cfg(feature="embeddings")]`-gated as a whole, the two `distillation_live` / `resolved_reasoner_kind` bindings must be produced under the same cfg. Verify `crate::error::SynapticError::ConfigurationError` exists (grep: `grep -n "ConfigurationError" src/error.rs`); if the variant name differs, use the actual config-error variant.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p synaptic --features embeddings distillation 2>&1 | tail -20`
+Expected: PASS — the three new tests plus the Task-1 tests.
+
+Also confirm no regression:
+Run: `cargo test -p synaptic --features embeddings store_extracted_facts 2>&1 | tail -20`
+Expected: PASS (existing tests unaffected — the alias still stores facts).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib.rs
+git commit -m "feat(config): DistillationMode config + constructor live-flag + deprecated alias"
+```
+
+---
+
+### Task 3: Tag raw source after facts land + `mark_raw_source` helper
+
+**Files:**
+- Modify: `src/lib.rs` — `reason_over_store` (~713), new `mark_raw_source` helper (next to `mark_superseded` ~763), `RAW_SOURCE_FIELD` const (next to `SUPERSEDED_FIELD` ~913), and the gate at ~692.
+- Test: inline `#[cfg(test)]` in `src/lib.rs`
+
+**Interfaces:**
+- Consumes: `distillation_live` (Task 2), `RAW_SOURCE_FIELD`.
+- Produces: after `reason_over_store` stores ≥1 fact, the raw entry has `custom_fields["raw_source"]` set; on extraction/store failure it does not.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `src/lib.rs` test module:
+
+```rust
+// A stub reasoner that returns a fixed set of facts (or an error) so the write
+// path is testable without an LLM. Placed in the test module.
+#[cfg(feature = "embeddings")]
+#[derive(Clone)]
+struct StubReasoner {
+    facts: Vec<String>,
+    fail: bool,
+}
+
+#[cfg(feature = "embeddings")]
+#[async_trait::async_trait]
+impl memory::reasoning::MemoryReasoner for StubReasoner {
+    async fn extract(
+        &self,
+        _text: &str,
+        _ctx: &memory::reasoning::ExtractionContext,
+    ) -> Result<memory::reasoning::Extraction> {
+        if self.fail {
+            return Err(crate::error::MemoryError::ProcessingError(
+                "stub extract failure".to_string(),
+            ));
+        }
+        Ok(memory::reasoning::Extraction {
+            facts: self
+                .facts
+                .iter()
+                .map(|t| memory::reasoning::Fact {
+                    text: t.clone(),
+                    entities: Vec::new(),
+                    relations: Vec::new(),
+                })
+                .collect(),
+        })
+    }
+    async fn resolve(
+        &self,
+        _candidate: &memory::reasoning::Fact,
+        _neighbors: &[memory::reasoning::NeighborFact],
+    ) -> Result<memory::reasoning::ConflictResolution> {
+        Ok(memory::reasoning::ConflictResolution::Insert)
+    }
+    async fn synthesize(
+        &self,
+        _cluster: &[MemoryEntry],
+    ) -> Result<Option<memory::reasoning::Insight>> {
+        Ok(None)
+    }
+    fn name(&self) -> &str {
+        "StubReasoner"
+    }
+}
+
+#[tokio::test]
+async fn distillation_tags_raw_source_after_facts_land() {
+    let config = MemoryConfig {
+        store_extracted_facts: true,
+        enable_knowledge_graph: true,
+        ..Default::default()
+    };
+    let mut mem = AgentMemory::new(config).await.unwrap();
+    mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
+        facts: vec!["Alice lives in Berlin".to_string()],
+        fail: false,
+    }));
+    mem.store("turn1", "Alice: I moved to Berlin last year").await.unwrap();
+
+    // Raw turn is tagged; the fact memory exists and is not tagged.
+    let raw = mem.get_entry_for_test("turn1").await.unwrap();
+    assert!(raw.metadata.custom_fields.contains_key("raw_source"));
+    let fact = mem.get_entry_for_test("turn1::fact0").await.unwrap();
+    assert!(!fact.metadata.custom_fields.contains_key("raw_source"));
+}
+
+#[tokio::test]
+async fn distillation_failure_leaves_raw_untagged() {
+    let config = MemoryConfig {
+        store_extracted_facts: true,
+        enable_knowledge_graph: true,
+        ..Default::default()
+    };
+    let mut mem = AgentMemory::new(config).await.unwrap();
+    mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
+        facts: vec![],
+        fail: true,
+    }));
+    // Write still succeeds (best-effort); raw turn stays searchable/untagged.
+    mem.store("turn1", "Alice: I moved to Berlin").await.unwrap();
+    let raw = mem.get_entry_for_test("turn1").await.unwrap();
+    assert!(!raw.metadata.custom_fields.contains_key("raw_source"));
+}
+```
+
+Add these two test-only helpers to `impl AgentMemory` (guard with `#[cfg(all(feature = "embeddings", test))]` or `#[cfg(feature = "test-utils")]` to match repo convention — check which the existing tests use; the `neighbor_examined_max` helper uses `test-utils`, but these are simpler as `#[cfg(test)]`):
+
+```rust
+    #[cfg(all(feature = "embeddings", test))]
+    fn set_reasoner_for_test(&mut self, r: Arc<dyn memory::reasoning::MemoryReasoner>) {
+        self.reasoner = r;
+    }
+
+    #[cfg(all(feature = "embeddings", test))]
+    async fn get_entry_for_test(&self, key: &str) -> Option<MemoryEntry> {
+        self.storage.retrieve(key).await.ok().flatten()
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p synaptic --features embeddings distillation_tags_raw_source_after_facts_land 2>&1 | tail -25`
+Expected: FAIL — `set_reasoner_for_test`/`get_entry_for_test` missing, `raw_source` never set.
+
+- [ ] **Step 3: Implement**
+
+3a. Add the const next to `SUPERSEDED_FIELD` (~913):
+
+```rust
+    /// Custom-field key marking a memory as a raw source turn that write-time
+    /// distillation has summarized into facts. Excluded from `search` when
+    /// [`MemoryConfig::retrieval_excludes_raw_sources`] is set.
+    #[cfg(feature = "embeddings")]
+    const RAW_SOURCE_FIELD: &'static str = "raw_source";
+```
+
+3b. Add `mark_raw_source` next to `mark_superseded` (~777):
+
+```rust
+    /// Tag a raw source turn as summarized-by-distillation (facts-primary
+    /// retrieval). Mirrors [`mark_superseded`]: records `raw_source` in the
+    /// entry's custom fields and persists it, without re-running reasoning.
+    #[cfg(feature = "embeddings")]
+    async fn mark_raw_source(&mut self, key: &str) -> Result<()> {
+        if let Some(mut entry) = self.storage.retrieve(key).await? {
+            entry
+                .metadata
+                .custom_fields
+                .insert(Self::RAW_SOURCE_FIELD.to_string(), Utc::now().to_rfc3339());
+            self.storage.store(&entry).await?;
+            if self.state.has_memory(key) {
+                self.state.add_memory(entry);
+            }
+        }
+        Ok(())
+    }
+```
+
+3c. In `reason_over_store` (~713), track whether any fact was stored and tag the raw entry at the end. The existing per-fact loop stores facts behind `self._config.store_extracted_facts` (~744) — change that gate to the live flag and record success. Replace the fact-storage block (~744-752) with:
+
+```rust
+            // Persist the extracted fact as its own retrievable memory so
+            // search surfaces distilled facts, not just raw turns.
+            if self.distillation_live && !fact.text.trim().is_empty() {
+                let fact_key = format!("{}::fact{}", entry.key, i);
+                self.storing_facts = true;
+                // Box::pin breaks the recursive-future size cycle
+                // (store_with_report → reason_over_store → store_with_report).
+                let result = Box::pin(self.store_with_report(&fact_key, &fact.text)).await;
+                self.storing_facts = false;
+                result?;
+                stored_any_fact = true;
+            }
+```
+
+Add `let mut stored_any_fact = false;` at the top of `reason_over_store` (after the empty-extraction early return, ~724), and after the `for` loop, before `Ok(())`:
+
+```rust
+        // Failure-ordering invariant: tag the raw turn as a summarized source
+        // ONLY after ≥1 fact has been stored. If extraction or fact storage
+        // failed above (propagated via `?`), we never reach here, so the raw
+        // turn stays untagged and searchable — a distillation outage degrades
+        // to raw-turn retrieval rather than hiding a turn with no replacement.
+        if stored_any_fact {
+            self.mark_raw_source(&entry.key).await?;
+        }
+```
+
+3d. Update the gate at ~692 so reasoning runs when distillation is live (not only when a KG exists — but the KG is a prerequisite, so keep both):
+
+```rust
+        #[cfg(feature = "embeddings")]
+        if self.knowledge_graph.is_some() && self.distillation_live && !self.storing_facts {
+            if let Err(e) = self.reason_over_store(&entry).await {
+                tracing::warn!(error = %e, "reasoning degraded during store");
+                degradations.reasoning = Some(e.to_string());
+            }
+        }
+```
+
+Note: this changes the previous behavior where `reason_over_store` ran whenever a KG existed (for KG-only supersession side effects) even with facts off. If preserving KG supersession when distillation is off is required, keep the gate as `knowledge_graph.is_some() && !self.storing_facts` and instead rely on the `self.distillation_live` check already inside the fact-storage block (3c) — reasoning runs, but only tags/stores facts when live. **Choose the latter** to avoid regressing KG behavior: revert the gate to its original condition and leave the `distillation_live` checks only inside `reason_over_store`. The `stored_any_fact` tag block already guards tagging.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p synaptic --features embeddings distillation 2>&1 | tail -25`
+Expected: PASS — both new tests plus prior distillation tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib.rs
+git commit -m "feat(write-path): tag raw sources after facts land (failure-ordering invariant)"
+```
+
+---
+
+### Task 4: `search` filter excludes raw sources
+
+**Files:**
+- Modify: `src/lib.rs` — `search` (~1345)
+- Test: inline `#[cfg(test)]` in `src/lib.rs`
+
+**Interfaces:**
+- Consumes: `RAW_SOURCE_FIELD`, `retrieval_excludes_raw_sources`, `distillation_live`.
+- Produces: `search` returns fact memories and excludes `raw_source`-tagged turns by default; with `retrieval_excludes_raw_sources=false` the raw turn reappears.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[tokio::test]
+async fn search_excludes_raw_sources_by_default() {
+    let config = MemoryConfig {
+        store_extracted_facts: true,
+        enable_knowledge_graph: true,
+        ..Default::default()
+    };
+    let mut mem = AgentMemory::new(config).await.unwrap();
+    mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
+        facts: vec!["Alice lives in Berlin".to_string()],
+        fail: false,
+    }));
+    mem.store("turn1", "Alice: I moved to Berlin last year").await.unwrap();
+
+    let hits = mem.search("Berlin", 10).await.unwrap();
+    let keys: Vec<&str> = hits.iter().map(|f| f.entry.key.as_str()).collect();
+    assert!(keys.iter().any(|k| k.contains("::fact")), "fact must be retrievable");
+    assert!(!keys.contains(&"turn1"), "raw source must be excluded by default");
+}
+
+#[tokio::test]
+async fn search_includes_raw_sources_when_disabled() {
+    let config = MemoryConfig {
+        store_extracted_facts: true,
+        enable_knowledge_graph: true,
+        retrieval_excludes_raw_sources: false,
+        ..Default::default()
+    };
+    let mut mem = AgentMemory::new(config).await.unwrap();
+    mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
+        facts: vec!["Alice lives in Berlin".to_string()],
+        fail: false,
+    }));
+    mem.store("turn1", "Alice: I moved to Berlin last year").await.unwrap();
+
+    let hits = mem.search("Berlin", 10).await.unwrap();
+    let keys: Vec<&str> = hits.iter().map(|f| f.entry.key.as_str()).collect();
+    assert!(keys.contains(&"turn1"), "raw source must reappear when filter disabled");
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p synaptic --features embeddings search_excludes_raw_sources_by_default 2>&1 | tail -20`
+Expected: FAIL — raw `turn1` is still in results (no filter yet).
+
+- [ ] **Step 3: Implement the filter**
+
+In `search` (~1345), right after the existing superseded `retain` block, add:
+
+```rust
+        // Facts-primary retrieval: when enabled, drop raw source turns that
+        // distillation has summarized, so search surfaces distilled facts.
+        #[cfg(feature = "embeddings")]
+        if self._config.retrieval_excludes_raw_sources {
+            results.retain(|f| {
+                !f.entry
+                    .metadata
+                    .custom_fields
+                    .contains_key(Self::RAW_SOURCE_FIELD)
+            });
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p synaptic --features embeddings search_ 2>&1 | tail -20`
+Expected: PASS — both new tests.
+
+Full regression on the crate:
+Run: `cargo test -p synaptic --features embeddings 2>&1 | tail -8`
+Expected: PASS — all lib tests (no regressions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib.rs
+git commit -m "feat(search): exclude raw sources by default (facts-primary retrieval)"
+```
+
+---
+
+### Task 5: Eval harness A/B write-path switch
+
+**Files:**
+- Modify: `tools/eval/src/qa.rs` — `run_agentic_qa` / `run_agentic_qa_impl` (~1827, ~1872) to accept a `MemoryConfig` factory; the internal `AgentMemory::new(MemoryConfig::default())` call (~1888) uses it.
+- Modify: `tools/eval/src/bin/run_eval.rs` — `run_agentic_qa_only` (~767) reads a `--distill` flag and builds the facts-primary config.
+- Test: inline `#[cfg(test)]` in `run_eval.rs` for the flag parse + config builder.
+
+**Interfaces:**
+- Consumes: `synaptic::MemoryConfig`, `DistillationMode`.
+- Produces:
+  - `qa::run_agentic_qa(conversations, judge, k, max_rounds, grounded, ground_verify, memory_config: MemoryConfig)` — new trailing param.
+  - `run_eval` `--distill` flag → `MemoryConfig { distillation: On, enable_knowledge_graph: true, retrieval_excludes_raw_sources: true, ..default }`; absent → `MemoryConfig::default()`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add a `#[cfg(test)]` module to `run_eval.rs`:
+
+```rust
+#[cfg(test)]
+mod distill_flag_tests {
+    use super::distillation_config;
+    use synaptic::memory::reasoning::DistillationMode;
+
+    #[test]
+    fn distill_flag_builds_facts_primary_config() {
+        let cfg = distillation_config(true);
+        assert_eq!(cfg.distillation, DistillationMode::On);
+        assert!(cfg.enable_knowledge_graph);
+        assert!(cfg.retrieval_excludes_raw_sources);
+    }
+
+    #[test]
+    fn no_distill_flag_is_default() {
+        let cfg = distillation_config(false);
+        assert_eq!(cfg.distillation, DistillationMode::Auto);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p synaptic-eval --bin run_eval distill_flag 2>&1 | tail -20`
+Expected: FAIL — `distillation_config` not found.
+
+- [ ] **Step 3: Implement**
+
+3a. Add the config builder to `run_eval.rs` (near the other helpers):
+
+```rust
+/// Build the memory config for the agentic-QA run. `distill=true` selects the
+/// facts-primary write path (DistillationMode::On, KG on, raw sources excluded);
+/// `false` returns the default config (today's raw-turn behavior).
+fn distillation_config(distill: bool) -> synaptic::MemoryConfig {
+    if distill {
+        synaptic::MemoryConfig {
+            distillation: synaptic::memory::reasoning::DistillationMode::On,
+            enable_knowledge_graph: true,
+            retrieval_excludes_raw_sources: true,
+            ..Default::default()
+        }
+    } else {
+        synaptic::MemoryConfig::default()
+    }
+}
+```
+
+3b. In `run_agentic_qa_only` (~767), parse the flag and pass the config. The signature currently takes `conversations` + writer; the flag comes from the top-level `args`. Since `run_agentic_qa_only` does not see `args`, thread a `bool` param: change its signature to `run_agentic_qa_only(conversations, distill: bool, w)` and its caller in `main` (~256) to pass `args.iter().any(|a| a == "--distill")`. Then:
+
+```rust
+    let report = qa::run_agentic_qa(
+        conversations,
+        &judge,
+        K,
+        max_rounds,
+        grounded,
+        ground_verify,
+        distillation_config(distill),
+    )
+    .await
+    .map_err(|e| e.to_string())?;
+```
+
+3c. In `qa.rs`, add the trailing `memory_config: MemoryConfig` param to `run_agentic_qa`, `run_agentic_qa_over_facts`, and `run_agentic_qa_impl`, and use it in place of `MemoryConfig::default()` at ~1888:
+
+```rust
+        let mut memory = AgentMemory::new(memory_config.clone())
+            .await
+            .map_err(mem_err)?;
+```
+
+(`MemoryConfig` derives `Clone`; confirm with `grep -n "struct MemoryConfig" -A2 src/lib.rs`. It does.)
+
+3d. Update the other callers of `run_agentic_qa` / `_over_facts` (grep: `rg "run_agentic_qa(_over_facts)?\(" tools/eval`) to pass `MemoryConfig::default()` where they don't opt into distillation, so the crate still compiles.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p synaptic-eval --bin run_eval distill_flag 2>&1 | tail -20`
+Expected: PASS — 2 tests.
+
+Build the whole eval crate to catch caller drift:
+Run: `cargo build -p synaptic-eval --bin run_eval 2>&1 | tail -5`
+Expected: `Finished`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/eval/src/qa.rs tools/eval/src/bin/run_eval.rs
+git commit -m "feat(eval): --distill A/B write-path switch for agentic QA"
+```
+
+---
+
+### Task 6: Run the full-LoCoMo A/B and document the result
+
+**Files:**
+- Modify: `docs/evaluation.md` (new A/B section at end)
+- Modify: `README.md` (distillation note)
+- Modify: memory `v2-capability-scorecard.md` (only if the result changes the scorecard claim)
+
+This task produces a MEASUREMENT and documentation, not library code. It uses the codex OAuth shim as the extraction endpoint (the same setup used for the judge — NOT the user's OpenAI API key) and the GPU cross-encoder build.
+
+- [ ] **Step 1: Build the release eval binary with the LLM + GPU features**
+
+```bash
+source "$SCRATCHPAD/cudaenv.sh"
+cargo build --release -p synaptic-eval --bin run_eval \
+  --features 'synaptic/static-embeddings synaptic/reranker-model synaptic/cuda synaptic/llm-reasoning'
+```
+Expected: `Finished`. (The `llm-reasoning` feature is required so `LlmReasoner::from_env()` can resolve the codex shim endpoint; without it, `DistillationMode::On` will error per Task 1.)
+
+- [ ] **Step 2: Start the codex→OpenAI shim** (per the running-qa-eval memory) and export the LLM env for both the judge and the write-path reasoner:
+
+```bash
+export SYNAPTIC_LLM_URL="http://127.0.0.1:<shim-port>/v1"
+export SYNAPTIC_LLM_MODEL="<codex-model>"
+export SYNAPTIC_EVAL_JUDGE=codex SYNAPTIC_EVAL_CODEX_TIMEOUT_SECS=120 SYNAPTIC_EVAL_QA_CONCURRENCY=12
+export SYNAPTIC_RETRIEVAL_EMBEDDER=static SYNAPTIC_STATIC_MODEL_DIR=models/potion-base-8M SYNAPTIC_RETRIEVAL_PRF=1
+export SYNAPTIC_RERANKER=cross-encoder SYNAPTIC_RERANKER_MODEL_DIR=models/ms-marco-MiniLM-L6-v2
+```
+
+- [ ] **Step 3: Run Arm A (baseline, raw-turn ingestion)** with a dedicated checkpoint:
+
+```bash
+export SYNAPTIC_EVAL_QA_CHECKPOINT="$SCRATCHPAD/ab_baseline_ckpt.jsonl"
+./target/release/run_eval tools/eval/data/locomo10.json --agentic-qa 2>&1 | tee "$SCRATCHPAD/ab_baseline.out"
+```
+Expected: a `QA: graded=1986 ... accuracy=...` line. Record the overall + per-category numbers.
+
+- [ ] **Step 4: Run Arm B (distillation, facts-primary)** with its own checkpoint:
+
+```bash
+export SYNAPTIC_EVAL_QA_CHECKPOINT="$SCRATCHPAD/ab_distill_ckpt.jsonl"
+./target/release/run_eval tools/eval/data/locomo10.json --agentic-qa --distill 2>&1 | tee "$SCRATCHPAD/ab_distill.out"
+```
+Expected: a `QA: graded=1986 ... accuracy=...` line. Note: Arm B is slower — each turn incurs an LLM extraction call at ingest.
+
+- [ ] **Step 5: Write the A/B section in `docs/evaluation.md`**
+
+Add a dated section with a table: overall + per-category accuracy for Arm A vs Arm B and the delta, plus a one-line honest verdict. If Arm B ≥ Arm A, state distillation is validated as a default; if not, state it is not shipped default-on and why. Use the exact measured numbers — do not invent them. Template:
+
+```markdown
+### Write-time distillation A/B on full LoCoMo (2026-07-20)
+
+Same 1,986-q set, same judge (codex) + retrieval (PRF + GPU cross-encoder); only the
+write path differs. Arm A ingests raw turns; Arm B distills facts (DistillationMode::On,
+facts-primary, raw sources excluded from search), using the codex shim as the extractor.
+
+| category | Arm A (raw) | Arm B (distill) | Δ |
+|---|---|---|---|
+| Overall | <A> | <B> | <Δ> |
+| SingleHop | ... | ... | ... |
+| Temporal | ... | ... | ... |
+| OpenDomain | ... | ... | ... |
+| MultiHop | ... | ... | ... |
+| Abstention | ... | ... | ... |
+
+**Verdict:** <one honest sentence — validated default if B ≥ A, else not shipped and why>.
+```
+
+- [ ] **Step 6: Update `README.md`** with a short note (only the copy, no numbers unless B≥A):
+
+```markdown
+### Write-time fact distillation
+
+When an LLM endpoint is configured (`SYNAPTIC_LLM_URL` / `SYNAPTIC_LLM_MODEL`, with the
+`llm-reasoning` feature) and the knowledge graph is enabled, `store()` distills each turn
+into fact memories that become the primary retrievable units; the original turns are kept
+but excluded from default search. Control it with `MemoryConfig::distillation`
+(`Auto` — default, on when an LLM is configured / `On` / `Off`).
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/evaluation.md README.md
+git commit -m "docs(eval): full-LoCoMo write-time distillation A/B result"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Facts-primary retrieval (Approach A, metadata + filter) → Tasks 3, 4. ✓
+- `DistillationMode` Auto/On/Off + resolver → Tasks 1, 2. ✓
+- Auto default (on when LLM+KG) → Task 2 (constructor). ✓
+- Deprecated `store_extracted_facts` alias → Task 2. ✓
+- Failure-ordering invariant (tag after facts land) → Task 3 (test `distillation_failure_leaves_raw_untagged`). ✓
+- Best-effort semantics (degradations.reasoning) → Task 3 (gate unchanged, error path logs). ✓
+- Search filter `retrieval_excludes_raw_sources` → Task 4. ✓
+- Eval A/B write-path switch → Task 5. ✓
+- Full-LoCoMo before/after, honesty-gated → Task 6. ✓
+- No-LLM/no-KG equivalence → Task 2 test `distillation_defaults_to_auto_off_without_llm`. ✓
+
+**2. Placeholder scan:** Task 6 uses `<A>/<B>/<Δ>` — these are intentional measurement outputs to be filled from real runs, not code placeholders. All code steps contain complete code. `<shim-port>` / `<codex-model>` are environment specifics documented in the running-qa-eval memory.
+
+**3. Type consistency:** `DistillationMode` (Task 1) used consistently in Tasks 2, 5. `ResolvedReasonerKind` (Task 1) used in Task 2. `RAW_SOURCE_FIELD` const (Task 3) used in Task 4. `distillation_live` field (Task 2) used in Task 3. `distillation_config` (Task 5) matches its test. Reasoner trait method signatures in the Task-3 stub (`extract`/`resolve`) must match the real `MemoryReasoner` trait — VERIFY against `src/memory/reasoning/mod.rs` before writing the stub (the `Extraction`/`Fact`/`ConflictResolution`/`NeighborFact` shapes are used from real code at `src/lib.rs:714-731`, so they are accurate).
+
+**Verified APIs (confirmed against the code, 2026-07-20):**
+- Crate error type is `crate::error::MemoryError` (`src/error.rs:6,16`). Config error variant: `MemoryError::Configuration { message: String }` (`:60`). Processing error: `MemoryError::ProcessingError(String)` (`:178`). The plan uses these exact forms.
+- `MemoryReasoner` has FOUR methods: `extract`, `resolve`, `synthesize`, `name` (`src/memory/reasoning/mod.rs:146-159`). The `StubReasoner` implements all four (done above).
+- `Fact` fields: `text: String`, `entities: Vec<Entity>`, `relations: Vec<Relation>` (`:64`). The stub sets `entities: Vec::new()`.
+- `MemoryConfig.enable_knowledge_graph` **already defaults to `true`** (`src/lib.rs:1723`), so the `Auto` prerequisite is met by default; a default build with an LLM endpoint is live without extra config. The tests set it explicitly only for clarity.
+- `MemoryConfig` derives `Clone` (`src/lib.rs:1632`), so `memory_config.clone()` in Task 5 is valid.

--- a/docs/superpowers/specs/2026-07-20-write-time-distillation-design.md
+++ b/docs/superpowers/specs/2026-07-20-write-time-distillation-design.md
@@ -1,0 +1,192 @@
+# Write-Time Fact Distillation — Design Spec
+
+**Date:** 2026-07-20
+**Status:** Approved (brainstorm), pending implementation plan
+**Author:** brainstormed with the user
+
+## Problem
+
+Measurement this cycle established that rust-synaptic's LoCoMo QA gap versus Mem0 was
+never a *retrieval* problem — it was *ingestion*. With write-time LLM-distilled facts,
+this repo ties Mem0 (≈0.475 → 0.500 QA on the matched LoCoMo slice; see
+`docs/evaluation.md` "Closing the gap: write-time fact extraction"). But the product
+does not use this by default:
+
+- `MemoryConfig::store_extracted_facts` defaults to `false` (`src/lib.rs`).
+- The default reasoner is the heuristic TF-IDF `HeuristicReasoner`; the `LlmReasoner`
+  only activates with the `llm-reasoning` feature + endpoint env (`src/lib.rs:246`).
+- Even with `store_extracted_facts = true`, facts are stored *in addition to* the raw
+  turn, and both compete in retrieval — which did NOT reproduce the measured
+  facts-primary condition (the eval built the store from facts only).
+
+So the single highest-leverage, already-validated improvement is dormant. This spec
+promotes and hardens the existing `MemoryReasoner` + `store_extracted_facts` scaffolding
+into a real default write path: **when an LLM endpoint is configured, `store()` distills
+the incoming turn into fact-memories that become the primary retrievable units; raw turns
+are persisted but excluded from default search.**
+
+## Goals
+
+1. Distillation is a real, default-on path **when an LLM endpoint is configured**, with
+   zero surprising cost when one is not (no LLM → today's raw-turn behavior, unchanged).
+2. Facts are the primary retrievable units; raw turns are retained (provenance) but
+   excluded from default ranking — reproducing the measured Mem0-parity condition.
+3. Best-effort semantics: any distillation failure degrades to today's raw-turn
+   retrievability, never loses data or breaks the write.
+4. A matched before/after LoCoMo A/B proves the lift, gated on distillation ≥ baseline.
+
+## Non-Goals
+
+- Building a stronger no-LLM heuristic extractor (extraction quality is the whole lever;
+  the heuristic will not reach parity — explicitly out of scope).
+- A separate fact index / collection-aware retriever (larger change; the metadata-filter
+  approach achieves the same behavior).
+- Changing the answer/QA path, grounding, or abstention (separate deferred threads).
+- Fixing the O(n²) write path (separate deferred thread; noted, not addressed here).
+
+## Global Constraints
+
+- **Honesty bar (project-wide):** no fabricated numbers; report negative results; if the
+  A/B does not show distillation ≥ baseline, report it and do NOT ship default-on.
+- **Best-effort subsystems:** distillation joins the other `store_with_report` subsystems
+  as best-effort — failure sets a `degradations.*` field and logs, never aborts the write.
+- **Backwards compatibility:** existing callers using `store_extracted_facts` must keep
+  working (deprecated alias, mapped to the new enum).
+- **No behavior change for no-LLM deployments:** a store with no configured LLM reasoner
+  must be byte-for-byte equivalent to today (raw turns stored untagged and searchable).
+- **PR-only merge flow:** repo ruleset requires PRs; a new branch per PR iteration.
+
+## Design
+
+### Retrieval model (decided)
+
+**Facts primary, raw demoted** (Approach A — demote-by-metadata + search filter):
+
+- Raw turns are stored as today but tagged `custom_fields["raw_source"] = "<rfc3339 ts>"`
+  **only when distillation is live**.
+- Distilled facts are stored as normal, *untagged*, retrievable memories keyed
+  `{source_key}::fact{i}` (the existing naming in `reason_over_store`).
+- `search` excludes `raw_source`-tagged memories by default, via a new config
+  `retrieval_excludes_raw_sources` — structurally identical to the existing
+  `retrieval_excludes_superseded` filter (`src/lib.rs`, `SUPERSEDED_FIELD`).
+- Raw turns remain reachable by explicit key lookup or an opt-in "include raw" search.
+
+Rejected alternatives: (B) facts replace raw — lossy, no provenance; (C) separate fact
+index — retriever is not collection-aware, much larger change for identical behavior.
+
+### Configuration (decided)
+
+A single `MemoryConfig::distillation: DistillationMode` enum resolved at construction:
+
+- `Auto` **(default)** — distillation is live when **both** (a) the resolved reasoner is
+  the `LlmReasoner` and (b) the write-path prerequisites are met (`enable_knowledge_graph`
+  + `embeddings`, which today's `reason_over_store` already requires at `src/lib.rs:692`);
+  off otherwise. No LLM configured, or no KG/embeddings → off → today's behavior. This is
+  the "on when LLM configured" default posture. The `DistillationPolicy` resolver takes
+  the KG/embeddings availability as an input alongside the reasoner kind.
+- `On` — require distillation. If the write-path prerequisites (`enable_knowledge_graph` +
+  `embeddings`) are absent, return a construction error (distillation cannot run at all).
+  If prerequisites are met but no LLM reasoner is available because the feature is present
+  and no endpoint resolves, return a construction error (fail loud on misconfiguration). If
+  the caller forces `On` in a build without the `llm-reasoning` feature (only a heuristic
+  reasoner can exist), log a one-time warning that the measured lift requires an LLM and
+  proceed with heuristic facts rather than erroring.
+- `Off` — never distill (escape hatch; exactly today's behavior).
+
+`store_extracted_facts: bool` is retained as a **deprecated alias**: `true` → `On`,
+`false` → leaves `distillation` at its `Auto`/explicit value. The alias is documented as
+deprecated and slated for removal in a future major.
+
+`retrieval_excludes_raw_sources: bool` — defaults to `true`. Controls the search filter.
+
+### Components (three focused units)
+
+1. **`DistillationPolicy`** (new, small, `src/memory/reasoning/` or inline module):
+   pure resolver from `(DistillationMode, ResolvedReasonerKind)` → `{ live: bool }`, plus
+   the construction-error decision for `On`+no-LLM. Testable with no store, no I/O.
+   - `ResolvedReasonerKind` is a small enum (`Llm` | `Heuristic`) the constructor sets
+     when it resolves `self.reasoner` (`src/lib.rs:246`).
+
+2. **`reason_over_store`** (exists, `src/lib.rs:713`): extended to
+   - store each non-empty fact as `{key}::fact{i}` (already present behind the flag),
+   - after ≥1 fact is successfully stored, tag the *raw* entry `raw_source` and persist
+     the tag (reusing the `mark_*` update pattern, like `mark_superseded`).
+   - The existing `storing_facts` guard already prevents recursion / re-tagging of facts.
+
+3. **`search` filter** (`src/lib.rs`): add one retain clause mirroring the superseded
+   filter, gated on `retrieval_excludes_raw_sources`.
+
+### Data flow (write path)
+
+On `store(key, value)` with distillation live:
+
+1. Persist the raw turn (as today). Do **not** tag it yet.
+2. `reason_over_store` runs (gated on `!storing_facts`): extract facts; for each, resolve
+   against neighbors, apply KG resolution + supersession (all existing).
+3. Persist each non-empty fact as `{key}::fact{i}` (untagged, searchable) via the existing
+   `Box::pin(self.store_with_report(...))` recursive path with `storing_facts = true`.
+4. **Only after ≥1 fact is stored**, tag the raw entry `raw_source` and persist the tag.
+5. `search` excludes `raw_source`-tagged memories when `retrieval_excludes_raw_sources`.
+
+**Failure-ordering invariant (correctness crux):** the raw turn is tagged *after*
+successful fact storage, never before. If extraction or fact storage fails, the raw turn
+remains **untagged and searchable**, and `degradations.reasoning` is set — a distillation
+outage degrades to today's behavior rather than hiding a raw turn with no fact to replace
+it. This ordering is a required, tested property.
+
+### Error handling
+
+- Distillation is best-effort inside `store_with_report`: extractor/endpoint failure logs
+  a warning, sets `degradations.reasoning`, leaves the raw turn searchable, and the write
+  succeeds.
+- `DistillationMode::On` with no LLM reasoner available (feature present, endpoint
+  unresolved) is the one *construction-time* hard error — misconfiguration should fail
+  loudly, not silently store weak facts.
+
+## Testing
+
+**Unit (deterministic, no network — stub `MemoryReasoner` returning known facts/errors):**
+
+- `DistillationPolicy`: `Auto`+Llm → live; `Auto`+Heuristic → off; `On`+no-Llm(feature on,
+  no endpoint) → construction error; `On`+Heuristic(no feature) → live+warn; `Off` → off.
+- Write path, stub extractor with known facts: raw turn ends up tagged `raw_source`; facts
+  stored as `{key}::fact{i}` untagged; `search` returns facts and excludes the raw turn;
+  with `retrieval_excludes_raw_sources = false` the raw turn reappears in results.
+- **Failure invariant:** stub extractor returns `Err` → raw turn stays *untagged* and
+  searchable; `degradations.reasoning` is set; write still succeeds.
+- Recursion/tag guard: storing a `{key}::fact{i}` memory does not re-tag it `raw_source`
+  nor re-run distillation on it.
+- Deprecated alias: `store_extracted_facts = true` behaves as `DistillationMode::On`.
+- No-LLM equivalence: with a heuristic-only build, a store leaves the raw turn untagged
+  and searchable (no behavior change).
+
+**A/B measurement (the "prove the lift" deliverable):**
+
+Extend the eval harness with a write-path switch so the *same* full LoCoMo run
+(1,986 questions) can ingest either way, holding judge + retrieval (PRF + GPU
+cross-encoder) constant:
+
+- **Arm A (baseline):** raw-turn ingestion, distillation off.
+- **Arm B (distillation):** facts-primary via the new default path, using the codex LLM as
+  the extraction endpoint (the same OAuth shim already used for the judge).
+- Report overall + per-category QA accuracy deltas; reuse the resumable checkpoint
+  (`SYNAPTIC_EVAL_QA_CHECKPOINT`) so each arm is restartable.
+- **Done bar:** Arm B ≥ Arm A overall, targeting the measured ≈0.475 → 0.500 parity. If B
+  does not beat A, report honestly and do NOT ship distillation default-on.
+
+**Docs:** a `docs/evaluation.md` section with the A/B table; a README note that
+distillation auto-activates when an LLM endpoint is configured, and how to force On/Off.
+
+## Rollout
+
+1. Land config + policy + write-path + search filter + unit tests (default `Auto`, so
+   no-LLM deployments are unaffected) behind a PR with green substantive CI.
+2. Run the A/B; add the measured section to `docs/evaluation.md`.
+3. Only if B ≥ A: document distillation as the recommended default and update the README.
+   If B < A: keep the machinery (it is opt-in-correct) but do not claim/ship a default win;
+   record the negative result.
+
+## Open questions
+
+None blocking. The heuristic-`On` warning wording and the exact `raw_source` timestamp
+format are implementation details for the plan.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -837,7 +837,7 @@ impl AgentMemory {
     }
 
     /// Tag a raw source turn as summarized-by-distillation (facts-primary
-    /// retrieval). Mirrors [`mark_superseded`]: records `raw_source` in the
+    /// retrieval). Mirrors [`Self::mark_superseded`]: records `raw_source` in the
     /// entry's custom fields and persists it, without re-running reasoning.
     #[cfg(feature = "embeddings")]
     async fn mark_raw_source(&mut self, key: &str) -> Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1867,7 +1867,15 @@ impl Default for MemoryConfig {
             promotion_config: Some(memory::promotion::PromotionConfig::default()),
             store_extracted_facts: false,
             retrieval_excludes_superseded: false,
-            distillation: memory::reasoning::DistillationMode::Auto,
+            // Default OFF (opt-in), not Auto: a full-LoCoMo-subset A/B measured
+            // facts-primary distillation to HURT QA (raw baseline 0.505 ->
+            // distill 0.258 on 198 matched questions with a local 7B extractor;
+            // abstention doubled). Lossy facts drop answer detail and excluding
+            // raw turns removes the verbatim fallback (incl. the session-date
+            // prefix temporal questions need). A frontier extractor helps but is
+            // impractically slow for the write path. See docs/evaluation.md
+            // "Write-time distillation A/B". Enable explicitly to opt in.
+            distillation: memory::reasoning::DistillationMode::Off,
             retrieval_excludes_raw_sources: true,
         }
     }
@@ -2022,10 +2030,16 @@ mod tests {
 
     #[cfg(feature = "embeddings")]
     #[tokio::test]
-    async fn distillation_defaults_to_auto_off_without_llm() {
-        // Default build has no LLM endpoint => Auto resolves to not-live.
+    async fn distillation_default_is_off() {
+        // Default is DistillationMode::Off (opt-in) after the A/B measured
+        // facts-primary distillation to hurt QA — so the default write path is
+        // never live, even if an LLM endpoint happens to be configured.
         let mem = AgentMemory::new(MemoryConfig::default()).await.unwrap();
-        assert!(!mem.distillation_live, "Auto must be off without an LLM reasoner");
+        assert!(!mem.distillation_live, "default distillation must be off (opt-in)");
+        assert_eq!(
+            mem._config.distillation,
+            memory::reasoning::DistillationMode::Off
+        );
     }
 
     #[cfg(feature = "embeddings")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,17 @@ pub struct AgentMemory {
     /// re-run extraction (which would recurse forever).
     #[cfg(feature = "embeddings")]
     storing_facts: bool,
+    /// Whether write-time fact distillation is active for this instance
+    /// (resolved once at construction time from `MemoryConfig::distillation` /
+    /// the deprecated `store_extracted_facts` alias, the active reasoner kind,
+    /// and prerequisite availability).
+    #[cfg(feature = "embeddings")]
+    distillation_live: bool,
+    /// Which reasoner kind backs the write path (LLM or heuristic); used to
+    /// resolve `DistillationMode` and to warn when distillation goes live on
+    /// the heuristic reasoner.
+    #[cfg(feature = "embeddings")]
+    resolved_reasoner_kind: memory::reasoning::ResolvedReasonerKind,
     #[cfg(feature = "distributed-experimental")]
     distributed_coordinator:
         Option<std::sync::Arc<distributed::coordination::DistributedCoordinator>>,
@@ -166,6 +177,12 @@ pub struct AgentMemory {
 }
 
 impl AgentMemory {
+    /// Metadata field name used to tag a memory as a raw source that
+    /// write-time distillation has summarized into fact-memories. Consulted
+    /// by retrieval when `MemoryConfig::retrieval_excludes_raw_sources` is set.
+    #[allow(dead_code)]
+    const RAW_SOURCE_FIELD: &'static str = "raw_source";
+
     /// Create a new agent memory system with the given configuration
     #[tracing::instrument(skip(config), fields(session_id = %config.session_id.unwrap_or_else(Uuid::new_v4)))]
     pub async fn new(config: MemoryConfig) -> Result<Self> {
@@ -243,7 +260,10 @@ impl AgentMemory {
         // inner HeuristicReasoner on any LLM error, so the write path never
         // hard-fails or fabricates. Feature off or unconfigured: heuristic.
         #[cfg(feature = "embeddings")]
-        let reasoner: Arc<dyn memory::reasoning::MemoryReasoner> = {
+        let (reasoner, resolved_reasoner_kind): (
+            Arc<dyn memory::reasoning::MemoryReasoner>,
+            memory::reasoning::ResolvedReasonerKind,
+        ) = {
             let heuristic: Arc<dyn memory::reasoning::MemoryReasoner> =
                 Arc::new(memory::reasoning::HeuristicReasoner::new(Arc::new(
                     memory::embeddings::TfIdfProvider::default(),
@@ -251,12 +271,53 @@ impl AgentMemory {
             #[cfg(feature = "llm-reasoning")]
             {
                 match memory::reasoning::LlmReasoner::from_env() {
-                    Some(llm) => Arc::new(llm),
-                    None => heuristic,
+                    Some(llm) => (
+                        Arc::new(llm) as Arc<dyn memory::reasoning::MemoryReasoner>,
+                        memory::reasoning::ResolvedReasonerKind::Llm,
+                    ),
+                    None => (heuristic, memory::reasoning::ResolvedReasonerKind::Heuristic),
                 }
             }
             #[cfg(not(feature = "llm-reasoning"))]
-            heuristic
+            {
+                (heuristic, memory::reasoning::ResolvedReasonerKind::Heuristic)
+            }
+        };
+
+        // Resolve write-time distillation activation from config (and the
+        // deprecated `store_extracted_facts` alias, which forces `On`).
+        #[cfg(feature = "embeddings")]
+        let distillation_live = {
+            let mode = if config.store_extracted_facts {
+                memory::reasoning::DistillationMode::On
+            } else {
+                config.distillation
+            };
+            let prerequisites_met = config.enable_knowledge_graph;
+            let llm_feature_enabled = cfg!(feature = "llm-reasoning");
+            match memory::reasoning::resolve_distillation(
+                mode,
+                resolved_reasoner_kind,
+                prerequisites_met,
+                llm_feature_enabled,
+            ) {
+                Ok(decision) => {
+                    if decision.live
+                        && resolved_reasoner_kind
+                            == memory::reasoning::ResolvedReasonerKind::Heuristic
+                    {
+                        tracing::warn!(
+                            "write-time distillation is live with the heuristic reasoner; \
+                             the measured LoCoMo lift requires an LLM endpoint \
+                             (SYNAPTIC_LLM_URL / SYNAPTIC_LLM_MODEL)"
+                        );
+                    }
+                    decision.live
+                }
+                Err(msg) => {
+                    return Err(crate::error::MemoryError::Configuration { message: msg });
+                }
+            }
         };
 
         // Reflection engine: clusters memories accumulated since the last
@@ -456,6 +517,10 @@ impl AgentMemory {
             reflection_accumulated_importance: 0.0,
             #[cfg(feature = "embeddings")]
             storing_facts: false,
+            #[cfg(feature = "embeddings")]
+            distillation_live,
+            #[cfg(feature = "embeddings")]
+            resolved_reasoner_kind,
             #[cfg(feature = "distributed-experimental")]
             distributed_coordinator,
             #[cfg(feature = "analytics")]
@@ -1692,16 +1757,10 @@ pub struct MemoryConfig {
     pub enable_memory_promotion: bool,
     /// Memory promotion configuration
     pub promotion_config: Option<memory::promotion::PromotionConfig>,
-    /// Intelligent write path: when `true`, each stored value is passed through
-    /// the [`memory::reasoning::MemoryReasoner`] and the extracted facts are
-    /// stored as their own **retrievable** memories (keyed `<key>::fact<N>`),
-    /// in addition to the raw value and the knowledge-graph updates. This is the
-    /// Mem0-style write-time distillation that lets retrieval surface clean
-    /// facts rather than raw turns (measured to lift LoCoMo QA; see
-    /// `docs/evaluation.md`). Requires `enable_knowledge_graph` + `embeddings`;
-    /// extraction quality scales with the active reasoner (heuristic default, or
-    /// `LlmReasoner` when `SYNAPTIC_LLM_URL`/`_MODEL` are set). Default: `false`
-    /// (raw-value-only behavior is unchanged).
+    /// DEPRECATED — use [`MemoryConfig::distillation`]. When `true`, forces
+    /// `DistillationMode::On` (facts stored as `<key>::fact<N>` memories). Kept
+    /// for backwards compatibility; slated for removal in a future major.
+    /// Default `false`.
     pub store_extracted_facts: bool,
     /// Bi-temporal validity in retrieval: when `true`, `search` drops memories
     /// that the intelligent write path has marked superseded (a later fact
@@ -1709,6 +1768,16 @@ pub struct MemoryConfig {
     /// update instead of the stale one. Default: `false` (superseded memories
     /// remain retrievable, matching prior behavior).
     pub retrieval_excludes_superseded: bool,
+    /// Write-time fact distillation activation (see
+    /// [`memory::reasoning::DistillationMode`]). Default `Auto`: live when an
+    /// LLM reasoner is configured and the knowledge graph + embeddings are
+    /// available, off otherwise (raw-value behavior unchanged).
+    pub distillation: memory::reasoning::DistillationMode,
+    /// Facts-primary retrieval: when `true`, `search` drops memories tagged as
+    /// raw sources (the original turns distillation summarized), so retrieval
+    /// surfaces distilled facts rather than raw turns. Default `true`. Only has
+    /// an effect when distillation is live (untagged raw turns are unaffected).
+    pub retrieval_excludes_raw_sources: bool,
 }
 
 impl Default for MemoryConfig {
@@ -1756,6 +1825,8 @@ impl Default for MemoryConfig {
             promotion_config: Some(memory::promotion::PromotionConfig::default()),
             store_extracted_facts: false,
             retrieval_excludes_superseded: false,
+            distillation: memory::reasoning::DistillationMode::Auto,
+            retrieval_excludes_raw_sources: true,
         }
     }
 }
@@ -1812,6 +1883,34 @@ mod tests {
             mem.retrieve("note::fact0").await.unwrap().is_none(),
             "no fact-memories should exist with the default (off) config"
         );
+    }
+
+    #[cfg(feature = "embeddings")]
+    #[tokio::test]
+    async fn distillation_defaults_to_auto_off_without_llm() {
+        // Default build has no LLM endpoint => Auto resolves to not-live.
+        let mem = AgentMemory::new(MemoryConfig::default()).await.unwrap();
+        assert!(!mem.distillation_live, "Auto must be off without an LLM reasoner");
+    }
+
+    #[cfg(feature = "embeddings")]
+    #[tokio::test]
+    async fn store_extracted_facts_alias_forces_on() {
+        // Deprecated alias: store_extracted_facts=true behaves as DistillationMode::On.
+        // With KG+embeddings present and no llm feature endpoint, On is live (heuristic).
+        let config = MemoryConfig {
+            store_extracted_facts: true,
+            enable_knowledge_graph: true,
+            ..Default::default()
+        };
+        let mem = AgentMemory::new(config).await.unwrap();
+        assert!(mem.distillation_live, "store_extracted_facts=true must make distillation live");
+    }
+
+    #[tokio::test]
+    async fn retrieval_excludes_raw_sources_defaults_true() {
+        let config = MemoryConfig::default();
+        assert!(config.retrieval_excludes_raw_sources);
     }
 
     #[cfg(feature = "embeddings")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,11 +124,6 @@ pub struct AgentMemory {
     /// and prerequisite availability).
     #[cfg(feature = "embeddings")]
     distillation_live: bool,
-    /// Which reasoner kind backs the write path (LLM or heuristic); used to
-    /// resolve `DistillationMode` and to warn when distillation goes live on
-    /// the heuristic reasoner.
-    #[cfg(feature = "embeddings")]
-    resolved_reasoner_kind: memory::reasoning::ResolvedReasonerKind,
     #[cfg(feature = "distributed-experimental")]
     distributed_coordinator:
         Option<std::sync::Arc<distributed::coordination::DistributedCoordinator>>,
@@ -180,6 +175,7 @@ impl AgentMemory {
     /// Metadata field name used to tag a memory as a raw source that
     /// write-time distillation has summarized into fact-memories. Consulted
     /// by retrieval when `MemoryConfig::retrieval_excludes_raw_sources` is set.
+    #[cfg(feature = "embeddings")]
     const RAW_SOURCE_FIELD: &'static str = "raw_source";
 
     #[cfg(all(feature = "embeddings", test))]
@@ -303,12 +299,10 @@ impl AgentMemory {
                 config.distillation
             };
             let prerequisites_met = config.enable_knowledge_graph;
-            let llm_feature_enabled = cfg!(feature = "llm-reasoning");
             match memory::reasoning::resolve_distillation(
                 mode,
                 resolved_reasoner_kind,
                 prerequisites_met,
-                llm_feature_enabled,
             ) {
                 Ok(decision) => {
                     if decision.live
@@ -528,8 +522,6 @@ impl AgentMemory {
             storing_facts: false,
             #[cfg(feature = "embeddings")]
             distillation_live,
-            #[cfg(feature = "embeddings")]
-            resolved_reasoner_kind,
             #[cfg(feature = "distributed-experimental")]
             distributed_coordinator,
             #[cfg(feature = "analytics")]
@@ -1808,7 +1800,9 @@ pub struct MemoryConfig {
     /// DEPRECATED — use [`MemoryConfig::distillation`]. When `true`, forces
     /// `DistillationMode::On` (facts stored as `<key>::fact<N>` memories). Kept
     /// for backwards compatibility; slated for removal in a future major.
-    /// Default `false`.
+    /// Default `false`. When this alias is live, raw source turns are excluded
+    /// from default `search` results (facts-primary retrieval) because
+    /// `retrieval_excludes_raw_sources` defaults to `true`.
     pub store_extracted_facts: bool,
     /// Bi-temporal validity in retrieval: when `true`, `search` drops memories
     /// that the intelligent write path has marked superseded (a later fact

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,8 +180,17 @@ impl AgentMemory {
     /// Metadata field name used to tag a memory as a raw source that
     /// write-time distillation has summarized into fact-memories. Consulted
     /// by retrieval when `MemoryConfig::retrieval_excludes_raw_sources` is set.
-    #[allow(dead_code)]
     const RAW_SOURCE_FIELD: &'static str = "raw_source";
+
+    #[cfg(all(feature = "embeddings", test))]
+    fn set_reasoner_for_test(&mut self, r: Arc<dyn memory::reasoning::MemoryReasoner>) {
+        self.reasoner = r;
+    }
+
+    #[cfg(all(feature = "embeddings", test))]
+    async fn get_entry_for_test(&self, key: &str) -> Option<MemoryEntry> {
+        self.storage.retrieve(key).await.ok().flatten()
+    }
 
     /// Create a new agent memory system with the given configuration
     #[tracing::instrument(skip(config), fields(session_id = %config.session_id.unwrap_or_else(Uuid::new_v4)))]
@@ -787,6 +796,7 @@ impl AgentMemory {
         if extraction.facts.is_empty() {
             return Ok(());
         }
+        let mut stored_any_fact = false;
         for (i, fact) in extraction.facts.iter().enumerate() {
             let neighbors = self.neighbor_facts(&entry.key, fact, 5).await?;
             let resolution = reasoner.resolve(fact, &neighbors).await?;
@@ -804,9 +814,9 @@ impl AgentMemory {
                 self.mark_superseded(&old_key).await?;
             }
 
-            // Optionally persist the extracted fact as its own retrievable
-            // memory so search surfaces distilled facts, not just raw turns.
-            if self._config.store_extracted_facts && !fact.text.trim().is_empty() {
+            // Persist the extracted fact as its own retrievable memory so
+            // search surfaces distilled facts, not just raw turns.
+            if self.distillation_live && !fact.text.trim().is_empty() {
                 let fact_key = format!("{}::fact{}", entry.key, i);
                 self.storing_facts = true;
                 // Box::pin breaks the recursive-future size cycle
@@ -814,6 +824,33 @@ impl AgentMemory {
                 let result = Box::pin(self.store_with_report(&fact_key, &fact.text)).await;
                 self.storing_facts = false;
                 result?;
+                stored_any_fact = true;
+            }
+        }
+        // Failure-ordering invariant: tag the raw turn as a summarized source
+        // ONLY after ≥1 fact has been stored. If extraction or fact storage
+        // failed above (propagated via `?`), we never reach here, so the raw
+        // turn stays untagged and searchable — a distillation outage degrades
+        // to raw-turn retrieval rather than hiding a turn with no replacement.
+        if stored_any_fact {
+            self.mark_raw_source(&entry.key).await?;
+        }
+        Ok(())
+    }
+
+    /// Tag a raw source turn as summarized-by-distillation (facts-primary
+    /// retrieval). Mirrors [`mark_superseded`]: records `raw_source` in the
+    /// entry's custom fields and persists it, without re-running reasoning.
+    #[cfg(feature = "embeddings")]
+    async fn mark_raw_source(&mut self, key: &str) -> Result<()> {
+        if let Some(mut entry) = self.storage.retrieve(key).await? {
+            entry
+                .metadata
+                .custom_fields
+                .insert(Self::RAW_SOURCE_FIELD.to_string(), Utc::now().to_rfc3339());
+            self.storage.store(&entry).await?;
+            if self.state.has_memory(key) {
+                self.state.add_memory(entry);
             }
         }
         Ok(())
@@ -1849,6 +1886,99 @@ pub enum StorageBackend {
 #[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
     use super::*;
+
+    // A stub reasoner that returns a fixed set of facts (or an error) so the write
+    // path is testable without an LLM.
+    #[cfg(feature = "embeddings")]
+    #[derive(Clone)]
+    struct StubReasoner {
+        facts: Vec<String>,
+        fail: bool,
+    }
+
+    #[cfg(feature = "embeddings")]
+    #[async_trait::async_trait]
+    impl memory::reasoning::MemoryReasoner for StubReasoner {
+        async fn extract(
+            &self,
+            _text: &str,
+            _ctx: &memory::reasoning::ExtractionContext,
+        ) -> Result<memory::reasoning::Extraction> {
+            if self.fail {
+                return Err(crate::error::MemoryError::ProcessingError(
+                    "stub extract failure".to_string(),
+                ));
+            }
+            Ok(memory::reasoning::Extraction {
+                facts: self
+                    .facts
+                    .iter()
+                    .map(|t| memory::reasoning::Fact {
+                        text: t.clone(),
+                        entities: Vec::new(),
+                        relations: Vec::new(),
+                    })
+                    .collect(),
+            })
+        }
+        async fn resolve(
+            &self,
+            _candidate: &memory::reasoning::Fact,
+            _neighbors: &[memory::reasoning::NeighborFact],
+        ) -> Result<memory::reasoning::ConflictResolution> {
+            Ok(memory::reasoning::ConflictResolution::Insert)
+        }
+        async fn synthesize(
+            &self,
+            _cluster: &[MemoryEntry],
+        ) -> Result<Option<memory::reasoning::Insight>> {
+            Ok(None)
+        }
+        fn name(&self) -> &str {
+            "StubReasoner"
+        }
+    }
+
+    #[cfg(feature = "embeddings")]
+    #[tokio::test]
+    async fn distillation_tags_raw_source_after_facts_land() {
+        let config = MemoryConfig {
+            store_extracted_facts: true,
+            enable_knowledge_graph: true,
+            ..Default::default()
+        };
+        let mut mem = AgentMemory::new(config).await.unwrap();
+        mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
+            facts: vec!["Alice lives in Berlin".to_string()],
+            fail: false,
+        }));
+        mem.store("turn1", "Alice: I moved to Berlin last year").await.unwrap();
+
+        // Raw turn is tagged; the fact memory exists and is not tagged.
+        let raw = mem.get_entry_for_test("turn1").await.unwrap();
+        assert!(raw.metadata.custom_fields.contains_key("raw_source"));
+        let fact = mem.get_entry_for_test("turn1::fact0").await.unwrap();
+        assert!(!fact.metadata.custom_fields.contains_key("raw_source"));
+    }
+
+    #[cfg(feature = "embeddings")]
+    #[tokio::test]
+    async fn distillation_failure_leaves_raw_untagged() {
+        let config = MemoryConfig {
+            store_extracted_facts: true,
+            enable_knowledge_graph: true,
+            ..Default::default()
+        };
+        let mut mem = AgentMemory::new(config).await.unwrap();
+        mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
+            facts: vec![],
+            fail: true,
+        }));
+        // Write still succeeds (best-effort); raw turn stays searchable/untagged.
+        mem.store("turn1", "Alice: I moved to Berlin").await.unwrap();
+        let raw = mem.get_entry_for_test("turn1").await.unwrap();
+        assert!(!raw.metadata.custom_fields.contains_key("raw_source"));
+    }
 
     #[test]
     fn test_memory_config_default() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,12 +280,18 @@ impl AgentMemory {
                         Arc::new(llm) as Arc<dyn memory::reasoning::MemoryReasoner>,
                         memory::reasoning::ResolvedReasonerKind::Llm,
                     ),
-                    None => (heuristic, memory::reasoning::ResolvedReasonerKind::Heuristic),
+                    None => (
+                        heuristic,
+                        memory::reasoning::ResolvedReasonerKind::Heuristic,
+                    ),
                 }
             }
             #[cfg(not(feature = "llm-reasoning"))]
             {
-                (heuristic, memory::reasoning::ResolvedReasonerKind::Heuristic)
+                (
+                    heuristic,
+                    memory::reasoning::ResolvedReasonerKind::Heuristic,
+                )
             }
         };
 
@@ -1965,7 +1971,9 @@ mod tests {
             facts: vec!["Alice lives in Berlin".to_string()],
             fail: false,
         }));
-        mem.store("turn1", "Alice: I moved to Berlin last year").await.unwrap();
+        mem.store("turn1", "Alice: I moved to Berlin last year")
+            .await
+            .unwrap();
 
         // Raw turn is tagged; the fact memory exists and is not tagged.
         let raw = mem.get_entry_for_test("turn1").await.unwrap();
@@ -1988,7 +1996,9 @@ mod tests {
             fail: true,
         }));
         // Write still succeeds (best-effort); raw turn stays searchable/untagged.
-        mem.store("turn1", "Alice: I moved to Berlin").await.unwrap();
+        mem.store("turn1", "Alice: I moved to Berlin")
+            .await
+            .unwrap();
         let raw = mem.get_entry_for_test("turn1").await.unwrap();
         assert!(!raw.metadata.custom_fields.contains_key("raw_source"));
     }
@@ -2035,7 +2045,10 @@ mod tests {
         // facts-primary distillation to hurt QA — so the default write path is
         // never live, even if an LLM endpoint happens to be configured.
         let mem = AgentMemory::new(MemoryConfig::default()).await.unwrap();
-        assert!(!mem.distillation_live, "default distillation must be off (opt-in)");
+        assert!(
+            !mem.distillation_live,
+            "default distillation must be off (opt-in)"
+        );
         assert_eq!(
             mem._config.distillation,
             memory::reasoning::DistillationMode::Off
@@ -2053,7 +2066,10 @@ mod tests {
             ..Default::default()
         };
         let mem = AgentMemory::new(config).await.unwrap();
-        assert!(mem.distillation_live, "store_extracted_facts=true must make distillation live");
+        assert!(
+            mem.distillation_live,
+            "store_extracted_facts=true must make distillation live"
+        );
     }
 
     #[tokio::test]
@@ -2144,12 +2160,20 @@ mod tests {
             facts: vec!["Alice lives in Berlin".to_string()],
             fail: false,
         }));
-        mem.store("turn1", "Alice: I moved to Berlin last year").await.unwrap();
+        mem.store("turn1", "Alice: I moved to Berlin last year")
+            .await
+            .unwrap();
 
         let hits = mem.search("Berlin", 10).await.unwrap();
         let keys: Vec<&str> = hits.iter().map(|f| f.entry.key.as_str()).collect();
-        assert!(keys.iter().any(|k| k.contains("::fact")), "fact must be retrievable");
-        assert!(!keys.contains(&"turn1"), "raw source must be excluded by default");
+        assert!(
+            keys.iter().any(|k| k.contains("::fact")),
+            "fact must be retrievable"
+        );
+        assert!(
+            !keys.contains(&"turn1"),
+            "raw source must be excluded by default"
+        );
     }
 
     #[cfg(feature = "embeddings")]
@@ -2166,11 +2190,16 @@ mod tests {
             facts: vec!["Alice lives in Berlin".to_string()],
             fail: false,
         }));
-        mem.store("turn1", "Alice: I moved to Berlin last year").await.unwrap();
+        mem.store("turn1", "Alice: I moved to Berlin last year")
+            .await
+            .unwrap();
 
         let hits = mem.search("Berlin", 10).await.unwrap();
         let keys: Vec<&str> = hits.iter().map(|f| f.entry.key.as_str()).collect();
-        assert!(keys.contains(&"turn1"), "raw source must reappear when filter disabled");
+        assert!(
+            keys.contains(&"turn1"),
+            "raw source must reappear when filter disabled"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1453,6 +1453,17 @@ impl AgentMemory {
                     .contains_key(Self::SUPERSEDED_FIELD)
             });
         }
+        // Facts-primary retrieval: when enabled, drop raw source turns that
+        // distillation has summarized, so search surfaces distilled facts.
+        #[cfg(feature = "embeddings")]
+        if self._config.retrieval_excludes_raw_sources {
+            results.retain(|f| {
+                !f.entry
+                    .metadata
+                    .custom_fields
+                    .contains_key(Self::RAW_SOURCE_FIELD)
+            });
+        }
         tracing::debug!("Search completed, found {} results", results.len());
         Ok(results)
     }
@@ -2110,6 +2121,48 @@ mod tests {
             mem.retrieve("note::fact0::fact0").await.unwrap().is_none(),
             "fact-memories must not themselves be re-extracted (recursion guard)"
         );
+    }
+
+    #[cfg(feature = "embeddings")]
+    #[tokio::test]
+    async fn search_excludes_raw_sources_by_default() {
+        let config = MemoryConfig {
+            store_extracted_facts: true,
+            enable_knowledge_graph: true,
+            ..Default::default()
+        };
+        let mut mem = AgentMemory::new(config).await.unwrap();
+        mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
+            facts: vec!["Alice lives in Berlin".to_string()],
+            fail: false,
+        }));
+        mem.store("turn1", "Alice: I moved to Berlin last year").await.unwrap();
+
+        let hits = mem.search("Berlin", 10).await.unwrap();
+        let keys: Vec<&str> = hits.iter().map(|f| f.entry.key.as_str()).collect();
+        assert!(keys.iter().any(|k| k.contains("::fact")), "fact must be retrievable");
+        assert!(!keys.contains(&"turn1"), "raw source must be excluded by default");
+    }
+
+    #[cfg(feature = "embeddings")]
+    #[tokio::test]
+    async fn search_includes_raw_sources_when_disabled() {
+        let config = MemoryConfig {
+            store_extracted_facts: true,
+            enable_knowledge_graph: true,
+            retrieval_excludes_raw_sources: false,
+            ..Default::default()
+        };
+        let mut mem = AgentMemory::new(config).await.unwrap();
+        mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
+            facts: vec!["Alice lives in Berlin".to_string()],
+            fail: false,
+        }));
+        mem.store("turn1", "Alice: I moved to Berlin last year").await.unwrap();
+
+        let hits = mem.search("Berlin", 10).await.unwrap();
+        let keys: Vec<&str> = hits.iter().map(|f| f.entry.key.as_str()).collect();
+        assert!(keys.contains(&"turn1"), "raw source must reappear when filter disabled");
     }
 
     #[test]

--- a/src/memory/reasoning/distillation.rs
+++ b/src/memory/reasoning/distillation.rs
@@ -1,0 +1,179 @@
+//! Distillation policy: decides whether write-time fact distillation is live
+//! from the configured mode, the resolved reasoner kind, and whether the write
+//! path prerequisites (knowledge graph + embeddings) are available. Pure logic,
+//! no store or IO, so it is unit-testable in isolation.
+
+/// How write-time fact distillation is activated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DistillationMode {
+    /// Live when an LLM reasoner is resolved and the write-path prerequisites
+    /// (knowledge graph + embeddings) are available; off otherwise. Default.
+    #[default]
+    Auto,
+    /// Require distillation. A hard error at construction when prerequisites are
+    /// absent, or when the `llm-reasoning` feature is enabled but no endpoint
+    /// resolved (a heuristic reasoner where an LLM was expected). In a build
+    /// without the feature, proceeds live with a heuristic reasoner and a
+    /// one-time warning.
+    On,
+    /// Never distill (escape hatch; today's raw-value-only behavior).
+    Off,
+}
+
+/// Which reasoner the constructor resolved for the write path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolvedReasonerKind {
+    Llm,
+    Heuristic,
+}
+
+/// Outcome of resolving the distillation policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DistillationDecision {
+    /// Whether the write path should distill facts and tag raw sources.
+    pub live: bool,
+}
+
+/// Resolve whether distillation is live. `prerequisites_met` is
+/// `enable_knowledge_graph && embeddings-available`; `llm_feature_enabled` is
+/// whether the `llm-reasoning` cargo feature is compiled in. Returns `Err` only
+/// for the `On` misconfiguration cases, where the caller should fail construction.
+pub fn resolve_distillation(
+    mode: DistillationMode,
+    reasoner: ResolvedReasonerKind,
+    prerequisites_met: bool,
+    llm_feature_enabled: bool,
+) -> Result<DistillationDecision, String> {
+    match mode {
+        DistillationMode::Off => Ok(DistillationDecision { live: false }),
+        DistillationMode::Auto => Ok(DistillationDecision {
+            live: prerequisites_met && reasoner == ResolvedReasonerKind::Llm,
+        }),
+        DistillationMode::On => {
+            if !prerequisites_met {
+                return Err(
+                    "DistillationMode::On requires enable_knowledge_graph and the \
+                     embeddings feature, but they are not available"
+                        .to_string(),
+                );
+            }
+            // Feature enabled but reasoner came back Heuristic => an endpoint was
+            // expected (SYNAPTIC_LLM_URL/_MODEL) but did not resolve.
+            if llm_feature_enabled && reasoner == ResolvedReasonerKind::Heuristic {
+                return Err(
+                    "DistillationMode::On with the llm-reasoning feature requires a \
+                     configured LLM endpoint (SYNAPTIC_LLM_URL / SYNAPTIC_LLM_MODEL), \
+                     but none resolved"
+                        .to_string(),
+                );
+            }
+            Ok(DistillationDecision { live: true })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_distillation, DistillationMode, ResolvedReasonerKind};
+
+    // Auto: live only with an LLM reasoner AND prerequisites.
+    #[test]
+    fn auto_llm_with_prereqs_is_live() {
+        let d = resolve_distillation(
+            DistillationMode::Auto,
+            ResolvedReasonerKind::Llm,
+            true,
+            true,
+        )
+        .unwrap();
+        assert!(d.live);
+    }
+
+    #[test]
+    fn auto_heuristic_is_off() {
+        let d = resolve_distillation(
+            DistillationMode::Auto,
+            ResolvedReasonerKind::Heuristic,
+            true,
+            false,
+        )
+        .unwrap();
+        assert!(!d.live);
+    }
+
+    #[test]
+    fn auto_llm_without_prereqs_is_off() {
+        let d = resolve_distillation(
+            DistillationMode::Auto,
+            ResolvedReasonerKind::Llm,
+            false,
+            true,
+        )
+        .unwrap();
+        assert!(!d.live);
+    }
+
+    // Off: never live, regardless of everything else.
+    #[test]
+    fn off_is_never_live() {
+        let d = resolve_distillation(
+            DistillationMode::Off,
+            ResolvedReasonerKind::Llm,
+            true,
+            true,
+        )
+        .unwrap();
+        assert!(!d.live);
+    }
+
+    // On: hard error when prerequisites are absent.
+    #[test]
+    fn on_without_prereqs_errors() {
+        let err = resolve_distillation(
+            DistillationMode::On,
+            ResolvedReasonerKind::Heuristic,
+            false,
+            false,
+        );
+        assert!(err.is_err());
+    }
+
+    // On + feature enabled but reasoner resolved Heuristic = endpoint expected
+    // but unresolved = misconfiguration = hard error.
+    #[test]
+    fn on_llm_feature_but_heuristic_reasoner_errors() {
+        let err = resolve_distillation(
+            DistillationMode::On,
+            ResolvedReasonerKind::Heuristic,
+            true,
+            true,
+        );
+        assert!(err.is_err());
+    }
+
+    // On without the llm feature (heuristic is the only possible reasoner):
+    // proceed live with a warning rather than erroring.
+    #[test]
+    fn on_no_llm_feature_is_live_with_heuristic() {
+        let d = resolve_distillation(
+            DistillationMode::On,
+            ResolvedReasonerKind::Heuristic,
+            true,
+            false,
+        )
+        .unwrap();
+        assert!(d.live);
+    }
+
+    #[test]
+    fn on_llm_with_prereqs_is_live() {
+        let d = resolve_distillation(
+            DistillationMode::On,
+            ResolvedReasonerKind::Llm,
+            true,
+            true,
+        )
+        .unwrap();
+        assert!(d.live);
+    }
+}

--- a/src/memory/reasoning/distillation.rs
+++ b/src/memory/reasoning/distillation.rs
@@ -10,11 +10,10 @@ pub enum DistillationMode {
     /// (knowledge graph + embeddings) are available; off otherwise. Default.
     #[default]
     Auto,
-    /// Require distillation. A hard error at construction when prerequisites are
-    /// absent, or when the `llm-reasoning` feature is enabled but no endpoint
-    /// resolved (a heuristic reasoner where an LLM was expected). In a build
-    /// without the feature, proceeds live with a heuristic reasoner and a
-    /// one-time warning.
+    /// Require distillation. A hard error at construction when prerequisites
+    /// (knowledge graph + embeddings) are absent. If the resolved reasoner is
+    /// heuristic (no LLM endpoint resolved), proceeds live anyway with a
+    /// one-time warning rather than erroring.
     On,
     /// Never distill (escape hatch; today's raw-value-only behavior).
     Off,
@@ -35,14 +34,15 @@ pub struct DistillationDecision {
 }
 
 /// Resolve whether distillation is live. `prerequisites_met` is
-/// `enable_knowledge_graph && embeddings-available`; `llm_feature_enabled` is
-/// whether the `llm-reasoning` cargo feature is compiled in. Returns `Err` only
-/// for the `On` misconfiguration cases, where the caller should fail construction.
+/// `enable_knowledge_graph && embeddings-available`. Returns `Err` only when
+/// `On` is requested but prerequisites are absent, where the caller should
+/// fail construction. `On` with a heuristic reasoner (no LLM endpoint
+/// resolved) is not an error here; the caller is expected to warn and
+/// proceed live.
 pub fn resolve_distillation(
     mode: DistillationMode,
     reasoner: ResolvedReasonerKind,
     prerequisites_met: bool,
-    llm_feature_enabled: bool,
 ) -> Result<DistillationDecision, String> {
     match mode {
         DistillationMode::Off => Ok(DistillationDecision { live: false }),
@@ -57,35 +57,21 @@ pub fn resolve_distillation(
                         .to_string(),
                 );
             }
-            // Feature enabled but reasoner came back Heuristic => an endpoint was
-            // expected (SYNAPTIC_LLM_URL/_MODEL) but did not resolve.
-            if llm_feature_enabled && reasoner == ResolvedReasonerKind::Heuristic {
-                return Err(
-                    "DistillationMode::On with the llm-reasoning feature requires a \
-                     configured LLM endpoint (SYNAPTIC_LLM_URL / SYNAPTIC_LLM_MODEL), \
-                     but none resolved"
-                        .to_string(),
-                );
-            }
             Ok(DistillationDecision { live: true })
         }
     }
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::{resolve_distillation, DistillationMode, ResolvedReasonerKind};
 
     // Auto: live only with an LLM reasoner AND prerequisites.
     #[test]
     fn auto_llm_with_prereqs_is_live() {
-        let d = resolve_distillation(
-            DistillationMode::Auto,
-            ResolvedReasonerKind::Llm,
-            true,
-            true,
-        )
-        .unwrap();
+        let d = resolve_distillation(DistillationMode::Auto, ResolvedReasonerKind::Llm, true)
+            .unwrap();
         assert!(d.live);
     }
 
@@ -95,7 +81,6 @@ mod tests {
             DistillationMode::Auto,
             ResolvedReasonerKind::Heuristic,
             true,
-            false,
         )
         .unwrap();
         assert!(!d.live);
@@ -103,26 +88,16 @@ mod tests {
 
     #[test]
     fn auto_llm_without_prereqs_is_off() {
-        let d = resolve_distillation(
-            DistillationMode::Auto,
-            ResolvedReasonerKind::Llm,
-            false,
-            true,
-        )
-        .unwrap();
+        let d = resolve_distillation(DistillationMode::Auto, ResolvedReasonerKind::Llm, false)
+            .unwrap();
         assert!(!d.live);
     }
 
     // Off: never live, regardless of everything else.
     #[test]
     fn off_is_never_live() {
-        let d = resolve_distillation(
-            DistillationMode::Off,
-            ResolvedReasonerKind::Llm,
-            true,
-            true,
-        )
-        .unwrap();
+        let d = resolve_distillation(DistillationMode::Off, ResolvedReasonerKind::Llm, true)
+            .unwrap();
         assert!(!d.live);
     }
 
@@ -133,33 +108,18 @@ mod tests {
             DistillationMode::On,
             ResolvedReasonerKind::Heuristic,
             false,
-            false,
         );
         assert!(err.is_err());
     }
 
-    // On + feature enabled but reasoner resolved Heuristic = endpoint expected
-    // but unresolved = misconfiguration = hard error.
+    // On with a heuristic reasoner (no LLM endpoint resolved) but prerequisites
+    // met: proceed live rather than erroring; the caller warns.
     #[test]
-    fn on_llm_feature_but_heuristic_reasoner_errors() {
-        let err = resolve_distillation(
-            DistillationMode::On,
-            ResolvedReasonerKind::Heuristic,
-            true,
-            true,
-        );
-        assert!(err.is_err());
-    }
-
-    // On without the llm feature (heuristic is the only possible reasoner):
-    // proceed live with a warning rather than erroring.
-    #[test]
-    fn on_no_llm_feature_is_live_with_heuristic() {
+    fn on_with_heuristic_reasoner_is_live() {
         let d = resolve_distillation(
             DistillationMode::On,
             ResolvedReasonerKind::Heuristic,
             true,
-            false,
         )
         .unwrap();
         assert!(d.live);
@@ -167,13 +127,8 @@ mod tests {
 
     #[test]
     fn on_llm_with_prereqs_is_live() {
-        let d = resolve_distillation(
-            DistillationMode::On,
-            ResolvedReasonerKind::Llm,
-            true,
-            true,
-        )
-        .unwrap();
+        let d = resolve_distillation(DistillationMode::On, ResolvedReasonerKind::Llm, true)
+            .unwrap();
         assert!(d.live);
     }
 }

--- a/src/memory/reasoning/distillation.rs
+++ b/src/memory/reasoning/distillation.rs
@@ -70,8 +70,8 @@ mod tests {
     // Auto: live only with an LLM reasoner AND prerequisites.
     #[test]
     fn auto_llm_with_prereqs_is_live() {
-        let d = resolve_distillation(DistillationMode::Auto, ResolvedReasonerKind::Llm, true)
-            .unwrap();
+        let d =
+            resolve_distillation(DistillationMode::Auto, ResolvedReasonerKind::Llm, true).unwrap();
         assert!(d.live);
     }
 
@@ -88,27 +88,24 @@ mod tests {
 
     #[test]
     fn auto_llm_without_prereqs_is_off() {
-        let d = resolve_distillation(DistillationMode::Auto, ResolvedReasonerKind::Llm, false)
-            .unwrap();
+        let d =
+            resolve_distillation(DistillationMode::Auto, ResolvedReasonerKind::Llm, false).unwrap();
         assert!(!d.live);
     }
 
     // Off: never live, regardless of everything else.
     #[test]
     fn off_is_never_live() {
-        let d = resolve_distillation(DistillationMode::Off, ResolvedReasonerKind::Llm, true)
-            .unwrap();
+        let d =
+            resolve_distillation(DistillationMode::Off, ResolvedReasonerKind::Llm, true).unwrap();
         assert!(!d.live);
     }
 
     // On: hard error when prerequisites are absent.
     #[test]
     fn on_without_prereqs_errors() {
-        let err = resolve_distillation(
-            DistillationMode::On,
-            ResolvedReasonerKind::Heuristic,
-            false,
-        );
+        let err =
+            resolve_distillation(DistillationMode::On, ResolvedReasonerKind::Heuristic, false);
         assert!(err.is_err());
     }
 
@@ -116,19 +113,15 @@ mod tests {
     // met: proceed live rather than erroring; the caller warns.
     #[test]
     fn on_with_heuristic_reasoner_is_live() {
-        let d = resolve_distillation(
-            DistillationMode::On,
-            ResolvedReasonerKind::Heuristic,
-            true,
-        )
-        .unwrap();
+        let d = resolve_distillation(DistillationMode::On, ResolvedReasonerKind::Heuristic, true)
+            .unwrap();
         assert!(d.live);
     }
 
     #[test]
     fn on_llm_with_prereqs_is_live() {
-        let d = resolve_distillation(DistillationMode::On, ResolvedReasonerKind::Llm, true)
-            .unwrap();
+        let d =
+            resolve_distillation(DistillationMode::On, ResolvedReasonerKind::Llm, true).unwrap();
         assert!(d.live);
     }
 }

--- a/src/memory/reasoning/mod.rs
+++ b/src/memory/reasoning/mod.rs
@@ -6,10 +6,14 @@
 //! ([`ConflictResolution`]), and higher-level [`Insight`]s synthesized
 //! across clusters of related memories.
 
+pub mod distillation;
 pub mod heuristic;
 #[cfg(feature = "llm-reasoning")]
 pub mod llm;
 
+pub use distillation::{
+    resolve_distillation, DistillationDecision, DistillationMode, ResolvedReasonerKind,
+};
 pub use heuristic::HeuristicReasoner;
 #[cfg(feature = "llm-reasoning")]
 pub use llm::LlmReasoner;

--- a/tools/eval/src/bin/run_eval.rs
+++ b/tools/eval/src/bin/run_eval.rs
@@ -257,7 +257,8 @@ async fn main() -> Result<(), String> {
         if let Some(ref facts) = facts_map {
             return run_agentic_facts_only(&conversations, facts, &mut w).await;
         }
-        return run_agentic_qa_only(&conversations, &mut w).await;
+        let distill = args.iter().any(|a| a == "--distill");
+        return run_agentic_qa_only(&conversations, distill, &mut w).await;
     }
     if growth_only {
         return run_growth_and_qa(&conversations, grow_100k, &mut w).await;
@@ -880,8 +881,45 @@ async fn run_qa_reflect_only(
 /// without codex this reports not-run, never a fabricated number.
 /// `SYNAPTIC_EVAL_AGENTIC_ROUNDS` overrides the max rounds per question
 /// (default 3; see [`qa::agentic_max_rounds`]).
+/// Build the memory config for the agentic-QA run. `distill=true` selects the
+/// facts-primary write path (DistillationMode::On, KG on, raw sources excluded);
+/// `false` returns the default config (today's raw-turn behavior).
+fn distillation_config(distill: bool) -> synaptic::MemoryConfig {
+    if distill {
+        synaptic::MemoryConfig {
+            distillation: synaptic::memory::reasoning::DistillationMode::On,
+            enable_knowledge_graph: true,
+            retrieval_excludes_raw_sources: true,
+            ..Default::default()
+        }
+    } else {
+        synaptic::MemoryConfig::default()
+    }
+}
+
+#[cfg(test)]
+mod distill_flag_tests {
+    use super::distillation_config;
+    use synaptic::memory::reasoning::DistillationMode;
+
+    #[test]
+    fn distill_flag_builds_facts_primary_config() {
+        let cfg = distillation_config(true);
+        assert_eq!(cfg.distillation, DistillationMode::On);
+        assert!(cfg.enable_knowledge_graph);
+        assert!(cfg.retrieval_excludes_raw_sources);
+    }
+
+    #[test]
+    fn no_distill_flag_is_default() {
+        let cfg = distillation_config(false);
+        assert_eq!(cfg.distillation, DistillationMode::Auto);
+    }
+}
+
 async fn run_agentic_qa_only(
     conversations: &[EvalConversation],
+    distill: bool,
     w: &mut impl FnMut(String) -> Result<(), String>,
 ) -> Result<(), String> {
     w("== Agentic answer-guided retrieval QA (--agentic-qa) ==".to_string())?;
@@ -913,6 +951,7 @@ async fn run_agentic_qa_only(
         max_rounds,
         grounded,
         ground_verify,
+        distillation_config(distill),
     )
     .await
     .map_err(|e| e.to_string())?;
@@ -1083,6 +1122,7 @@ async fn run_agentic_facts_only(
         qa::agentic_max_rounds(),
         qa::grounded_enabled(),
         qa::ground_verify_enabled(),
+        synaptic::MemoryConfig::default(),
     )
     .await
     .map_err(|e| e.to_string())?;

--- a/tools/eval/src/qa.rs
+++ b/tools/eval/src/qa.rs
@@ -1875,6 +1875,7 @@ pub async fn run_agentic_qa(
     max_rounds: usize,
     grounded: bool,
     ground_verify: bool,
+    memory_config: MemoryConfig,
 ) -> Result<AgenticReport, QaError> {
     run_agentic_qa_impl(
         conversations,
@@ -1884,6 +1885,7 @@ pub async fn run_agentic_qa(
         max_rounds,
         grounded,
         ground_verify,
+        memory_config,
     )
     .await
 }
@@ -1900,6 +1902,7 @@ pub async fn run_agentic_qa_over_facts(
     max_rounds: usize,
     grounded: bool,
     ground_verify: bool,
+    memory_config: MemoryConfig,
 ) -> Result<AgenticReport, QaError> {
     run_agentic_qa_impl(
         conversations,
@@ -1909,6 +1912,7 @@ pub async fn run_agentic_qa_over_facts(
         max_rounds,
         grounded,
         ground_verify,
+        memory_config,
     )
     .await
 }
@@ -1921,6 +1925,7 @@ async fn run_agentic_qa_impl(
     max_rounds: usize,
     grounded: bool,
     ground_verify: bool,
+    memory_config: MemoryConfig,
 ) -> Result<AgenticReport, QaError> {
     let max_rounds = max_rounds.max(1);
     let concurrency = qa_concurrency();
@@ -1976,7 +1981,7 @@ async fn run_agentic_qa_impl(
             continue;
         }
 
-        let mut memory = AgentMemory::new(MemoryConfig::default())
+        let mut memory = AgentMemory::new(memory_config.clone())
             .await
             .map_err(mem_err)?;
         match facts_by_index.and_then(|m| m.get(&ci)) {


### PR DESCRIPTION
Supersedes #110 (doc-link fix; ruleset blocks pushing to an existing PR branch). Core CI (fmt, clippy, 4 test matrices, 3 test suites) was green on #110; this adds only a one-line rustdoc-link fix.

Builds write-time fact distillation as a configurable write path, **measures it honestly, and ships it default-Off** because the measurement is negative. Spec + plan under `docs/superpowers/`.

## Built (Tasks 1–5, TDD, per-task + whole-branch reviewed; 2 CI-blockers fixed)
`DistillationMode {Auto,On,Off}` + pure `DistillationPolicy` resolver; config + constructor live-flag; deprecated `store_extracted_facts` alias → `On`; write path distills each turn into `{key}::fact{i}` and tags the raw turn `raw_source` **only after ≥1 fact lands** (failure-ordering invariant, tested); best-effort; `search` excludes raw sources; eval `--distill` A/B switch. 484 lib tests pass; clippy + fmt + docs clean.

## Measurement (Task 6) — negative
Matched LoCoMo A/B (conv 0, **198 q**, codex judge + PRF + GPU cross-encoder constant; only the write path differs):

| category | Arm A (raw) | Arm B (7B distill) | Δ |
|---|---|---|---|
| **Overall** | **0.5051** | **0.2576** | **−0.2475** |
| SingleHop | 0.729 | 0.257 | −0.471 |
| Temporal | 0.784 | 0.486 | −0.297 |
| MultiHop | 0.188 | 0.062 | −0.125 |
| OpenDomain | 0.385 | 0.308 | −0.077 |

Accuracy nearly halved; abstention doubled (103 vs 44). A qwen-vs-codex extraction diagnostic isolates two mechanisms: (1) a frontier extractor preserves answer detail the 7B drops — but codex is impractically slow for a per-turn write path (full frontier A/B infeasible); (2) facts-primary loses raw context regardless of extractor (the `[session-date]` prefix temporal questions need; the verbatim fallback).

## Decision (honesty bar)
Default → **`DistillationMode::Off`** (opt-in). Machinery stays complete/tested/reviewed for deployments with a strong, fast extractor that measure it themselves. README + `docs/evaluation.md` document the result with caveats.

**Lesson:** facts-primary retrieval that excludes raw turns trades away verbatim recall LoCoMo QA depends on — distillation should *augment* raw retrieval, not replace it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)