### PR TITLE
feat(distillation): default to augment (raw retained) — recovers the facts-primary loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ answer-guided retrieval** eval mode that lifts end-to-end QA accuracy to
 **0.50** on a labelled subset (a codex-CLI judge; see caveats) while abstaining
 ("I don't know") rather than confabulating when the evidence is absent — a
 faithfulness property measured explicitly. **Write-time fact distillation** is
-implemented as an opt-in write path (`MemoryConfig::distillation`, default
-**Off**): in an offline facts-only construction with a frontier extractor it
-tied [Mem0](https://github.com/mem0ai/mem0) (0.500) on a 40-question slice, but
-a matched end-to-end A/B of the *shipped* facts-primary path (raw turns
-excluded from search) with an accessible local extractor measured it to **hurt**
-QA (0.505 → 0.258 on 198 questions) — so it ships default-off. Honest
-head-to-heads vs Mem0 and Graphiti (Zep), and this negative distillation
-result — each *reversing* an earlier under-tested claim — are documented with
-all caveats in [docs/evaluation.md](docs/evaluation.md).
+an opt-in write path (`MemoryConfig::distillation`, default **Off**): a matched
+end-to-end A/B showed that a *facts-primary* variant (raw turns excluded from
+search) **hurts** QA (0.505 → 0.258 on 198 questions with a local extractor) —
+the exclusion, not the distillation, was the culprit — whereas an *augment*
+variant that keeps raw turns searchable ties the baseline (0.500). So
+distillation ships default-off, and when enabled defaults to the safe augment
+mode. Honest head-to-heads vs Mem0 and Graphiti (Zep), and this distillation
+investigation — reversing an earlier under-tested claim, then isolating the fix
+— are documented with all caveats in [docs/evaluation.md](docs/evaluation.md).
 
 This is a development library (version 0.2.0, not published to crates.io).
 The table below states honestly which parts are stable, which are beta, and
@@ -44,7 +44,7 @@ backed by a measured run in [docs/evaluation.md](docs/evaluation.md).
 | Storage backends | stable | Memory, file (Sled); SQL (PostgreSQL) behind `sql-storage` |
 | Knowledge graph | stable | Node merging, relationship detection, traversal; tested |
 | Intelligent write path (`MemoryReasoner`) | beta | On store, the active reasoner extracts facts/entities/relations from the value: entities & relations feed the knowledge graph. Deterministic `HeuristicReasoner` by default (offline); `LlmReasoner` (OpenAI-compatible endpoint) under `llm-reasoning`, with heuristic fallback. |
-| Write-time distillation (`MemoryConfig::distillation`) | experimental, **default off** | When `On` (or the deprecated `store_extracted_facts = true`) each extracted fact is persisted as its own retrievable memory (`<key>::fact<N>`) and raw turns are excluded from `search` (facts-primary). A matched LoCoMo A/B measured this to **hurt** QA with an accessible extractor (0.505 → 0.258) — opt-in only. See [docs/evaluation.md](docs/evaluation.md) |
+| Write-time distillation (`MemoryConfig::distillation`) | experimental, **default off** | When `On` (or the deprecated `store_extracted_facts = true`) each extracted fact is persisted as its own retrievable memory (`<key>::fact<N>`). Defaults to **augment** (`retrieval_excludes_raw_sources = false`): facts are added alongside raw turns — a matched LoCoMo A/B tied baseline (0.500). Setting the flag `true` gives facts-primary (raw excluded), which the same A/B measured to **hurt** QA (0.505 → 0.258). See [docs/evaluation.md](docs/evaluation.md) |
 | Embeddings | stable | Deterministic local embeddings; used by hybrid retrieval |
 | Search / hybrid retrieval | beta | Tokenized keyword + vector + graph + temporal retrievers fused with Reciprocal Rank Fusion (RRF), composite scoring, and a deterministic reranker over an over-fetched candidate pool. Optional: PRF pool augmentation (`SYNAPTIC_RETRIEVAL_PRF`), multi-hop graph expansion, semantic embeddings (`static-embeddings` / `ml-models` / Ollama), and a candle BERT cross-encoder reranker (`reranker-model`, GPU via `cuda`). Measured on LoCoMo — see [docs/evaluation.md](docs/evaluation.md) |
 | Evaluation harness (`tools/eval`) | beta | Real LoCoMo/LongMemEval loaders; retrieval metrics (recall/precision/MRR, `--recall-curve`, `--completeness`), memory-growth, and LLM-gated end-to-end QA (`--qa-only`, `--agentic-qa`) with abstention/faithfulness metrics. Every printed number is a real run; QA is gated on a configured judge, never fabricated |
@@ -130,11 +130,14 @@ with a lexical/TF-IDF embedder):
 Write-time distillation is a runtime config, not a feature flag: set
 `MemoryConfig::distillation = DistillationMode::On` (or the deprecated
 `store_extracted_facts = true`) to persist each extracted fact as a retrievable
-memory and serve facts-primary. **Default is `Off`** — a matched LoCoMo A/B
-measured facts-primary distillation to hurt QA with an accessible extractor
-(see [docs/evaluation.md](docs/evaluation.md)); enable only with a strong, fast
-extractor you have measured on your own workload. Quality scales with the active
-reasoner (`LlmReasoner` under `llm-reasoning`, else `HeuristicReasoner`).
+memory. **Default is `Off`.** When enabled it defaults to **augment**
+(`retrieval_excludes_raw_sources = false`): facts are added alongside raw turns,
+which a matched LoCoMo A/B measured as neutral vs. the raw baseline (0.500 vs
+0.505). Setting `retrieval_excludes_raw_sources = true` gives *facts-primary*
+(raw excluded), which the same A/B measured to **hurt** QA (→ 0.258) — use it
+only with a strong extractor you have measured on your own workload. Quality
+scales with the active reasoner (`LlmReasoner` under `llm-reasoning`, else
+`HeuristicReasoner`).
 
 Other optional features: `sql-storage`, `multimodal`, `external-integrations`,
 `cross-platform`, `observability`, and `distributed-experimental` (explicitly

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -1821,3 +1821,33 @@ not measured end-to-end (infeasibly slow here). The finding that generalizes: **
 retrieval that excludes raw turns trades away verbatim recall (dates, exact details) that LoCoMo QA
 depends on** — distillation should *augment* raw retrieval, not replace it, and only with an
 extraction step faithful enough to not drop answer-bearing detail.
+
+### Follow-up: augment (raw retained) recovers the loss — the exclusion was the culprit (2026-07-21)
+
+The negative result above pointed at a specific fix: distillation should *augment* raw retrieval,
+not *replace* it. We tested it directly with a third arm on the same conversation and matched
+questions, changing only `retrieval_excludes_raw_sources` (a new `--distill-keep-raw` eval flag):
+Arm C distills facts (same qwen2.5:7b extractor) but **keeps raw turns searchable**.
+
+| arm | overall | abstained | Δ vs raw baseline |
+|---|---|---|---|
+| A — raw baseline | 0.5051 | 44 | — |
+| B — facts-primary (raw excluded) | 0.2576 | 103 | −0.2475 |
+| **C — augment (raw retained)** | **0.5000** | 52 | **−0.0051 (tie)** |
+
+Per category (A raw / B facts-primary / C augment): Temporal 0.784 / 0.486 / **0.784**; MultiHop
+0.188 / 0.062 / **0.188**; OpenDomain 0.385 / 0.308 / **0.385**; SingleHop 0.729 / 0.257 / 0.671;
+Abstention 0.196 / 0.196 / **0.261**.
+
+**The harm was entirely the raw-exclusion, not distillation.** Augment recovers the whole −0.25 —
+matching baseline exactly on Temporal, MultiHop, and OpenDomain, nearly on SingleHop, and slightly
+*beating* it on Abstention. So distilled facts added alongside raw turns are **safe** (neutral with a
+weak extractor) and preserve the verbatim fallback (dates, exact details) that facts-primary threw
+away. They do not *lift* QA here — a 7B extractor's facts add no signal the raw turns lack — but this
+is the correct foundation: with a stronger extractor, augment could add lift without the downside.
+
+**Change applied:** the opt-in distillation default is now **augment** —
+`MemoryConfig::retrieval_excludes_raw_sources` defaults to `false`. Enabling `distillation = On` (or
+the deprecated `store_extracted_facts = true`) now adds facts alongside raw turns rather than
+replacing them, so opting in is safe by default. Facts-primary (raw excluded) remains available by
+setting the flag to `true`, for callers who measure it as a net win on their own extractor/workload.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1806,9 +1806,9 @@ pub struct MemoryConfig {
     /// DEPRECATED — use [`MemoryConfig::distillation`]. When `true`, forces
     /// `DistillationMode::On` (facts stored as `<key>::fact<N>` memories). Kept
     /// for backwards compatibility; slated for removal in a future major.
-    /// Default `false`. When this alias is live, raw source turns are excluded
-    /// from default `search` results (facts-primary retrieval) because
-    /// `retrieval_excludes_raw_sources` defaults to `true`.
+    /// Default `false`. When this alias is live, distilled facts are added
+    /// alongside raw turns (augment mode), since `retrieval_excludes_raw_sources`
+    /// defaults to `false`.
     pub store_extracted_facts: bool,
     /// Bi-temporal validity in retrieval: when `true`, `search` drops memories
     /// that the intelligent write path has marked superseded (a later fact
@@ -1817,14 +1817,20 @@ pub struct MemoryConfig {
     /// remain retrievable, matching prior behavior).
     pub retrieval_excludes_superseded: bool,
     /// Write-time fact distillation activation (see
-    /// [`memory::reasoning::DistillationMode`]). Default `Auto`: live when an
-    /// LLM reasoner is configured and the knowledge graph + embeddings are
-    /// available, off otherwise (raw-value behavior unchanged).
+    /// [`memory::reasoning::DistillationMode`]). Default `Off` (opt-in): a
+    /// matched LoCoMo A/B measured facts-primary distillation to hurt QA (see
+    /// `docs/evaluation.md`), so the default write path never distills. Set to
+    /// `On` to enable; quality scales with the active reasoner (an `LlmReasoner`
+    /// under `llm-reasoning`, else the heuristic).
     pub distillation: memory::reasoning::DistillationMode,
     /// Facts-primary retrieval: when `true`, `search` drops memories tagged as
     /// raw sources (the original turns distillation summarized), so retrieval
-    /// surfaces distilled facts rather than raw turns. Default `true`. Only has
-    /// an effect when distillation is live (untagged raw turns are unaffected).
+    /// surfaces distilled facts *instead of* raw turns. Default `false`
+    /// (**augment** mode: distilled facts are added alongside raw turns rather
+    /// than replacing them). The A/B showed that *excluding* raw turns is what
+    /// hurt QA — it removed the verbatim fallback (dates, exact details) — while
+    /// augment recovered baseline accuracy (0.505 → 0.258 facts-primary vs 0.500
+    /// augment). Only has an effect when distillation is live.
     pub retrieval_excludes_raw_sources: bool,
 }
 
@@ -1882,7 +1888,10 @@ impl Default for MemoryConfig {
             // impractically slow for the write path. See docs/evaluation.md
             // "Write-time distillation A/B". Enable explicitly to opt in.
             distillation: memory::reasoning::DistillationMode::Off,
-            retrieval_excludes_raw_sources: true,
+            // Augment, not facts-primary: distillation (when opted in) adds
+            // facts alongside raw turns rather than excluding raw from search.
+            // The A/B showed exclusion is what hurt QA; augment ties baseline.
+            retrieval_excludes_raw_sources: false,
         }
     }
 }
@@ -2073,9 +2082,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn retrieval_excludes_raw_sources_defaults_true() {
+    async fn retrieval_excludes_raw_sources_defaults_false_augment() {
+        // Default is augment (raw retained), not facts-primary: the A/B showed
+        // excluding raw turns hurts QA.
         let config = MemoryConfig::default();
-        assert!(config.retrieval_excludes_raw_sources);
+        assert!(!config.retrieval_excludes_raw_sources);
     }
 
     #[cfg(feature = "embeddings")]
@@ -2149,10 +2160,13 @@ mod tests {
 
     #[cfg(feature = "embeddings")]
     #[tokio::test]
-    async fn search_excludes_raw_sources_by_default() {
+    async fn search_excludes_raw_sources_when_enabled() {
+        // Facts-primary is now opt-in (default is augment), so set the flag
+        // explicitly to exercise the exclusion filter.
         let config = MemoryConfig {
             store_extracted_facts: true,
             enable_knowledge_graph: true,
+            retrieval_excludes_raw_sources: true,
             ..Default::default()
         };
         let mut mem = AgentMemory::new(config).await.unwrap();

--- a/tools/eval/src/bin/run_eval.rs
+++ b/tools/eval/src/bin/run_eval.rs
@@ -257,8 +257,11 @@ async fn main() -> Result<(), String> {
         if let Some(ref facts) = facts_map {
             return run_agentic_facts_only(&conversations, facts, &mut w).await;
         }
-        let distill = args.iter().any(|a| a == "--distill");
-        return run_agentic_qa_only(&conversations, distill, &mut w).await;
+        // `--distill` = facts-primary (raw excluded); `--distill-keep-raw` =
+        // augment (distill on, raw turns retained in search).
+        let keep_raw = args.iter().any(|a| a == "--distill-keep-raw");
+        let distill = keep_raw || args.iter().any(|a| a == "--distill");
+        return run_agentic_qa_only(&conversations, distill, !keep_raw, &mut w).await;
     }
     if growth_only {
         return run_growth_and_qa(&conversations, grow_100k, &mut w).await;
@@ -881,15 +884,18 @@ async fn run_qa_reflect_only(
 /// without codex this reports not-run, never a fabricated number.
 /// `SYNAPTIC_EVAL_AGENTIC_ROUNDS` overrides the max rounds per question
 /// (default 3; see [`qa::agentic_max_rounds`]).
-/// Build the memory config for the agentic-QA run. `distill=true` selects the
-/// facts-primary write path (DistillationMode::On, KG on, raw sources excluded);
-/// `false` returns the default config (today's raw-turn behavior).
-fn distillation_config(distill: bool) -> synaptic::MemoryConfig {
+/// Build the memory config for the agentic-QA run. `distill=true` turns on the
+/// distillation write path (DistillationMode::On, KG on). `exclude_raw` controls
+/// whether raw source turns are dropped from search: `true` = facts-primary
+/// (facts replace raw in retrieval), `false` = augment (facts ADD alongside raw,
+/// so the verbatim fallback is preserved). `distill=false` returns the default
+/// config (today's raw-turn behavior).
+fn distillation_config(distill: bool, exclude_raw: bool) -> synaptic::MemoryConfig {
     if distill {
         synaptic::MemoryConfig {
             distillation: synaptic::memory::reasoning::DistillationMode::On,
             enable_knowledge_graph: true,
-            retrieval_excludes_raw_sources: true,
+            retrieval_excludes_raw_sources: exclude_raw,
             ..Default::default()
         }
     } else {
@@ -904,22 +910,33 @@ mod distill_flag_tests {
 
     #[test]
     fn distill_flag_builds_facts_primary_config() {
-        let cfg = distillation_config(true);
+        let cfg = distillation_config(true, true);
         assert_eq!(cfg.distillation, DistillationMode::On);
         assert!(cfg.enable_knowledge_graph);
         assert!(cfg.retrieval_excludes_raw_sources);
     }
 
     #[test]
+    fn distill_keep_raw_augments() {
+        // Augment mode: distillation on, but raw turns retained in search.
+        let cfg = distillation_config(true, false);
+        assert_eq!(cfg.distillation, DistillationMode::On);
+        assert!(cfg.enable_knowledge_graph);
+        assert!(!cfg.retrieval_excludes_raw_sources);
+    }
+
+    #[test]
     fn no_distill_flag_is_default() {
-        let cfg = distillation_config(false);
-        assert_eq!(cfg.distillation, DistillationMode::Auto);
+        // Library default is Off (opt-in) after the A/B negative result.
+        let cfg = distillation_config(false, true);
+        assert_eq!(cfg.distillation, DistillationMode::Off);
     }
 }
 
 async fn run_agentic_qa_only(
     conversations: &[EvalConversation],
     distill: bool,
+    exclude_raw: bool,
     w: &mut impl FnMut(String) -> Result<(), String>,
 ) -> Result<(), String> {
     w("== Agentic answer-guided retrieval QA (--agentic-qa) ==".to_string())?;
@@ -951,7 +968,7 @@ async fn run_agentic_qa_only(
         max_rounds,
         grounded,
         ground_verify,
-        distillation_config(distill),
+        distillation_config(distill, exclude_raw),
     )
     .await
     .map_err(|e| e.to_string())?;


### PR DESCRIPTION
Follow-up to #111 (facts-primary distillation measured to hurt QA). Acts on that result's lesson — *distillation should augment raw retrieval, not replace it* — and confirms it with a third matched arm.

## Result (matched 3-way, conv 0, n=198, codex judge + PRF + GPU cross-encoder constant)

| arm | overall | abstained | Δ vs raw |
|---|---|---|---|
| A — raw baseline | 0.5051 | 44 | — |
| B — facts-primary (raw excluded) | 0.2576 | 103 | −0.2475 |
| **C — augment (raw retained)** | **0.5000** | 52 | **−0.0051 (tie)** |

Per category (A / B / C): Temporal 0.784 / 0.486 / **0.784**; MultiHop 0.188 / 0.062 / **0.188**; OpenDomain 0.385 / 0.308 / **0.385**; SingleHop 0.729 / 0.257 / 0.671; Abstention 0.196 / 0.196 / **0.261**.

**The raw-exclusion was the entire culprit, not distillation.** Keeping raw turns searchable recovers the whole −0.25 — matching baseline exactly on three categories, nearly on SingleHop, and slightly *beating* it on Abstention. Augment preserves the verbatim fallback (dates, exact details) that facts-primary discarded.

## Change
- Opt-in distillation now **defaults to augment**: `MemoryConfig::retrieval_excludes_raw_sources` defaults to `false` (facts added alongside raw turns). Facts-primary (raw excluded) remains available via the flag for callers who measure it as a net win on their own extractor.
- Adds the eval `--distill-keep-raw` flag used for this measurement.
- `distillation` remains default `Off` (opt-in); this only changes behavior *when* distillation is enabled, making it safe-by-default.

## Honest framing
Augment does **not lift** QA here — a 7B extractor's facts add no signal the raw turns lack — it's *neutral* (safe). The value is (1) it definitively explains the earlier negative result, (2) it makes the opt-in feature safe-by-default, and (3) it's the correct foundation for a real lift with a stronger extractor. Caveats: single-conversation matched set (n=198); local 7B extractor.

484 lib tests pass; clippy + fmt + strict-docs (`--document-private-items -D warnings`) all clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)