### PR TITLE
eval: three capability-validation threads (bi-temporal, reflection, distillation lift) — all masked by strong answerer

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -1851,3 +1851,62 @@ is the correct foundation: with a stronger extractor, augment could add lift wit
 the deprecated `store_extracted_facts = true`) now adds facts alongside raw turns rather than
 replacing them, so opting in is safe by default. Facts-primary (raw excluded) remains available by
 setting the flag to `true`, for callers who measure it as a net win on their own extractor/workload.
+
+## Three capability-validation threads: all masked by a strong answerer (2026-07-21)
+
+Following the distillation investigation, we measured the three remaining v2 capability questions on
+their target instruments. All three came back neutral/masked — a coherent, honest result that sharpens
+the scorecard's core lesson.
+
+**Thread 1 — bi-temporal (supersede-on-update).** LongMemEval knowledge-update, n=40, codex agentic,
+heuristic supersession marking; only `retrieval_excludes_superseded` differs (new `--exclude-superseded`
+eval flag):
+
+| arm | accuracy |
+|---|---|
+| superseded retained | 0.925 (37/40) |
+| superseded excluded (bi-temporal) | 0.950 (38/40) |
+
++1 question, within codex noise at n=40. Codex is near-ceiling (mean rounds = 1.0, no follow-ups) — it
+resolves updates from the retrieved context itself, so the retrieval-precision value of dropping stale
+facts is **masked**. The mechanism is proven (library unit test: Berlin→Munich, flag on returns only
+Munich); the end-to-end value needs a weak answerer to surface.
+
+**Thread 2 — reflection/synthesis.** LongMemEval multi-session (the synthesis-requiring type), n=40,
+single-shot codex, `--reflect` vs baseline:
+
+| arm | accuracy |
+|---|---|
+| baseline | 0.425 (17/40) |
+| + reflection (216 insights synthesized) | 0.450 (18/40) |
+
++1 question, within noise — **neutral even on the question type reflection should most help**. 216
+insights were synthesized and made retrievable but didn't move accuracy: the heuristic synthesizer
+(TF-IDF clustering) doesn't produce the specific cross-turn facts these questions need, and codex
+already synthesizes across the retrieved raw turns. A fair test needs an LLM synthesizer.
+
+**Thread 3 — distillation lift with a stronger extractor.** Matched conv-0 (n=198), augment mode,
+qwen2.5-**14b** extractor vs the earlier 7b:
+
+| arm | accuracy |
+|---|---|
+| raw baseline | 0.5051 |
+| augment (7b) | 0.5000 |
+| augment (14b) | 0.4697 |
+
+A stronger extractor does **not** turn augment into a lift (14b within noise of baseline, marginally
+below 7b). In augment mode raw turns already carry the answers, so single-turn extraction — however
+good the model — only *duplicates* what raw turns hold. Per-turn distillation adds no retrievable
+signal on LoCoMo regardless of extractor strength; a real lift would need cross-turn synthesis, not
+better per-turn facts.
+
+**The throughline (confirmed across three fresh measurements).** Retrieval-side capabilities
+(distillation, bi-temporal validity, reflection) are **masked by a strong answerer**: codex reads
+verbatim detail (masks distillation), resolves updates from context (masks bi-temporal), and
+synthesizes across retrieved turns (masks reflection). Each would matter with a *weak* answerer, or
+where first-stage retrieval — not answering — is the bottleneck. This is exactly what the v2 scorecard
+predicted; measuring it on the target instruments confirms it rather than refuting it. The honest
+consequence: none of these three is a shippable default lift on LoCoMo/LongMemEval with a frontier
+answerer, and each needs a weak-answerer (or LLM-synthesizer) instrument — which the agentic eval path
+does not yet support — to demonstrate its value. (Caveats throughout: n≈40 subsets, heuristic
+supersession/synthesis, single-conversation extractor comparison.)

--- a/tools/eval/src/bin/run_eval.rs
+++ b/tools/eval/src/bin/run_eval.rs
@@ -258,10 +258,19 @@ async fn main() -> Result<(), String> {
             return run_agentic_facts_only(&conversations, facts, &mut w).await;
         }
         // `--distill` = facts-primary (raw excluded); `--distill-keep-raw` =
-        // augment (distill on, raw turns retained in search).
+        // augment (distill on, raw turns retained in search);
+        // `--exclude-superseded` = bi-temporal (drop stale facts after updates).
         let keep_raw = args.iter().any(|a| a == "--distill-keep-raw");
+        let exclude_superseded = args.iter().any(|a| a == "--exclude-superseded");
         let distill = keep_raw || args.iter().any(|a| a == "--distill");
-        return run_agentic_qa_only(&conversations, distill, !keep_raw, &mut w).await;
+        return run_agentic_qa_only(
+            &conversations,
+            distill,
+            !keep_raw,
+            exclude_superseded,
+            &mut w,
+        )
+        .await;
     }
     if growth_only {
         return run_growth_and_qa(&conversations, grow_100k, &mut w).await;
@@ -888,14 +897,31 @@ async fn run_qa_reflect_only(
 /// distillation write path (DistillationMode::On, KG on). `exclude_raw` controls
 /// whether raw source turns are dropped from search: `true` = facts-primary
 /// (facts replace raw in retrieval), `false` = augment (facts ADD alongside raw,
-/// so the verbatim fallback is preserved). `distill=false` returns the default
-/// config (today's raw-turn behavior).
-fn distillation_config(distill: bool, exclude_raw: bool) -> synaptic::MemoryConfig {
+/// so the verbatim fallback is preserved). `exclude_superseded` drops memories
+/// the write path marked bi-temporally superseded (a later fact contradicted
+/// them), so retrieval returns the current fact after an update. Supersession
+/// marking runs whenever the knowledge graph is on (independent of distillation),
+/// so `exclude_superseded` is applied to whatever config `distill` selects —
+/// including the default config — without forcing distillation on (which would
+/// confound the bi-temporal isolation with fact-storage effects).
+fn distillation_config(
+    distill: bool,
+    exclude_raw: bool,
+    exclude_superseded: bool,
+) -> synaptic::MemoryConfig {
     if distill {
         synaptic::MemoryConfig {
             distillation: synaptic::memory::reasoning::DistillationMode::On,
             enable_knowledge_graph: true,
             retrieval_excludes_raw_sources: exclude_raw,
+            retrieval_excludes_superseded: exclude_superseded,
+            ..Default::default()
+        }
+    } else if exclude_superseded {
+        // Bi-temporal without distillation: default config (KG on) already runs
+        // supersession marking; just drop superseded memories from retrieval.
+        synaptic::MemoryConfig {
+            retrieval_excludes_superseded: true,
             ..Default::default()
         }
     } else {
@@ -910,7 +936,7 @@ mod distill_flag_tests {
 
     #[test]
     fn distill_flag_builds_facts_primary_config() {
-        let cfg = distillation_config(true, true);
+        let cfg = distillation_config(true, true, false);
         assert_eq!(cfg.distillation, DistillationMode::On);
         assert!(cfg.enable_knowledge_graph);
         assert!(cfg.retrieval_excludes_raw_sources);
@@ -919,16 +945,35 @@ mod distill_flag_tests {
     #[test]
     fn distill_keep_raw_augments() {
         // Augment mode: distillation on, but raw turns retained in search.
-        let cfg = distillation_config(true, false);
+        let cfg = distillation_config(true, false, false);
         assert_eq!(cfg.distillation, DistillationMode::On);
         assert!(cfg.enable_knowledge_graph);
         assert!(!cfg.retrieval_excludes_raw_sources);
     }
 
     #[test]
+    fn exclude_superseded_bitemporal_without_distill() {
+        // Bi-temporal without distillation: supersession marking runs whenever
+        // the KG is on (default), so we just drop superseded memories — no need
+        // to force distillation on (which would confound the isolation).
+        let cfg = distillation_config(false, false, true);
+        assert_eq!(cfg.distillation, DistillationMode::Off);
+        assert!(cfg.enable_knowledge_graph);
+        assert!(cfg.retrieval_excludes_superseded);
+    }
+
+    #[test]
+    fn distill_with_exclude_superseded_sets_both() {
+        let cfg = distillation_config(true, false, true);
+        assert_eq!(cfg.distillation, DistillationMode::On);
+        assert!(!cfg.retrieval_excludes_raw_sources);
+        assert!(cfg.retrieval_excludes_superseded);
+    }
+
+    #[test]
     fn no_distill_flag_is_default() {
         // Library default is Off (opt-in) after the A/B negative result.
-        let cfg = distillation_config(false, true);
+        let cfg = distillation_config(false, true, false);
         assert_eq!(cfg.distillation, DistillationMode::Off);
     }
 }
@@ -937,6 +982,7 @@ async fn run_agentic_qa_only(
     conversations: &[EvalConversation],
     distill: bool,
     exclude_raw: bool,
+    exclude_superseded: bool,
     w: &mut impl FnMut(String) -> Result<(), String>,
 ) -> Result<(), String> {
     w("== Agentic answer-guided retrieval QA (--agentic-qa) ==".to_string())?;
@@ -968,7 +1014,7 @@ async fn run_agentic_qa_only(
         max_rounds,
         grounded,
         ground_verify,
-        distillation_config(distill, exclude_raw),
+        distillation_config(distill, exclude_raw, exclude_superseded),
     )
     .await
     .map_err(|e| e.to_string())?;


### PR DESCRIPTION
Executes the three remaining v2 capability-validation threads and documents the results. All three come back neutral/masked — a coherent, honest confirmation of the scorecard's core lesson.

## Code
Adds the `--exclude-superseded` eval flag (bi-temporal A/B): drops superseded memories from retrieval so a later fact wins after an update. Supersession marking runs whenever the KG is on (independent of distillation), so the flag applies to the default config without confounding the isolation. 6 flag tests pass; clippy + fmt + strict-docs clean.

## Results (all on their target instruments)

**Thread 1 — bi-temporal**, LongMemEval knowledge-update, n=40, codex agentic:
| arm | acc |
|---|---|
| superseded retained | 0.925 |
| excluded (bi-temporal) | 0.950 |

+1 question, within noise — codex is near-ceiling (mean rounds 1.0) and resolves updates from context itself. Retrieval-precision value **masked**. Mechanism proven by the library unit test.

**Thread 2 — reflection**, LongMemEval multi-session (synthesis), n=40, single-shot codex:
| arm | acc |
|---|---|
| baseline | 0.425 |
| +reflection (216 insights) | 0.450 |

+1 question — **neutral even on synthesis questions**. Heuristic synthesis (clustering) doesn't produce the cross-turn facts needed; codex already synthesizes across retrieved raw turns. Needs an LLM synthesizer for a fair test.

**Thread 3 — distillation lift**, conv-0 augment, n=198, stronger extractor:
| arm | acc |
|---|---|
| raw baseline | 0.5051 |
| augment (7b) | 0.5000 |
| augment (14b) | 0.4697 |

A stronger extractor gives **no lift** — in augment mode raw turns already carry the answers, so per-turn facts only duplicate them.

## Throughline
Retrieval-side capabilities (distillation, bi-temporal, reflection) are **masked by a strong answerer** — confirmed across three fresh measurements. Each needs a weak-answerer (or LLM-synthesizer) instrument, which the agentic eval path doesn't yet support, to demonstrate its value. Caveats: n≈40 subsets, heuristic supersession/synthesis, single-conversation extractor comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)