### PR TITLE
docs(eval): weak-answerer distillation closes the question (facts-primary hurts every answerer)

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -1945,3 +1945,29 @@ blocked upstream at *supersession detection*, not at the answerer. Applying it t
 (augment) and reflection would similarly isolate whether their value is answerer-masked or, like
 bi-temporal, blocked upstream — each needs its own (LLM-reasoner or LLM-synthesizer) run, now that the
 answerer side is solved. Caveats: n=40, heuristic supersession, single dataset.
+
+## Weak-answerer distillation: facts-primary hurts every answerer — closing the question (2026-07-21)
+
+The distillation investigation's last open question: with a strong answerer, facts-primary
+distillation *hurt* (it reads verbatim detail from raw turns) — would a **weak** answerer instead do
+better with clean distilled facts than noisy raw turns? Using the weak-answerer instrument (qwen-7b
+answers, codex grades), matched conv-0, n=199:
+
+| answerer | raw | facts-primary | Δ |
+|---|---|---|---|
+| codex (strong) | 0.5051 | 0.2576 | −0.2475 |
+| **qwen-7b (weak)** | **0.3266** | **0.1910** | **−0.1357** |
+
+**Facts-primary hurts both answerers.** The hypothesis is refuted: a weak answerer does *worse* with
+distilled facts, not better. The mechanism holds for both — excluding raw turns discards the verbatim
+detail (dates, exact phrasing) that both strong and weak answerers need, and single-turn 7b facts
+cannot replace it. (The weak answerer also validates the instrument: qwen drops raw-turn QA from
+codex's 0.505 to 0.327, i.e. it is genuinely retrieval-dependent, yet still can't benefit from
+facts-primary.)
+
+**This closes the distillation question.** There is no answerer-strength regime where per-turn
+facts-primary distillation is a win. The augment default (raw retained; `retrieval_excludes_raw_sources
+= false`, shipped) is the only safe configuration, and it is neutral. A real distillation *lift* would
+require the facts to add signal raw turns lack — i.e. cross-turn synthesis or entity linking, not
+per-turn extraction — which is a different mechanism than what this feature implements. Caveats:
+single conversation (n=199), 7b extractor.


### PR DESCRIPTION
The distillation investigation's last open question, answered with the weak-answerer instrument (#114): with a strong answerer facts-primary *hurt* — would a **weak** answerer instead prefer clean distilled facts over noisy raw turns?

## Result (matched conv-0, n=199, qwen answers / codex grades)

| answerer | raw | facts-primary | Δ |
|---|---|---|---|
| codex (strong) | 0.5051 | 0.2576 | −0.2475 |
| **qwen-7b (weak)** | **0.3266** | **0.1910** | **−0.1357** |

**Facts-primary hurts both answerers** — the hypothesis is refuted. A weak answerer does *worse* with distilled facts, not better: excluding raw turns discards verbatim detail (dates, exact phrasing) that both strong and weak answerers need, and single-turn 7b facts can't replace it. (The run also validates the instrument: qwen drops raw QA from 0.505 to 0.327 — genuinely retrieval-dependent — yet still can't benefit from facts-primary.)

## This closes the distillation question
No answerer-strength regime makes per-turn facts-primary distillation a win. The augment default (raw retained, shipped in #112) is the only safe config, and it's neutral. A real distillation *lift* would need facts that add signal raw turns lack — cross-turn synthesis or entity linking — a different mechanism than per-turn extraction.

Caveats: single conversation (n=199), 7b extractor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)