### PR TITLE
feat: async write-path enrichment — decouple ingest from LLM latency (630× on the hot path)

### DIFF
--- a/benches/comprehensive_benchmarks.rs
+++ b/benches/comprehensive_benchmarks.rs
@@ -546,7 +546,7 @@ fn bench_throughput_validation(c: &mut Criterion) {
                     }
                     3 => {
                         // Stats operation (25%)
-                        let stats = memory.stats();
+                        let stats = memory.stats().await;
                         black_box(stats);
                     }
                     _ => unreachable!(),

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -1996,3 +1996,40 @@ nothing fired). The productive next step for every write-side LLM capability (di
 supersession, reflection synthesis) is the same: **move LLM enrichment off the synchronous per-turn
 write path** — batch it, do it asynchronously, or gate it to a cheap detector — so it can run at scale
 without stalling ingest. That is an engineering change to the write path, not another eval.
+
+## Async write-path enrichment: the write hot path is decoupled from LLM latency (2026-07-23)
+
+The write-side bottleneck (synchronous per-turn LLM enrichment made ingest gate on LLM latency —
+distillation ingest ~24 min/conv, an LLM-supersession A/B ~4 h) is addressed by decoupling the raw
+write from enrichment: `store()` records the raw memory and (in `Deferred`/`Background` mode) enqueues
+the entry; enrichment (`extract → resolve → supersede → fact-store`) runs later via `enrich_pending()`
+or a background worker, with bounded concurrency. Measured on LoCoMo conv-0 (419 turns), local 7B
+reasoner (ollama qwen2.5:7b):
+
+| path | time |
+|---|---|
+| synchronous (Inline) ingest | **1433.9 s** (~24 min) |
+| deferred: raw write | **2.3 s** |
+| deferred: enrich (concurrency 8) | 1343.5 s |
+| deferred total (raw + enrich) | 1345.7 s |
+
+**The write hot path drops from 1434 s to 2.3 s — ~630×.** `store()` is no longer gated on LLM
+latency: all 419 turns are written in 2.3 s, and enrichment happens off the critical path. In
+`Background` mode the enrichment worker drains the queue continuously, so ingest never waits at all.
+This is the primary architectural win — it is what makes write-time LLM capabilities (distillation,
+bi-temporal supersession detection) usable without stalling ingest.
+
+**Honest caveat — the *total* enrichment speedup is backend-bound, not harness-bound.** Total
+deferred time (1345.7 s) is only 1.1× faster than synchronous (1433.9 s) because a single 7B model on
+one GPU (ollama, default `num_parallel` ≈ 1–2) serves the 8 concurrent enrichment requests nearly
+serially — the harness submits 8 in flight (verified: 16 live connections during the deferred enrich),
+but the LLM backend, not the write path, is now the ceiling. The concurrency mechanism is real and
+proven; realizing it as wall-clock speedup on *total* enrichment requires a parallel/batching-capable
+backend (`OLLAMA_NUM_PARALLEL=8`, multiple model replicas, or a hosted API), which would take the
+enrichment toward `total_LLM_time / effective_parallelism`. Caveats: single conversation (n=419
+turns), local 7B reasoner, default ollama parallelism.
+
+**Net:** ingest is decoupled from LLM latency unconditionally (630× on the hot path; enrichment moved
+off the critical path); the additional concurrency speedup on total enrichment is available with a
+backend that serves requests in parallel. Default mode remains `Inline` (unchanged behavior); the
+opt-in `Deferred`/`Background` modes carry the decoupling.

--- a/docs/superpowers/plans/2026-07-22-async-write-path-enrichment.md
+++ b/docs/superpowers/plans/2026-07-22-async-write-path-enrichment.md
@@ -1,0 +1,762 @@
+# Async Write-Path Enrichment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Decouple the fast raw write from slow per-turn LLM enrichment so ingest is no longer gated on LLM latency, with bounded-concurrent enrichment on shared handles.
+
+**Architecture:** `AgentMemory.state` becomes `Arc<RwLock<AgentState>>`. A `MemoryConfig::enrichment_mode` (`Inline` default / `Deferred` / `Background`) controls whether `store()` runs enrichment inline (today's behavior) or enqueues it. The existing `reason_over_store` logic is lifted onto a free async function (`enrich_one`) taking `Arc` handles (storage, kg, state, reasoner, scoring provider); `enrich_pending()` drains the queue with bounded concurrency, and an opt-in background worker drains continuously.
+
+**Tech Stack:** Rust, Tokio (`RwLock`, `Mutex`, `Semaphore`, `Notify`, `spawn`), `futures::stream::buffer_unordered`, the `synaptic` crate.
+
+## Global Constraints
+
+- Default `EnrichmentMode::Inline` behaves byte-for-byte like today (enrich synchronously in `store_with_report`); all existing tests pass unchanged.
+- Best-effort: a per-entry enrichment failure logs at `warn`, increments an error counter, never aborts the batch or the `store()`; the raw memory is always stored.
+- All new enrichment code behind `#[cfg(feature = "embeddings")]`, matching the existing write-path reasoning.
+- Lock order is fixed **KG → state**; locks are never held across a reasoner `await`.
+- Fact-stores feed storage + state + the `Arc` scoring provider (`retrieval_scoring_provider`) so facts stay retrievable; the owned `embedding_manager` is not fed for deferred facts (documented minor gap).
+- `::fact{i}` keys are never enqueued for enrichment (re-entrancy guard).
+- No fabricated numbers; the measurement uses a real LLM reasoner.
+- PR-only merge flow; a new branch per PR iteration.
+
+## Verified APIs (confirmed against code, 2026-07-22)
+- `Storage`: `async fn store(&self, &MemoryEntry)`, `retrieve(&self, &str) -> Option<MemoryEntry>`, `search(&self, &str, usize)` — all `&self` (Arc-safe). Field: `storage: Arc<dyn memory::storage::Storage + Send + Sync>`.
+- `EmbeddingProvider::embed(&self, text: &str, options: Option<&EmbedOptions>) -> Result<Embedding>`. Field: `retrieval_scoring_provider: Option<Arc<dyn memory::embeddings::provider::EmbeddingProvider>>`.
+- `AgentState::add_memory(&mut self, MemoryEntry)`, `has_memory(&self, &str) -> bool`. Derives `Clone`.
+- `knowledge_graph: Option<Arc<tokio::sync::RwLock<memory::knowledge_graph::MemoryKnowledgeGraph>>>`.
+- `reasoner: Arc<dyn memory::reasoning::MemoryReasoner>`.
+- Error: `crate::error::MemoryError::ProcessingError(String)`.
+- Enrichment methods to lift: `reason_over_store` (`src/lib.rs:785`), `neighbor_facts` (`:901`), `apply_resolution` (`:1025`), `mark_superseded` (`:863`), `mark_raw_source` (`:843`). Consts `RAW_SOURCE_FIELD`, `SUPERSEDED_FIELD`, `NEIGHBOR_CANDIDATE_LIMIT` on `AgentMemory`.
+- `store_with_report` inline enrichment gate: `src/lib.rs:764` (`if self.knowledge_graph.is_some() && !self.storing_facts { reason_over_store }`).
+
+## File Structure
+
+- `src/lib.rs` (modify): state field → `Arc<RwLock<AgentState>>` + all 23 call sites; `EnrichmentMode` reconciliation; queue field; `store_with_report` enqueue branch; `enrich_pending`; background worker fields + `shutdown`/`wait_for_enrichment`; re-export.
+- `src/memory/enrichment.rs` (new): `EnrichmentParams`, `EnrichmentReport`, `PendingEnrichment`, the free-function engine `enrich_one` and its helpers (`neighbor_facts_shared`, `apply_resolution_shared`, `mark_field_shared`), lifted from the `&mut self` methods. One clear responsibility: run one entry's enrichment against shared handles.
+- `src/memory/mod.rs` (modify): `pub mod enrichment;`.
+- `src/lib.rs` `MemoryConfig` (modify): `enrichment_mode`, `enrichment_concurrency`.
+- `tools/eval/src/bin/run_eval.rs` + `tools/eval/src/runner.rs` (modify): `--deferred-enrichment` ingest path + timing.
+
+---
+
+### Task 1: `state` → `Arc<RwLock<AgentState>>` (foundation, behavior-preserving)
+
+**Files:**
+- Modify: `src/lib.rs` (struct field ~line 3 of struct; 23 `self.state.*` sites; 2 `create_checkpoint(&self.state)` at `:774`,`:1471`; `should_checkpoint(&self.state)` at `:772`; constructor `state: AgentState::...` init)
+- Test: existing `src/lib.rs` tests (must stay green — this task changes representation, not behavior)
+
+**Interfaces:**
+- Produces: `AgentMemory.state: std::sync::Arc<tokio::sync::RwLock<memory::state::AgentState>>`. Read: `self.state.read().await`. Write: `self.state.write().await`.
+
+- [ ] **Step 1: Change the field type**
+
+In the `AgentMemory` struct definition, change:
+```rust
+    state: memory::state::AgentState,
+```
+to:
+```rust
+    state: std::sync::Arc<tokio::sync::RwLock<memory::state::AgentState>>,
+```
+
+- [ ] **Step 2: Change the constructor initializer**
+
+The state local is built at `src/lib.rs:220` (`let state = memory::state::AgentState::new(...)`) and consumed via field-init shorthand `state,` in the final `Self { ... }` (`src/lib.rs:511`). Replace that shorthand `state,` with:
+```rust
+            state: std::sync::Arc::new(tokio::sync::RwLock::new(state)),
+```
+
+- [ ] **Step 3: Update all read/write call sites**
+
+Run `grep -n "self.state." src/lib.rs`. For each site, insert `.read().await` (for `has_memory`, `get_memory`, `peek_memory`, `session_id`, `created_at`, `long_term_memory_count`, `short_term_memory_count`, `total_memory_size`, `get_long_term_memories`) or `.write().await` (for `add_memory`, `clear`, `remove_memory`, `insert_preserving_access`). Example:
+```rust
+// before: self.state.has_memory(key)
+self.state.read().await.has_memory(key)
+// before: self.state.add_memory(entry.clone());
+self.state.write().await.add_memory(entry.clone());
+```
+For the two checkpoint sites (`:772`, `:774`, `:1471`), take a read guard first:
+```rust
+        let state_guard = self.state.read().await;
+        if self.checkpoint_manager.should_checkpoint(&state_guard) {
+            self.checkpoint_manager.create_checkpoint(&state_guard).await?;
+        }
+        drop(state_guard);
+```
+and at `:1471`:
+```rust
+        let state_guard = self.state.read().await;
+        self.checkpoint_manager.create_checkpoint(&state_guard).await
+```
+**Caution:** do not hold a `state` read guard across a `self.state.write().await` in the same scope (deadlock) — take short guards, drop before the next lock.
+
+- [ ] **Step 4: Build and run the full lib test suite (behavior unchanged)**
+
+Run: `cargo test -p synaptic --lib --features embeddings 2>&1 | tail -8`
+Expected: PASS — same count as before this task (the representation changed, behavior did not). If a deadlock hangs a test, find where a read guard is held across a write in the same scope and shorten it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib.rs
+git commit -m "refactor(memory): state -> Arc<RwLock<AgentState>> (behavior-preserving)"
+```
+
+---
+
+### Task 2: `EnrichmentMode` config + pending queue + `store()` enqueue
+
+**Files:**
+- Modify: `src/lib.rs` (`MemoryConfig` struct + `Default`; `AgentMemory` fields; constructor; `store_with_report` enrichment gate `:764`)
+- Create: `src/memory/enrichment.rs` (types only, this task)
+- Modify: `src/memory/mod.rs` (`pub mod enrichment;`)
+- Test: inline `#[cfg(test)]` in `src/lib.rs`
+
+**Interfaces:**
+- Produces:
+  - `memory::enrichment::EnrichmentMode { Inline, Deferred, Background }` (derives `Debug, Clone, Copy, PartialEq, Eq, Default`; `#[default] Inline`)
+  - `memory::enrichment::PendingEnrichment { pub key: String, pub value: String }`
+  - `MemoryConfig.enrichment_mode: EnrichmentMode`, `MemoryConfig.enrichment_concurrency: usize` (default 8)
+  - `AgentMemory.enrichment_queue: Arc<tokio::sync::Mutex<std::collections::VecDeque<PendingEnrichment>>>`
+
+- [ ] **Step 1: Create the enrichment module with types**
+
+Create `src/memory/enrichment.rs`:
+```rust
+//! Async/deferred write-path enrichment: the raw store is fast; the slow LLM
+//! enrichment (extract -> resolve -> supersede -> fact-store) runs later,
+//! concurrently, on shared handles. See docs/superpowers/specs/2026-07-22-*.
+
+/// How write-path LLM enrichment is scheduled relative to `store()`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EnrichmentMode {
+    /// Enrich synchronously inside `store()` (today's behavior). Default.
+    #[default]
+    Inline,
+    /// `store()` enqueues; enrichment runs on an explicit `enrich_pending()`.
+    Deferred,
+    /// `store()` enqueues + notifies a background worker that drains continuously.
+    Background,
+}
+
+/// One entry awaiting enrichment (queued by `store()` in Deferred/Background).
+#[derive(Debug, Clone)]
+pub struct PendingEnrichment {
+    pub key: String,
+    pub value: String,
+}
+```
+Add to `src/memory/mod.rs` near the other `pub mod` lines:
+```rust
+pub mod enrichment;
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Add to the `src/lib.rs` test module:
+```rust
+    #[tokio::test]
+    async fn enrichment_defaults_to_inline() {
+        let config = MemoryConfig::default();
+        assert_eq!(
+            config.enrichment_mode,
+            memory::enrichment::EnrichmentMode::Inline
+        );
+        assert_eq!(config.enrichment_concurrency, 8);
+    }
+
+    #[cfg(feature = "embeddings")]
+    #[tokio::test]
+    async fn deferred_mode_queues_without_inline_enrich() {
+        let config = MemoryConfig {
+            enrichment_mode: memory::enrichment::EnrichmentMode::Deferred,
+            store_extracted_facts: true,
+            enable_knowledge_graph: true,
+            ..Default::default()
+        };
+        let mut mem = AgentMemory::new(config).await.unwrap();
+        mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
+            facts: vec!["Alice lives in Berlin".to_string()],
+            fail: false,
+        }));
+        mem.store("turn1", "Alice: I moved to Berlin").await.unwrap();
+        // Deferred: no fact-memory yet (enrichment not run), raw is present.
+        assert!(mem.get_entry_for_test("turn1").await.is_some());
+        assert!(mem.get_entry_for_test("turn1::fact0").await.is_none());
+        assert_eq!(mem.enrichment_queue_len().await, 1);
+    }
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `cargo test -p synaptic --lib --features embeddings enrichment_defaults_to_inline deferred_mode_queues 2>&1 | tail -15`
+Expected: FAIL — `enrichment_mode` field and `enrichment_queue_len` do not exist.
+
+- [ ] **Step 4: Add config fields + defaults**
+
+In `MemoryConfig` (after `retrieval_excludes_raw_sources`):
+```rust
+    /// How write-path LLM enrichment is scheduled (see
+    /// [`memory::enrichment::EnrichmentMode`]). Default `Inline` (enrich
+    /// synchronously inside `store`), byte-for-byte today's behavior.
+    pub enrichment_mode: memory::enrichment::EnrichmentMode,
+    /// Bounded concurrency for `enrich_pending`/background enrichment. Default 8.
+    pub enrichment_concurrency: usize,
+```
+In `Default for MemoryConfig`:
+```rust
+            enrichment_mode: memory::enrichment::EnrichmentMode::Inline,
+            enrichment_concurrency: 8,
+```
+
+- [ ] **Step 5: Add the queue field + test helper + constructor init**
+
+Add to the `AgentMemory` struct:
+```rust
+    #[cfg(feature = "embeddings")]
+    enrichment_queue: std::sync::Arc<
+        tokio::sync::Mutex<std::collections::VecDeque<memory::enrichment::PendingEnrichment>>,
+    >,
+```
+In the constructor `Self { ... }`:
+```rust
+            #[cfg(feature = "embeddings")]
+            enrichment_queue: std::sync::Arc::new(tokio::sync::Mutex::new(
+                std::collections::VecDeque::new(),
+            )),
+```
+Add a test-only accessor to `impl AgentMemory`:
+```rust
+    #[cfg(all(feature = "embeddings", test))]
+    async fn enrichment_queue_len(&self) -> usize {
+        self.enrichment_queue.lock().await.len()
+    }
+```
+
+- [ ] **Step 6: Branch the `store_with_report` enrichment gate**
+
+Replace the inline-enrichment block at `src/lib.rs:764` (`if self.knowledge_graph.is_some() && !self.storing_facts { ... reason_over_store ... }`) with a mode branch:
+```rust
+        #[cfg(feature = "embeddings")]
+        if self.knowledge_graph.is_some() && !self.storing_facts {
+            match self._config.enrichment_mode {
+                memory::enrichment::EnrichmentMode::Inline => {
+                    if let Err(e) = self.reason_over_store(&entry).await {
+                        tracing::warn!(error = %e, "reasoning degraded during store");
+                        degradations.reasoning = Some(e.to_string());
+                    }
+                }
+                memory::enrichment::EnrichmentMode::Deferred
+                | memory::enrichment::EnrichmentMode::Background => {
+                    // Never enqueue a fact-memory (re-entrancy guard already
+                    // ensures fact stores set storing_facts, so we never reach
+                    // here for them; the key check is belt-and-braces).
+                    if !key.contains("::fact") {
+                        self.enrichment_queue.lock().await.push_back(
+                            memory::enrichment::PendingEnrichment {
+                                key: key.to_string(),
+                                value: value.to_string(),
+                            },
+                        );
+                        // Background notification wired in Task 5.
+                    }
+                }
+            }
+        }
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `cargo test -p synaptic --lib --features embeddings enrichment_defaults_to_inline deferred_mode_queues 2>&1 | tail -10`
+Expected: PASS.
+Regression: `cargo test -p synaptic --lib --features embeddings 2>&1 | tail -6` — all pass (Inline default unchanged).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib.rs src/memory/enrichment.rs src/memory/mod.rs
+git commit -m "feat(enrichment): EnrichmentMode config + pending queue + deferred enqueue"
+```
+
+---
+
+### Task 3: `enrich_one` engine (lifted onto Arc handles)
+
+**Files:**
+- Modify: `src/memory/enrichment.rs` (add the engine)
+- Modify: `src/lib.rs` (expose consts needed by the engine, if private)
+- Test: inline `#[cfg(test)]` in `src/memory/enrichment.rs`
+
+**Interfaces:**
+- Consumes: `PendingEnrichment` (Task 2), the reasoner trait, storage/kg/state/scoring Arc types.
+- Produces:
+  - `pub struct EnrichmentParams { pub distillation_live: bool, pub exclude_raw_default: bool }` — the per-entry knobs (mirrors `AgentMemory.distillation_live`).
+  - `pub struct EnrichmentOutcome { pub facts_stored: usize, pub supersessions: usize, pub raw_tagged: bool }`
+  - `pub async fn enrich_one(storage, kg, state, reasoner, scoring, params, key, value) -> Result<EnrichmentOutcome, crate::error::MemoryError>` with exact handle types:
+    - `storage: &std::sync::Arc<dyn crate::memory::storage::Storage + Send + Sync>`
+    - `kg: &std::sync::Arc<tokio::sync::RwLock<crate::memory::knowledge_graph::MemoryKnowledgeGraph>>`
+    - `state: &std::sync::Arc<tokio::sync::RwLock<crate::memory::state::AgentState>>`
+    - `reasoner: &std::sync::Arc<dyn crate::memory::reasoning::MemoryReasoner>`
+    - `scoring: &Option<std::sync::Arc<dyn crate::memory::embeddings::provider::EmbeddingProvider>>`
+
+- [ ] **Step 1: Write the failing test (stub reasoner, in-memory storage)**
+
+Add a `#[cfg(test)]` module to `src/memory/enrichment.rs`. It builds an in-memory storage (`std::sync::Arc::new(crate::memory::MemoryStorage::new(...))` — confirm its constructor args with `grep -n "impl MemoryStorage\|pub fn new\|pub struct MemoryStorage" src/memory/storage/*.rs`), an empty KG (`MemoryKnowledgeGraph::new(...)`), an `Arc<RwLock<AgentState>>`, a stub reasoner returning one fact, and asserts `enrich_one` stores the raw memory's fact + tags raw. (Mirror the `StubReasoner` shape from `src/lib.rs` tests — `extract` returns one `Fact` with `entities: vec![]`, `resolve` returns `ConflictResolution::Insert`, `synthesize` `Ok(None)`, `name` a literal.)
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // ... construct storage (in-memory), kg (new), state, stub reasoner ...
+    #[tokio::test]
+    async fn enrich_one_stores_fact_and_tags_raw() {
+        // raw "turn1" pre-stored in storage+state
+        // enrich_one(..., distillation_live=true, ...) over ("turn1","Alice: Berlin")
+        // assert storage has "turn1::fact0"; "turn1" has raw_source custom field
+        // assert outcome.facts_stored == 1 && outcome.raw_tagged
+    }
+}
+```
+(The implementer fills the exact construction using the crate's in-memory storage constructor — find it with `grep -n "MemoryStorage\|InMemory\|pub fn new" src/memory/storage/mod.rs`.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p synaptic --lib --features embeddings enrich_one_stores 2>&1 | tail -15`
+Expected: FAIL — `enrich_one` not found.
+
+- [ ] **Step 3: Implement the engine by lifting `reason_over_store` and helpers**
+
+Port `reason_over_store` (`src/lib.rs:785`), `neighbor_facts` (`:901`), `apply_resolution` (`:1025`), `mark_superseded` (`:863`), `mark_raw_source` (`:843`) into free functions in `enrichment.rs`, replacing `self.X` with the handle args:
+- `self.storage` → `storage`; `self.knowledge_graph` (the `Some(kg)` guard) → `kg` (always present here — enrichment only runs when KG exists); `self.reasoner` → `reasoner`; `self.retrieval_scoring_provider` → `scoring`; `self.distillation_live` → `params.distillation_live`.
+- `self.state.add_memory(e)` → `state.write().await.add_memory(e)`; `self.state.has_memory(k)` → `state.read().await.has_memory(k)`.
+- Fact-store: instead of the recursive `Box::pin(self.store_with_report(fact_key, fact.text))`, store the fact **directly**:
+```rust
+async fn store_fact_shared(
+    storage: &Arc<dyn Storage + Send + Sync>,
+    state: &Arc<RwLock<AgentState>>,
+    scoring: &Option<Arc<dyn EmbeddingProvider>>,
+    fact_key: &str,
+    fact_text: &str,
+) -> Result<(), MemoryError> {
+    let entry = MemoryEntry::new(fact_key.to_string(), fact_text.to_string(), MemoryType::LongTerm);
+    storage.store(&entry).await?;
+    state.write().await.add_memory(entry.clone());
+    if let Some(p) = scoring {
+        // Keep the retrieval scoring corpus live so the pipeline can rank the fact.
+        let _ = p.embed(fact_text, None).await;
+    }
+    Ok(())
+}
+```
+- `mark_superseded` / `mark_raw_source` become `mark_field_shared(storage, state, key, field_const, value)` that retrieves, inserts the custom field, re-stores, and updates state if present. Use the field string literals `"superseded_at"` and `"raw_source"` (matching `AgentMemory::SUPERSEDED_FIELD`/`RAW_SOURCE_FIELD`).
+- `neighbor_facts` uses `storage.search` + the token-cosine ranking exactly as `src/lib.rs:901`; port verbatim with `storage` in place of `self.storage`. Keep `NEIGHBOR_CANDIDATE_LIMIT = 20` as a local const.
+- Preserve the **failure-ordering invariant**: tag raw source only after ≥1 fact stored.
+- Lock discipline: acquire `kg.write().await` only for the KG mutation in `apply_resolution_shared`; never hold it across `reasoner.resolve`.
+
+Assemble `enrich_one` to mirror `reason_over_store`'s control flow (extract → per-fact neighbor+resolve+apply+supersede → store fact if `distillation_live` → tag raw if any stored), returning `EnrichmentOutcome`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p synaptic --lib --features embeddings enrich_one 2>&1 | tail -12`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/memory/enrichment.rs src/lib.rs
+git commit -m "feat(enrichment): enrich_one engine on shared Arc handles"
+```
+
+---
+
+### Task 4: `enrich_pending()` bounded-concurrent + `EnrichmentReport`
+
+**Files:**
+- Modify: `src/memory/enrichment.rs` (`EnrichmentReport`)
+- Modify: `src/lib.rs` (`enrich_pending` method)
+- Test: inline `#[cfg(test)]` in `src/lib.rs`
+
+**Interfaces:**
+- Produces:
+  - `memory::enrichment::EnrichmentReport { pub entries: usize, pub facts_stored: usize, pub supersessions: usize, pub raw_sources_tagged: usize, pub errors: usize }` (derives `Debug, Clone, Default, PartialEq, Eq`)
+  - `pub async fn AgentMemory::enrich_pending(&self) -> memory::enrichment::EnrichmentReport`
+
+- [ ] **Step 1: Add `EnrichmentReport` to `enrichment.rs`**
+
+```rust
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct EnrichmentReport {
+    pub entries: usize,
+    pub facts_stored: usize,
+    pub supersessions: usize,
+    pub raw_sources_tagged: usize,
+    pub errors: usize,
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+```rust
+    #[cfg(feature = "embeddings")]
+    #[tokio::test]
+    async fn enrich_pending_processes_queue() {
+        let config = MemoryConfig {
+            enrichment_mode: memory::enrichment::EnrichmentMode::Deferred,
+            store_extracted_facts: true,
+            enable_knowledge_graph: true,
+            ..Default::default()
+        };
+        let mut mem = AgentMemory::new(config).await.unwrap();
+        mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
+            facts: vec!["Alice lives in Berlin".to_string()],
+            fail: false,
+        }));
+        mem.store("turn1", "Alice: I moved to Berlin").await.unwrap();
+        assert!(mem.get_entry_for_test("turn1::fact0").await.is_none());
+        let report = mem.enrich_pending().await;
+        assert_eq!(report.entries, 1);
+        assert_eq!(report.facts_stored, 1);
+        assert_eq!(report.errors, 0);
+        // fact now retrievable + queue drained
+        assert!(mem.get_entry_for_test("turn1::fact0").await.is_some());
+        assert_eq!(mem.enrichment_queue_len().await, 0);
+    }
+
+    #[cfg(feature = "embeddings")]
+    #[tokio::test]
+    async fn enrich_pending_best_effort_on_error() {
+        let config = MemoryConfig {
+            enrichment_mode: memory::enrichment::EnrichmentMode::Deferred,
+            store_extracted_facts: true,
+            enable_knowledge_graph: true,
+            ..Default::default()
+        };
+        let mut mem = AgentMemory::new(config).await.unwrap();
+        mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
+            facts: vec![],
+            fail: true,
+        }));
+        mem.store("turn1", "Alice: Berlin").await.unwrap();
+        let report = mem.enrich_pending().await;
+        assert_eq!(report.entries, 1);
+        assert_eq!(report.errors, 1);
+        // raw memory intact despite enrichment failure
+        assert!(mem.get_entry_for_test("turn1").await.is_some());
+    }
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `cargo test -p synaptic --lib --features embeddings enrich_pending_processes enrich_pending_best_effort 2>&1 | tail -15`
+Expected: FAIL — `enrich_pending` not found.
+
+- [ ] **Step 4: Implement `enrich_pending`**
+
+Add to `impl AgentMemory` (behind `#[cfg(feature = "embeddings")]`):
+```rust
+    /// Drain the pending-enrichment queue and enrich all entries with bounded
+    /// concurrency (`MemoryConfig::enrichment_concurrency`). Best-effort: a
+    /// per-entry failure is counted in the report, never aborts the batch.
+    /// Only meaningful in Deferred/Background modes (Inline leaves the queue
+    /// empty). Takes `&self` — mutation is via the Arc/RwLock handles.
+    #[cfg(feature = "embeddings")]
+    pub async fn enrich_pending(&self) -> memory::enrichment::EnrichmentReport {
+        use futures::stream::{self, StreamExt};
+        let Some(ref kg) = self.knowledge_graph else {
+            return memory::enrichment::EnrichmentReport::default();
+        };
+        let pending: Vec<memory::enrichment::PendingEnrichment> = {
+            let mut q = self.enrichment_queue.lock().await;
+            q.drain(..).collect()
+        };
+        if pending.is_empty() {
+            return memory::enrichment::EnrichmentReport::default();
+        }
+        let params = memory::enrichment::EnrichmentParams {
+            distillation_live: self.distillation_live,
+            exclude_raw_default: self._config.retrieval_excludes_raw_sources,
+        };
+        let concurrency = self._config.enrichment_concurrency.max(1);
+        let storage = std::sync::Arc::clone(&self.storage);
+        let kg = std::sync::Arc::clone(kg);
+        let state = std::sync::Arc::clone(&self.state);
+        let reasoner = std::sync::Arc::clone(&self.reasoner);
+        let scoring = self.retrieval_scoring_provider.clone();
+        let outcomes = stream::iter(pending)
+            .map(|p| {
+                let (storage, kg, state, reasoner, scoring, params) = (
+                    storage.clone(), kg.clone(), state.clone(),
+                    reasoner.clone(), scoring.clone(), params.clone(),
+                );
+                async move {
+                    memory::enrichment::enrich_one(
+                        &storage, &kg, &state, &reasoner, &scoring, &params, &p.key, &p.value,
+                    )
+                    .await
+                }
+            })
+            .buffer_unordered(concurrency)
+            .collect::<Vec<_>>()
+            .await;
+        let mut report = memory::enrichment::EnrichmentReport {
+            entries: outcomes.len(),
+            ..Default::default()
+        };
+        for o in outcomes {
+            match o {
+                Ok(oc) => {
+                    report.facts_stored += oc.facts_stored;
+                    report.supersessions += oc.supersessions;
+                    report.raw_sources_tagged += usize::from(oc.raw_tagged);
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "enrichment degraded for entry");
+                    report.errors += 1;
+                }
+            }
+        }
+        report
+    }
+```
+Add `#[derive(Clone)]` to `EnrichmentParams` (Task 3) so it can be cloned per task.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test -p synaptic --lib --features embeddings enrich_pending 2>&1 | tail -12`
+Expected: PASS. Regression: `cargo test -p synaptic --lib --features embeddings 2>&1 | tail -6` all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib.rs src/memory/enrichment.rs
+git commit -m "feat(enrichment): enrich_pending bounded-concurrent + EnrichmentReport"
+```
+
+---
+
+### Task 5: Background worker + `shutdown` / `wait_for_enrichment`
+
+**Files:**
+- Modify: `src/lib.rs` (`AgentMemory` fields for worker; constructor spawn; `store_with_report` notify; `shutdown`, `wait_for_enrichment`)
+- Test: inline `#[cfg(test)]` in `src/lib.rs`
+
+**Interfaces:**
+- Produces:
+  - `AgentMemory` fields: `enrichment_notify: Arc<tokio::sync::Notify>`, `enrichment_shutdown: Arc<std::sync::atomic::AtomicBool>`, `enrichment_worker: Option<tokio::task::JoinHandle<()>>`
+  - `pub async fn AgentMemory::wait_for_enrichment(&self)` — returns when the queue is empty
+  - `pub async fn AgentMemory::shutdown(&mut self)` — signal + await worker drain
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[cfg(feature = "embeddings")]
+    #[tokio::test]
+    async fn background_mode_enriches_without_explicit_call() {
+        let config = MemoryConfig {
+            enrichment_mode: memory::enrichment::EnrichmentMode::Background,
+            store_extracted_facts: true,
+            enable_knowledge_graph: true,
+            ..Default::default()
+        };
+        let mut mem = AgentMemory::new(config).await.unwrap();
+        mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
+            facts: vec!["Alice lives in Berlin".to_string()],
+            fail: false,
+        }));
+        mem.store("turn1", "Alice: Berlin").await.unwrap();
+        // No enrich_pending() call; the background worker drains it.
+        mem.wait_for_enrichment().await;
+        assert!(mem.get_entry_for_test("turn1::fact0").await.is_some());
+    }
+```
+NOTE: the background worker uses the `self.reasoner` captured at spawn time. `set_reasoner_for_test` must therefore either (a) be called before any store, and the worker must read the reasoner from a shared `Arc<ArcSwap>`/re-clone, OR (b) for the test, the worker reads `self.reasoner` via an `Arc` cloned at spawn — but the stub is set after construction. To keep the test valid, make the worker capture an `Arc<tokio::sync::RwLock<Arc<dyn MemoryReasoner>>>` OR have `set_reasoner_for_test` also update the worker's copy. SIMPLEST: store the reasoner behind `Arc<ArcSwapOption>`? To avoid a new dep, make the worker re-fetch the reasoner from a shared `Arc<tokio::sync::Mutex<Arc<dyn MemoryReasoner>>>` that both `set_reasoner_for_test` and the constructor write. Implement that shared cell (`reasoner_cell`) and have both `enrich_pending` and the worker read from it; keep `self.reasoner` as the initial value written into the cell. (This is the one place the plan adds indirection so tests can inject a stub into the background worker.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p synaptic --lib --features embeddings background_mode_enriches 2>&1 | tail -12`
+Expected: FAIL — `wait_for_enrichment` not found.
+
+- [ ] **Step 3: Implement the worker + shared reasoner cell**
+
+- Add field `reasoner_cell: Arc<tokio::sync::Mutex<Arc<dyn memory::reasoning::MemoryReasoner>>>`, initialized in the constructor from the resolved `reasoner`. Change `set_reasoner_for_test` to also write the cell. Change `enrich_pending` and the worker to read the reasoner from `self.reasoner_cell.lock().await.clone()`.
+- Add `enrichment_notify: Arc<Notify>`, `enrichment_shutdown: Arc<AtomicBool>`, `enrichment_worker: Option<JoinHandle<()>>`.
+- In the constructor, when `enrichment_mode == Background`, spawn:
+```rust
+        #[cfg(feature = "embeddings")]
+        let enrichment_worker = if config.enrichment_mode
+            == memory::enrichment::EnrichmentMode::Background
+            && knowledge_graph.is_some()
+        {
+            let queue = enrichment_queue.clone();
+            let notify = enrichment_notify.clone();
+            let shutdown = enrichment_shutdown.clone();
+            let storage = storage.clone();
+            let kg = knowledge_graph.clone().unwrap();
+            let state = state.clone();
+            let reasoner_cell = reasoner_cell.clone();
+            let scoring = retrieval_scoring_provider.clone();
+            let params = memory::enrichment::EnrichmentParams {
+                distillation_live,
+                exclude_raw_default: config.retrieval_excludes_raw_sources,
+            };
+            let concurrency = config.enrichment_concurrency.max(1);
+            Some(tokio::spawn(async move {
+                loop {
+                    notify.notified().await;
+                    if shutdown.load(std::sync::atomic::Ordering::SeqCst)
+                        && queue.lock().await.is_empty()
+                    {
+                        break;
+                    }
+                    let reasoner = reasoner_cell.lock().await.clone();
+                    // drain + buffer_unordered enrich_one (same as enrich_pending's
+                    // core; factor into a shared free fn `drain_and_enrich(...)`).
+                    memory::enrichment::drain_and_enrich(
+                        &queue, &storage, &kg, &state, &reasoner, &scoring, &params, concurrency,
+                    ).await;
+                }
+            }))
+        } else {
+            None
+        };
+```
+- Factor the drain+enrich core of Task 4 into `pub async fn drain_and_enrich(queue, storage, kg, state, reasoner, scoring, params, concurrency) -> EnrichmentReport` in `enrichment.rs`; have both `enrich_pending` and the worker call it. (DRY — refactor Task 4's body into this fn.)
+- In `store_with_report`'s enqueue branch, after `push_back`, add: `if Background { self.enrichment_notify.notify_one(); }`.
+- Implement:
+```rust
+    #[cfg(feature = "embeddings")]
+    pub async fn wait_for_enrichment(&self) {
+        // Background: nudge the worker and poll until the queue drains.
+        loop {
+            if self.enrichment_queue.lock().await.is_empty() {
+                return;
+            }
+            self.enrichment_notify.notify_one();
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+    }
+
+    #[cfg(feature = "embeddings")]
+    pub async fn shutdown(&mut self) {
+        self.enrichment_shutdown
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        self.enrichment_notify.notify_one();
+        if let Some(h) = self.enrichment_worker.take() {
+            let _ = h.await;
+        }
+    }
+```
+Non-Background modes: `enrichment_worker` is `None`; `wait_for_enrichment` returns immediately (queue only fills in Deferred/Background, and Deferred requires an explicit `enrich_pending`, so `wait_for_enrichment` returning on empty is correct — for Deferred the caller uses `enrich_pending`, not `wait`).
+
+- [ ] **Step 4: Run tests + full regression**
+
+Run: `cargo test -p synaptic --lib --features embeddings background_mode_enriches 2>&1 | tail -10`
+Expected: PASS.
+Run: `cargo test -p synaptic --lib --features embeddings 2>&1 | tail -6` — all pass.
+Run: `cargo build -p synaptic 2>&1 | tail -3` — non-embeddings build compiles.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib.rs src/memory/enrichment.rs
+git commit -m "feat(enrichment): background worker + shutdown/wait_for_enrichment"
+```
+
+---
+
+### Task 6: Eval `--deferred-enrichment` measurement + docs
+
+**Files:**
+- Modify: `tools/eval/src/runner.rs` (ingest that queues then times `enrich_pending`)
+- Modify: `tools/eval/src/bin/run_eval.rs` (`--deferred-enrichment` flag + timing output)
+- Modify: `docs/evaluation.md` (result)
+
+This task produces a MEASUREMENT. It uses a real LLM reasoner (ollama qwen or the codex shim via `SYNAPTIC_LLM_URL`).
+
+- [ ] **Step 1: Add a deferred-ingest helper to `runner.rs`**
+
+```rust
+/// Ingest all turns with enrichment deferred, then run one bounded-concurrent
+/// enrich_pending pass. Returns (raw_ingest_secs, enrich_secs).
+pub async fn ingest_deferred(
+    conversation: &EvalConversation,
+    memory: &mut AgentMemory,
+) -> Result<(f64, f64), RunnerError> {
+    use std::time::Instant;
+    let t0 = Instant::now();
+    for session in &conversation.sessions {
+        for (i, turn) in session.turns.iter().enumerate() {
+            let key = turn_memory_key(session, i);
+            let value = match turn.timestamp.as_ref().or(session.timestamp.as_ref()) {
+                Some(ts) => format!("[{ts}] {}: {}", turn.speaker, turn.text),
+                None => format!("{}: {}", turn.speaker, turn.text),
+            };
+            memory.store(&key, &value).await.map_err(mem_err)?;
+        }
+    }
+    let raw_secs = t0.elapsed().as_secs_f64();
+    let t1 = Instant::now();
+    let _report = memory.enrich_pending().await;
+    let enrich_secs = t1.elapsed().as_secs_f64();
+    Ok((raw_secs, enrich_secs))
+}
+```
+
+- [ ] **Step 2: Add the `--deferred-enrichment` flag to `run_eval.rs`**
+
+Parse `--deferred-enrichment` in `main`. When set, add a mode that, for conversation 0 (respecting `--max-conversations`), builds an `AgentMemory` with `enrichment_mode: Deferred`, `store_extracted_facts: true`, `enable_knowledge_graph: true`, runs `runner::ingest_deferred`, and — for comparison — also times a synchronous ingest (`enrichment_mode: Inline`, same config, `runner::ingest`). Print:
+```
+== Deferred-enrichment ingest speedup (conv 0) ==
+synchronous (Inline) ingest: {sync}s
+deferred: raw {raw}s + enrich {enrich}s = {total}s  (concurrency {c})
+speedup: {sync/total:.1}x
+```
+Requires `SYNAPTIC_LLM_URL`/`SYNAPTIC_LLM_MODEL` (the library LLM reasoner); print a not-run notice if unset (never fabricate).
+
+- [ ] **Step 3: Build and smoke the flag (tiny, no LLM needed to compile)**
+
+Run: `cargo build --release -p synaptic-eval --bin run_eval --features 'synaptic/static-embeddings synaptic/llm-reasoning synaptic-eval/llm-reasoning' 2>&1 | tail -3`
+Expected: `Finished`.
+
+- [ ] **Step 4: Run the measurement with a real reasoner**
+
+```bash
+source "$SCRATCHPAD/cudaenv.sh"
+export SYNAPTIC_LLM_URL='http://localhost:11434/v1' SYNAPTIC_LLM_MODEL='qwen2.5:7b-instruct'
+export SYNAPTIC_RETRIEVAL_EMBEDDER=static SYNAPTIC_STATIC_MODEL_DIR=models/potion-base-8M
+./target/release/run_eval tools/eval/data/locomo10.json --deferred-enrichment --max-conversations 1
+```
+Expected: a speedup line. Target: conv-0's synchronous LLM ingest (~tens of minutes) drops toward `total_LLM_time / concurrency`.
+
+- [ ] **Step 5: Document the result in `docs/evaluation.md`**
+
+Add a dated section with the exact synchronous-vs-deferred numbers and the speedup, one honest sentence on what it unblocks (write-side capability re-runs), and caveats (single conversation, local 7B reasoner). Use the measured numbers — do not invent them.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/eval/src/runner.rs tools/eval/src/bin/run_eval.rs docs/evaluation.md
+git commit -m "feat(eval): --deferred-enrichment ingest-speedup measurement"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Arc<RwLock> state → Task 1. ✓
+- EnrichmentMode config + queue + enqueue → Task 2. ✓
+- enrich_one on Arc handles (storage/kg/state/reasoner/scoring) → Task 3. ✓
+- enrich_pending bounded-concurrent + report → Task 4. ✓
+- Background worker + shutdown + wait_for_enrichment → Task 5. ✓
+- Fact retrievability via scoring provider → Task 3 (`store_fact_shared` feeds `scoring.embed`). ✓
+- Failure-ordering invariant → Task 3 (tag raw only after ≥1 fact). ✓
+- Best-effort → Task 4 test `enrich_pending_best_effort_on_error`. ✓
+- Default-off equivalence → Task 2 (`Inline` branch = old `reason_over_store`) + full-suite regression each task. ✓
+- Re-entrancy (`::fact` not enqueued) → Task 2 enqueue branch. ✓
+- Measurement → Task 6. ✓
+
+**2. Placeholder scan:** Task 3 Step 1 and Task 6 leave the exact in-memory-storage constructor / measured numbers to the implementer — these are genuine "find the constructor" / "measurement output" items, not code placeholders; the surrounding code is complete. Task 5 Step 1 spells out the reasoner-cell indirection needed for the test rather than hand-waving.
+
+**3. Type consistency:** `enrich_one` handle types match the verified field types (Task 3 Interfaces). `EnrichmentReport`/`EnrichmentOutcome`/`EnrichmentParams` names consistent across Tasks 3–5. `drain_and_enrich` (Task 5) factors Task 4's body — Task 4's `enrich_pending` must be refactored to call it in Task 5 (noted). `enrichment_queue_len`/`get_entry_for_test`/`set_reasoner_for_test` are the existing test helpers.
+
+**Pre-implementation note:** Task 1 (the Arc<RwLock> refactor) is the riskiest — deadlocks come from holding a read guard across a write in one scope. Implement and fully green-test Task 1 before any other task. Confirm the in-memory storage constructor name (`grep -n "impl.*Storage for\|pub fn new" src/memory/storage/mod.rs`) for Task 3's test.

--- a/docs/superpowers/specs/2026-07-22-async-write-path-enrichment-design.md
+++ b/docs/superpowers/specs/2026-07-22-async-write-path-enrichment-design.md
@@ -96,7 +96,10 @@ This spec decouples the fast raw write from the slow LLM enrichment and makes en
    `embedding_manager` (a separate, already best-effort subsystem, `src/lib.rs:100`) is **not** fed
    for deferred-enriched facts — a documented, minor gap that does not affect pipeline/`storage`
    search retrievability (the real search path). Storage is `Arc<dyn Storage + Send + Sync>` with
-   `&self` methods, so concurrent access is sound.
+   `&self` methods, so concurrent access is sound. Deferred/Background facts likewise do **not**
+   get a knowledge-graph memory node, temporal tracking, or analytics events (unlike the Inline
+   path's `store_with_report`), so graph-based retrieval over deferred facts differs from Inline —
+   also documented, not expanded in scope here.
 
 5. **`enrich_pending()`** — `pub async fn enrich_pending(&self) -> EnrichmentReport`. Drains the
    queue, spawns bounded-concurrent (`Semaphore`, `enrichment_concurrency`) `enrich_one` tasks

--- a/docs/superpowers/specs/2026-07-22-async-write-path-enrichment-design.md
+++ b/docs/superpowers/specs/2026-07-22-async-write-path-enrichment-design.md
@@ -1,0 +1,182 @@
+# Async Write-Path Enrichment — Design Spec
+
+**Date:** 2026-07-22
+**Status:** Approved (brainstorm), pending implementation plan
+
+## Problem
+
+rust-synaptic's write path performs **synchronous per-turn LLM enrichment**: every `store()`
+awaits the reasoner's `extract → resolve → apply_resolution → mark_superseded → fact-store`
+sequence (`reason_over_store`, `src/lib.rs`). With an accessible LLM this is ~5.7 s per
+extraction call plus per-fact resolves, making ingest gated on LLM latency: LoCoMo conv-0 took
+35–60 min, and an LLM-supersession A/B was measured at ~4 h and aborted (see
+`docs/evaluation.md`). This is the identified architectural bottleneck that makes every
+write-side LLM capability (distillation, bi-temporal supersession detection, reflection
+synthesis) impractical to run or ship at scale.
+
+This spec decouples the fast raw write from the slow LLM enrichment and makes enrichment
+**concurrent**, so ingest latency is no longer gated on per-turn LLM latency.
+
+## Goals
+
+1. `store()` returns after the raw write without an inline LLM call (when enrichment is
+   deferred/background); enrichment runs later, concurrently.
+2. Bounded-concurrent enrichment (default 8) turns N serial LLM calls into ~N/8 wall-clock.
+3. Full state consistency: enriched facts and supersessions are in `state`, storage, and KG —
+   retrievable and checkpointable, identical semantics to the synchronous path.
+4. Best-effort: enrichment errors are logged/counted, never abort the write or the batch.
+5. Safe-by-default: enrichment mode is opt-in; default keeps today's exact synchronous behavior.
+6. Measure the LoCoMo ingest speedup with a real LLM reasoner, proving the bottleneck is removed.
+
+## Non-Goals
+
+- Persisting the enrichment queue across process restarts (in-memory; crash leaves un-enriched
+  entries as plain raw memories — consistent with best-effort).
+- Changing the reasoner, extraction/resolution logic, or the distillation/bi-temporal
+  semantics — this moves *when/how concurrently* enrichment runs, not *what* it computes.
+- Distributed/multi-process enrichment.
+
+## Global Constraints
+
+- Best-effort subsystem: a per-entry enrichment failure sets a counter in the returned report
+  and logs, never aborts the batch or the `store()`.
+- Default-off equivalence: with enrichment mode `Inline` (default), `store()` behaves
+  byte-for-byte like today (enrich synchronously); existing tests and callers unaffected.
+- All new enrichment code behind `#[cfg(feature = "embeddings")]`, matching the existing
+  write-path reasoning.
+- PR-only merge flow; a new branch per PR iteration.
+- No fabricated numbers; the measurement uses a real LLM reasoner (codex shim or ollama).
+
+## Design
+
+### Decisions (from brainstorm)
+
+- **Decoupling:** deferred-batch, explicit `enrich_pending()`, plus an opt-in background worker.
+- **State:** `state` becomes `Arc<RwLock<AgentState>>` for full consistency (chosen over the
+  storage-only gap and the reconcile-pass alternatives).
+- **Concurrency:** fully concurrent enrichment on the Arc/RwLock handles (max parallelism),
+  bounded by a semaphore.
+
+### Components
+
+1. **Shared state.** `AgentMemory.state: memory::state::AgentState` →
+   `Arc<tokio::sync::RwLock<memory::state::AgentState>>`. `AgentState` already derives `Clone`.
+   All 23 `self.state.X` sites in `src/lib.rs` become `self.state.read().await.X` /
+   `self.state.write().await.X`. `checkpoint_manager.create_checkpoint(&self.state)` (two sites,
+   `src/lib.rs:774`, `:1471`) and `should_checkpoint(&self.state)` become
+   `&*self.state.read().await`.
+
+2. **Enrichment mode config.** New `MemoryConfig::enrichment_mode: EnrichmentMode` enum:
+   - `Inline` **(default)** — today's behavior: `store_with_report` runs `reason_over_store`
+     inline (synchronous). No queue, no worker. Byte-for-byte unchanged.
+   - `Deferred` — `store()` enqueues; enrichment runs only on `enrich_pending()`.
+   - `Background` — `store()` enqueues + notifies a spawned worker that drains continuously.
+   New `MemoryConfig::enrichment_concurrency: usize` (default 8) — the semaphore permit count.
+
+3. **Pending queue.** `AgentMemory.enrichment_queue: Arc<Mutex<VecDeque<PendingEnrichment>>>`,
+   where `PendingEnrichment { key: String, value: String, timestamp: DateTime<Utc> }`.
+   `store_with_report` pushes here (in `Deferred`/`Background`) instead of calling
+   `reason_over_store` inline. `::fact{i}` keys (and any store made under the re-entrancy guard)
+   are never enqueued.
+
+4. **Enrichment engine.** The existing enrichment methods (`reason_over_store`, `neighbor_facts`,
+   `apply_resolution`, `mark_superseded`, `mark_raw_source`) are lifted from `&mut self` onto a
+   free-standing async function set that takes the Arc handles:
+   `enrich_one(storage: &Arc<dyn Storage>, kg: &Arc<RwLock<KG>>, state: &Arc<RwLock<AgentState>>,
+   reasoner: &Arc<dyn MemoryReasoner>, scoring: &Option<Arc<dyn EmbeddingProvider>>, config:
+   &EnrichmentParams, entry: &MemoryEntry) -> Result<EnrichmentOutcome>`. Each acquires locks in
+   the fixed order **KG → state** for the *shortest* span (mutate, drop); the LLM calls
+   (`extract`, `resolve`) happen outside any lock.
+   **Fact retrievability:** a fact-store writes `storage.store(fact)` +
+   `state.write().await.add_memory(fact)` **and** `scoring.embed(fact.value)` — the last keeps the
+   retrieval scoring provider's IDF corpus live so the pipeline/reranker can score the fact (this
+   is exactly what `store_with_report` does at `src/lib.rs:681`; `retrieval_scoring_provider` and
+   `retrieval_pipeline` are both `Arc`, so this is concurrency-safe). Facts are stored **directly**
+   (not via a recursive `store_with_report`), which avoids re-entrancy entirely. The owned
+   `embedding_manager` (a separate, already best-effort subsystem, `src/lib.rs:100`) is **not** fed
+   for deferred-enriched facts — a documented, minor gap that does not affect pipeline/`storage`
+   search retrievability (the real search path). Storage is `Arc<dyn Storage + Send + Sync>` with
+   `&self` methods, so concurrent access is sound.
+
+5. **`enrich_pending()`** — `pub async fn enrich_pending(&self) -> EnrichmentReport`. Drains the
+   queue, spawns bounded-concurrent (`Semaphore`, `enrichment_concurrency`) `enrich_one` tasks
+   over the drained entries, aggregates an `EnrichmentReport { entries, facts_stored,
+   supersessions, raw_sources_tagged, errors }`. `&self` (mutation only via Arc/RwLock).
+
+6. **Background worker (`Background` mode).** At construction, spawn a Tokio task holding clones
+   of the Arc handles + config + an `Arc<Notify>`. `store()` calls `notify_one()` after
+   enqueuing. The worker loops: wait on `Notify`, drain the queue, run `enrich_one` with bounded
+   concurrency. `AgentMemory` holds the `JoinHandle` and an `Arc<AtomicBool> shutdown`. New
+   `pub async fn shutdown(&self)` sets the flag, notifies, and awaits drain. New
+   `pub async fn wait_for_enrichment(&self)` blocks until the queue is empty (poll the queue len
+   behind the mutex; for `Background`, also await a drain signal) — for tests/eval determinism.
+   `Drop` best-effort signals shutdown (cannot await in `Drop`; the worker observes the flag).
+
+### Data flow
+
+`store(key, value)` (mode = Deferred/Background):
+1. Validate; build `MemoryEntry`; `storage.store` + `state.write().await.add_memory` (raw write,
+   as today). Temporal/analytics/KG-node/embeddings subsystems run as today.
+2. **Skip** the inline `reason_over_store`. Instead, if enrichment is live and the key is not a
+   `::fact{i}` key, push `PendingEnrichment` to the queue. In `Background`, `notify_one()`.
+3. Return `StoreDegradations` (enrichment degradations now reported later, via the
+   `EnrichmentReport`, not the per-store degradations).
+
+`enrich_pending()` / background drain:
+1. Lock queue, `drain(..)` into a local `Vec`, unlock.
+2. `stream::iter(entries).map(|e| enrich_one(...)).buffer_unordered(concurrency)`.
+3. Each `enrich_one`: `extract` (no lock) → for each fact: `neighbor_facts` (storage read) →
+   `resolve` (no lock) → apply under KG→state locks (add_extracted_fact / supersede /
+   fact-store / mark_raw_source). Re-reads neighbors under the lock it will mutate, so a
+   same-batch prior apply is visible (documented: "resolves in completion order").
+4. Aggregate outcomes → `EnrichmentReport`.
+
+`search()` is unchanged — it already reads from the pipeline/`storage`, and the superseded/
+raw_source filters read `custom_fields` from the returned fragments, so enriched results are
+visible once `enrich_pending` (or the worker) has run.
+
+### Error handling
+
+- `enrich_one` returns `Result`; a failure logs at `warn`, increments `EnrichmentReport.errors`,
+  and the entry's raw memory remains stored/searchable. The batch continues.
+- `Background` worker: same per-entry best-effort; the worker never panics out (errors counted,
+  logged; an internal `Arc<Mutex<EnrichmentReport>>` accumulates for observability).
+- Lock order KG→state is fixed everywhere to preclude deadlock; locks are never held across an
+  `await` on the reasoner.
+
+## Testing
+
+Unit (deterministic; a stub `MemoryReasoner` returning known facts / errors / sleeping):
+- Deferred: raw memory retrievable immediately after `store()`; `::fact` memories absent before
+  `enrich_pending()`, present after; `state` (shared) contains them (full consistency).
+- Concurrency speedup: stub sleeps `d` on each of M entries; `enrich_pending` wall-clock ≈
+  `ceil(M/concurrency)·d` (proves parallelism); all facts land exactly once.
+- Staleness: two queued entries, same subject, stub resolution supersedes → exactly one
+  supersession, current fact wins (proves resolve-under-lock).
+- Best-effort: stub errors on one entry → its raw memory intact, others enriched, `errors == 1`,
+  batch completes.
+- Re-entrancy: `::fact{i}` memories never enqueued/re-enriched.
+- Default-off equivalence: `EnrichmentMode::Inline` → `store()` byte-for-byte as today (existing
+  `store_extracted_facts_*`, distillation, superseded tests pass unchanged).
+- Background: `wait_for_enrichment()` blocks until drained; `shutdown()` drains and stops cleanly.
+
+Measurement (the payoff): eval-harness `--deferred-enrichment` path — ingest all LoCoMo conv-0
+turns fast (queue), then one `enrich_pending()` at concurrency 8, using the real LLM reasoner
+(ollama qwen or codex shim). Report `ingest wall-clock: synchronous Xs vs deferred Ys (N×)`.
+Target: conv-0's ~35–60 min synchronous LLM ingest drops toward `total_LLM_time / 8`.
+
+## Rollout
+
+1. Land the `Arc<RwLock>` state refactor + `EnrichmentMode`/queue/`enrich_pending`/background +
+   unit tests, default `Inline` (no behavior change), behind a PR with green substantive CI.
+2. Add the eval `--deferred-enrichment` measurement; run it; add the speedup to
+   `docs/evaluation.md`.
+3. If the speedup is real (expected ~concurrency×), document `Deferred`/`Background` as the
+   recommended modes for LLM-reasoner deployments; the write-side capability measurements
+   (distillation, LLM supersession) become tractable to re-run.
+
+## Open questions
+
+None blocking. Whether `Drop` should best-effort-drain (it cannot await) vs require an explicit
+`shutdown()` is an implementation detail; the plan will use the AtomicBool-observed-by-worker
+approach and document that callers should `shutdown().await` for a guaranteed drain.

--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -68,7 +68,7 @@ async fn basic_memory_operations() -> Result<()> {
     }
 
     // Get memory statistics
-    let stats = memory.stats();
+    let stats = memory.stats().await;
     println!(
         "✓ Memory stats: {} short-term, {} long-term, {} bytes total",
         stats.short_term_count, stats.long_term_count, stats.total_size

--- a/examples/combined_full_system.rs
+++ b/examples/combined_full_system.rs
@@ -253,7 +253,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         println!(" Retrieved memory: {}", retrieved.key);
 
                                         // Get memory stats
-                                        let memory_stats = memory.stats();
+                                        let memory_stats = memory.stats().await;
                                         println!(
                                             " Memory stats: {} short-term, {} long-term",
                                             memory_stats.short_term_count,

--- a/examples/complex_visualizations.rs
+++ b/examples/complex_visualizations.rs
@@ -761,7 +761,7 @@ async fn generate_complex_visualizations(memory: &AgentMemory) -> Result<(), Box
     println!("   Saved: {}", network_path);
 
     // Generate temporal analytics
-    let stats = memory.stats();
+    let stats = memory.stats().await;
     let temporal_data = vec![
         (
             chrono::Utc::now() - chrono::Duration::days(30),

--- a/examples/intelligent_updates.rs
+++ b/examples/intelligent_updates.rs
@@ -207,7 +207,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     println!("\n Example 9: Final System State");
     println!("-------------------------------");
 
-    let stats = memory.stats();
+    let stats = memory.stats().await;
     println!("Memory Statistics:");
     println!("  • Short-term memories: {}", stats.short_term_count);
     println!("  • Long-term memories: {}", stats.long_term_count);

--- a/examples/phase1_semantic_search.rs
+++ b/examples/phase1_semantic_search.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 
     // Get basic statistics
-    let stats = memory.stats();
+    let stats = memory.stats().await;
     println!("\n Memory System Statistics:");
     println!(
         "  • Total memories: {}",

--- a/examples/phase3_analytics.rs
+++ b/examples/phase3_analytics.rs
@@ -360,7 +360,7 @@ async fn integrated_analytics_demo() -> Result<(), Box<dyn Error>> {
     }
 
     println!(" Integrated analytics pipeline completed");
-    println!(" Memory stats: {:?}", memory.stats());
+    println!(" Memory stats: {:?}", memory.stats().await);
 
     Ok(())
 }

--- a/examples/real_integrations.rs
+++ b/examples/real_integrations.rs
@@ -618,7 +618,7 @@ async fn integrated_system_demo() -> Result<(), Box<dyn Error>> {
                         );
                     }
 
-                    println!(" Memory stats: {:?}", memory.stats());
+                    println!(" Memory stats: {:?}", memory.stats().await);
                 }
                 Err(e) => println!(" Failed to create integrated memory system: {}", e),
             }

--- a/examples/simple_intelligent_updates.rs
+++ b/examples/simple_intelligent_updates.rs
@@ -204,7 +204,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     println!("\n Example 9: Final System State");
     println!("-------------------------------");
 
-    let stats = memory.stats();
+    let stats = memory.stats().await;
     println!("Memory Statistics:");
     println!("  • Short-term memories: {}", stats.short_term_count);
     println!("  • Long-term memories: {}", stats.long_term_count);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,6 +174,26 @@ pub struct AgentMemory {
     neighbor_examined_max: std::sync::atomic::AtomicUsize,
     /// Entries awaiting enrichment when `MemoryConfig::enrichment_mode` is
     /// `Deferred` or `Background` (see `memory::enrichment`).
+    /// Shared cell holding the active reasoner, read by both `enrich_pending`
+    /// and the Background worker loop. Indirection exists so
+    /// `set_reasoner_for_test` (called after construction) can inject a stub
+    /// into an already-spawned worker task rather than the value it captured
+    /// at spawn time.
+    #[cfg(feature = "embeddings")]
+    reasoner_cell: Arc<tokio::sync::Mutex<Arc<dyn memory::reasoning::MemoryReasoner>>>,
+    /// Wakes the Background worker after `store()` enqueues an entry, and
+    /// after `shutdown()`/`wait_for_enrichment()` request a drain.
+    #[cfg(feature = "embeddings")]
+    enrichment_notify: Arc<tokio::sync::Notify>,
+    /// Set by `shutdown()`; the worker exits its loop once this is true AND
+    /// the queue is empty.
+    #[cfg(feature = "embeddings")]
+    enrichment_shutdown: Arc<std::sync::atomic::AtomicBool>,
+    /// Handle to the spawned Background worker task; `None` unless
+    /// `MemoryConfig::enrichment_mode == Background` and a knowledge graph is
+    /// configured. Taken (and awaited) by `shutdown()`.
+    #[cfg(feature = "embeddings")]
+    enrichment_worker: Option<tokio::task::JoinHandle<()>>,
     #[cfg(feature = "embeddings")]
     enrichment_queue: std::sync::Arc<
         tokio::sync::Mutex<std::collections::VecDeque<memory::enrichment::PendingEnrichment>>,
@@ -188,8 +208,9 @@ impl AgentMemory {
     const RAW_SOURCE_FIELD: &'static str = "raw_source";
 
     #[cfg(all(feature = "embeddings", test))]
-    fn set_reasoner_for_test(&mut self, r: Arc<dyn memory::reasoning::MemoryReasoner>) {
-        self.reasoner = r;
+    async fn set_reasoner_for_test(&mut self, r: Arc<dyn memory::reasoning::MemoryReasoner>) {
+        self.reasoner = r.clone();
+        *self.reasoner_cell.lock().await = r;
     }
 
     #[cfg(all(feature = "embeddings", test))]
@@ -209,65 +230,55 @@ impl AgentMemory {
     /// empty). Takes `&self` — mutation is via the Arc/RwLock handles.
     #[cfg(feature = "embeddings")]
     pub async fn enrich_pending(&self) -> memory::enrichment::EnrichmentReport {
-        use futures::stream::{self, StreamExt};
         let Some(ref kg) = self.knowledge_graph else {
             return memory::enrichment::EnrichmentReport::default();
         };
-        let pending: Vec<memory::enrichment::PendingEnrichment> = {
-            let mut q = self.enrichment_queue.lock().await;
-            q.drain(..).collect()
-        };
-        if pending.is_empty() {
-            return memory::enrichment::EnrichmentReport::default();
-        }
         let params = memory::enrichment::EnrichmentParams {
             distillation_live: self.distillation_live,
             exclude_raw_default: self._config.retrieval_excludes_raw_sources,
         };
         let concurrency = self._config.enrichment_concurrency.max(1);
-        let storage = std::sync::Arc::clone(&self.storage);
-        let kg = std::sync::Arc::clone(kg);
-        let state = std::sync::Arc::clone(&self.state);
-        let reasoner = std::sync::Arc::clone(&self.reasoner);
-        let scoring = self.retrieval_scoring_provider.clone();
-        let outcomes = stream::iter(pending)
-            .map(|p| {
-                let (storage, kg, state, reasoner, scoring, params) = (
-                    storage.clone(),
-                    kg.clone(),
-                    state.clone(),
-                    reasoner.clone(),
-                    scoring.clone(),
-                    params,
-                );
-                async move {
-                    memory::enrichment::enrich_one(
-                        &storage, &kg, &state, &reasoner, &scoring, params, &p.key, &p.value,
-                    )
-                    .await
-                }
-            })
-            .buffer_unordered(concurrency)
-            .collect::<Vec<_>>()
-            .await;
-        let mut report = memory::enrichment::EnrichmentReport {
-            entries: outcomes.len(),
-            ..Default::default()
-        };
-        for o in outcomes {
-            match o {
-                Ok(oc) => {
-                    report.facts_stored += oc.facts_stored;
-                    report.supersessions += oc.supersessions;
-                    report.raw_sources_tagged += usize::from(oc.raw_tagged);
-                }
-                Err(e) => {
-                    tracing::warn!(error = %e, "enrichment degraded for entry");
-                    report.errors += 1;
-                }
+        let reasoner = self.reasoner_cell.lock().await.clone();
+        memory::enrichment::drain_and_enrich(
+            &self.enrichment_queue,
+            &self.storage,
+            kg,
+            &self.state,
+            &reasoner,
+            &self.retrieval_scoring_provider,
+            params,
+            concurrency,
+        )
+        .await
+    }
+
+    /// Nudge the Background worker and poll until the enrichment queue
+    /// drains. In non-Background modes the queue only fills via an explicit
+    /// `enrich_pending()` call site (Deferred), so this returns immediately
+    /// whenever the queue happens to be empty.
+    #[cfg(feature = "embeddings")]
+    pub async fn wait_for_enrichment(&self) {
+        loop {
+            if self.enrichment_queue.lock().await.is_empty() {
+                return;
             }
+            self.enrichment_notify.notify_one();
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
         }
-        report
+    }
+
+    /// Signal the Background worker to stop, wake it, and await its clean
+    /// exit (it drains any remaining queued entries first). No-op if no
+    /// worker was spawned (non-Background modes) or `shutdown` was already
+    /// called (the second call finds `enrichment_worker` already `None`).
+    #[cfg(feature = "embeddings")]
+    pub async fn shutdown(&mut self) {
+        self.enrichment_shutdown
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        self.enrichment_notify.notify_one();
+        if let Some(h) = self.enrichment_worker.take() {
+            let _ = h.await;
+        }
     }
 
     /// Create a new agent memory system with the given configuration
@@ -588,11 +599,71 @@ impl AgentMemory {
             None
         };
 
+        let state = std::sync::Arc::new(tokio::sync::RwLock::new(state));
+        #[cfg(feature = "embeddings")]
+        let reasoner_cell = Arc::new(tokio::sync::Mutex::new(Arc::clone(&reasoner)));
+        #[cfg(feature = "embeddings")]
+        let enrichment_notify = Arc::new(tokio::sync::Notify::new());
+        #[cfg(feature = "embeddings")]
+        let enrichment_shutdown = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        #[cfg(feature = "embeddings")]
+        let enrichment_queue: std::sync::Arc<
+            tokio::sync::Mutex<std::collections::VecDeque<memory::enrichment::PendingEnrichment>>,
+        > = std::sync::Arc::new(tokio::sync::Mutex::new(std::collections::VecDeque::new()));
+
+        // Spawn the Background worker before the entries it captures are
+        // moved into `agent` below; it operates purely on shared `Arc`
+        // handles, so it can run independently of the `AgentMemory` value.
+        #[cfg(feature = "embeddings")]
+        let enrichment_worker = if config.enrichment_mode == memory::enrichment::EnrichmentMode::Background
+            && knowledge_graph.is_some()
+        {
+            let queue = enrichment_queue.clone();
+            let notify = enrichment_notify.clone();
+            let shutdown = enrichment_shutdown.clone();
+            let storage = storage.clone();
+            let Some(kg) = knowledge_graph.clone() else {
+                unreachable!("guarded by knowledge_graph.is_some() above")
+            };
+            let worker_state = state.clone();
+            let reasoner_cell = reasoner_cell.clone();
+            let scoring = retrieval_scoring_provider.clone();
+            let params = memory::enrichment::EnrichmentParams {
+                distillation_live,
+                exclude_raw_default: config.retrieval_excludes_raw_sources,
+            };
+            let concurrency = config.enrichment_concurrency.max(1);
+            Some(tokio::spawn(async move {
+                loop {
+                    notify.notified().await;
+                    if shutdown.load(std::sync::atomic::Ordering::SeqCst)
+                        && queue.lock().await.is_empty()
+                    {
+                        break;
+                    }
+                    let reasoner = reasoner_cell.lock().await.clone();
+                    memory::enrichment::drain_and_enrich(
+                        &queue,
+                        &storage,
+                        &kg,
+                        &worker_state,
+                        &reasoner,
+                        &scoring,
+                        params,
+                        concurrency,
+                    )
+                    .await;
+                }
+            }))
+        } else {
+            None
+        };
+
         // Build base agent without multimodal memory initialized
         let agent = Self {
             _config: config.clone(),
             session_id,
-            state: std::sync::Arc::new(tokio::sync::RwLock::new(state)),
+            state,
             storage,
             checkpoint_manager,
             knowledge_graph,
@@ -602,6 +673,14 @@ impl AgentMemory {
             embedding_manager,
             #[cfg(feature = "embeddings")]
             reasoner,
+            #[cfg(feature = "embeddings")]
+            reasoner_cell,
+            #[cfg(feature = "embeddings")]
+            enrichment_notify,
+            #[cfg(feature = "embeddings")]
+            enrichment_shutdown,
+            #[cfg(feature = "embeddings")]
+            enrichment_worker,
             #[cfg(feature = "embeddings")]
             reflection_engine,
             #[cfg(feature = "embeddings")]
@@ -631,9 +710,7 @@ impl AgentMemory {
             #[cfg(all(feature = "embeddings", feature = "test-utils"))]
             neighbor_examined_max: std::sync::atomic::AtomicUsize::new(0),
             #[cfg(feature = "embeddings")]
-            enrichment_queue: std::sync::Arc::new(tokio::sync::Mutex::new(
-                std::collections::VecDeque::new(),
-            )),
+            enrichment_queue,
         };
 
         // Initialize multimodal memory after creating base agent to avoid circular dependency
@@ -869,7 +946,11 @@ impl AgentMemory {
                                 value: value.to_string(),
                             },
                         );
-                        // Background notification wired in Task 5.
+                        if self._config.enrichment_mode
+                            == memory::enrichment::EnrichmentMode::Background
+                        {
+                            self.enrichment_notify.notify_one();
+                        }
                     }
                 }
             }
@@ -2119,7 +2200,7 @@ mod tests {
         mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
             facts: vec!["Alice lives in Berlin".to_string()],
             fail: false,
-        }));
+        })).await;
         mem.store("turn1", "Alice: I moved to Berlin").await.unwrap();
         // Deferred: no fact-memory yet (enrichment not run), raw is present.
         assert!(mem.get_entry_for_test("turn1").await.is_some());
@@ -2140,7 +2221,7 @@ mod tests {
         mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
             facts: vec!["Alice lives in Berlin".to_string()],
             fail: false,
-        }));
+        })).await;
         mem.store("turn1", "Alice: I moved to Berlin").await.unwrap();
         assert!(mem.get_entry_for_test("turn1::fact0").await.is_none());
         let report = mem.enrich_pending().await;
@@ -2150,6 +2231,27 @@ mod tests {
         // fact now retrievable + queue drained
         assert!(mem.get_entry_for_test("turn1::fact0").await.is_some());
         assert_eq!(mem.enrichment_queue_len().await, 0);
+    }
+
+    #[cfg(feature = "embeddings")]
+    #[tokio::test]
+    async fn background_mode_enriches_without_explicit_call() {
+        let config = MemoryConfig {
+            enrichment_mode: memory::enrichment::EnrichmentMode::Background,
+            store_extracted_facts: true,
+            enable_knowledge_graph: true,
+            ..Default::default()
+        };
+        let mut mem = AgentMemory::new(config).await.unwrap();
+        mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
+            facts: vec!["Alice lives in Berlin".to_string()],
+            fail: false,
+        }))
+        .await;
+        mem.store("turn1", "Alice: Berlin").await.unwrap();
+        // No enrich_pending() call; the background worker drains it.
+        mem.wait_for_enrichment().await;
+        assert!(mem.get_entry_for_test("turn1::fact0").await.is_some());
     }
 
     #[cfg(feature = "embeddings")]
@@ -2165,7 +2267,7 @@ mod tests {
         mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
             facts: vec![],
             fail: true,
-        }));
+        })).await;
         mem.store("turn1", "Alice: Berlin").await.unwrap();
         let report = mem.enrich_pending().await;
         assert_eq!(report.entries, 1);
@@ -2186,7 +2288,7 @@ mod tests {
         mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
             facts: vec!["Alice lives in Berlin".to_string()],
             fail: false,
-        }));
+        })).await;
         mem.store("turn1", "Alice: I moved to Berlin last year")
             .await
             .unwrap();
@@ -2210,7 +2312,7 @@ mod tests {
         mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
             facts: vec![],
             fail: true,
-        }));
+        })).await;
         // Write still succeeds (best-effort); raw turn stays searchable/untagged.
         mem.store("turn1", "Alice: I moved to Berlin")
             .await
@@ -2380,7 +2482,7 @@ mod tests {
         mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
             facts: vec!["Alice lives in Berlin".to_string()],
             fail: false,
-        }));
+        })).await;
         mem.store("turn1", "Alice: I moved to Berlin last year")
             .await
             .unwrap();
@@ -2410,7 +2512,7 @@ mod tests {
         mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
             facts: vec!["Alice lives in Berlin".to_string()],
             fail: false,
-        }));
+        })).await;
         mem.store("turn1", "Alice: I moved to Berlin last year")
             .await
             .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,6 +202,74 @@ impl AgentMemory {
         self.enrichment_queue.lock().await.len()
     }
 
+    /// Drain the pending-enrichment queue and enrich all entries with bounded
+    /// concurrency (`MemoryConfig::enrichment_concurrency`). Best-effort: a
+    /// per-entry failure is counted in the report, never aborts the batch.
+    /// Only meaningful in Deferred/Background modes (Inline leaves the queue
+    /// empty). Takes `&self` — mutation is via the Arc/RwLock handles.
+    #[cfg(feature = "embeddings")]
+    pub async fn enrich_pending(&self) -> memory::enrichment::EnrichmentReport {
+        use futures::stream::{self, StreamExt};
+        let Some(ref kg) = self.knowledge_graph else {
+            return memory::enrichment::EnrichmentReport::default();
+        };
+        let pending: Vec<memory::enrichment::PendingEnrichment> = {
+            let mut q = self.enrichment_queue.lock().await;
+            q.drain(..).collect()
+        };
+        if pending.is_empty() {
+            return memory::enrichment::EnrichmentReport::default();
+        }
+        let params = memory::enrichment::EnrichmentParams {
+            distillation_live: self.distillation_live,
+            exclude_raw_default: self._config.retrieval_excludes_raw_sources,
+        };
+        let concurrency = self._config.enrichment_concurrency.max(1);
+        let storage = std::sync::Arc::clone(&self.storage);
+        let kg = std::sync::Arc::clone(kg);
+        let state = std::sync::Arc::clone(&self.state);
+        let reasoner = std::sync::Arc::clone(&self.reasoner);
+        let scoring = self.retrieval_scoring_provider.clone();
+        let outcomes = stream::iter(pending)
+            .map(|p| {
+                let (storage, kg, state, reasoner, scoring, params) = (
+                    storage.clone(),
+                    kg.clone(),
+                    state.clone(),
+                    reasoner.clone(),
+                    scoring.clone(),
+                    params,
+                );
+                async move {
+                    memory::enrichment::enrich_one(
+                        &storage, &kg, &state, &reasoner, &scoring, params, &p.key, &p.value,
+                    )
+                    .await
+                }
+            })
+            .buffer_unordered(concurrency)
+            .collect::<Vec<_>>()
+            .await;
+        let mut report = memory::enrichment::EnrichmentReport {
+            entries: outcomes.len(),
+            ..Default::default()
+        };
+        for o in outcomes {
+            match o {
+                Ok(oc) => {
+                    report.facts_stored += oc.facts_stored;
+                    report.supersessions += oc.supersessions;
+                    report.raw_sources_tagged += usize::from(oc.raw_tagged);
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "enrichment degraded for entry");
+                    report.errors += 1;
+                }
+            }
+        }
+        report
+    }
+
     /// Create a new agent memory system with the given configuration
     #[tracing::instrument(skip(config), fields(session_id = %config.session_id.unwrap_or_else(Uuid::new_v4)))]
     pub async fn new(config: MemoryConfig) -> Result<Self> {
@@ -2057,6 +2125,53 @@ mod tests {
         assert!(mem.get_entry_for_test("turn1").await.is_some());
         assert!(mem.get_entry_for_test("turn1::fact0").await.is_none());
         assert_eq!(mem.enrichment_queue_len().await, 1);
+    }
+
+    #[cfg(feature = "embeddings")]
+    #[tokio::test]
+    async fn enrich_pending_processes_queue() {
+        let config = MemoryConfig {
+            enrichment_mode: memory::enrichment::EnrichmentMode::Deferred,
+            store_extracted_facts: true,
+            enable_knowledge_graph: true,
+            ..Default::default()
+        };
+        let mut mem = AgentMemory::new(config).await.unwrap();
+        mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
+            facts: vec!["Alice lives in Berlin".to_string()],
+            fail: false,
+        }));
+        mem.store("turn1", "Alice: I moved to Berlin").await.unwrap();
+        assert!(mem.get_entry_for_test("turn1::fact0").await.is_none());
+        let report = mem.enrich_pending().await;
+        assert_eq!(report.entries, 1);
+        assert_eq!(report.facts_stored, 1);
+        assert_eq!(report.errors, 0);
+        // fact now retrievable + queue drained
+        assert!(mem.get_entry_for_test("turn1::fact0").await.is_some());
+        assert_eq!(mem.enrichment_queue_len().await, 0);
+    }
+
+    #[cfg(feature = "embeddings")]
+    #[tokio::test]
+    async fn enrich_pending_best_effort_on_error() {
+        let config = MemoryConfig {
+            enrichment_mode: memory::enrichment::EnrichmentMode::Deferred,
+            store_extracted_facts: true,
+            enable_knowledge_graph: true,
+            ..Default::default()
+        };
+        let mut mem = AgentMemory::new(config).await.unwrap();
+        mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
+            facts: vec![],
+            fail: true,
+        }));
+        mem.store("turn1", "Alice: Berlin").await.unwrap();
+        let report = mem.enrich_pending().await;
+        assert_eq!(report.entries, 1);
+        assert_eq!(report.errors, 1);
+        // raw memory intact despite enrichment failure
+        assert!(mem.get_entry_for_test("turn1").await.is_some());
     }
 
     #[cfg(feature = "embeddings")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,6 +189,13 @@ pub struct AgentMemory {
     /// the queue is empty.
     #[cfg(feature = "embeddings")]
     enrichment_shutdown: Arc<std::sync::atomic::AtomicBool>,
+    /// Number of entries currently drained from `enrichment_queue` but not
+    /// yet finished enriching. `drain_and_enrich` moves entries into a local
+    /// batch before running them concurrently, so the queue itself is empty
+    /// while enrichment is still in flight; `wait_for_enrichment` must poll
+    /// this in addition to the queue to avoid returning early.
+    #[cfg(feature = "embeddings")]
+    enrichment_inflight: Arc<std::sync::atomic::AtomicUsize>,
     /// Handle to the spawned Background worker task; `None` unless
     /// `MemoryConfig::enrichment_mode == Background` and a knowledge graph is
     /// configured. Taken (and awaited) by `shutdown()`.
@@ -235,7 +242,6 @@ impl AgentMemory {
         };
         let params = memory::enrichment::EnrichmentParams {
             distillation_live: self.distillation_live,
-            exclude_raw_default: self._config.retrieval_excludes_raw_sources,
         };
         let concurrency = self._config.enrichment_concurrency.max(1);
         let reasoner = self.reasoner_cell.lock().await.clone();
@@ -248,6 +254,7 @@ impl AgentMemory {
             &self.retrieval_scoring_provider,
             params,
             concurrency,
+            &self.enrichment_inflight,
         )
         .await
     }
@@ -259,7 +266,12 @@ impl AgentMemory {
     #[cfg(feature = "embeddings")]
     pub async fn wait_for_enrichment(&self) {
         loop {
-            if self.enrichment_queue.lock().await.is_empty() {
+            let queue_empty = self.enrichment_queue.lock().await.is_empty();
+            let inflight_zero = self
+                .enrichment_inflight
+                .load(std::sync::atomic::Ordering::SeqCst)
+                == 0;
+            if queue_empty && inflight_zero {
                 return;
             }
             self.enrichment_notify.notify_one();
@@ -607,6 +619,8 @@ impl AgentMemory {
         #[cfg(feature = "embeddings")]
         let enrichment_shutdown = Arc::new(std::sync::atomic::AtomicBool::new(false));
         #[cfg(feature = "embeddings")]
+        let enrichment_inflight = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        #[cfg(feature = "embeddings")]
         let enrichment_queue: std::sync::Arc<
             tokio::sync::Mutex<std::collections::VecDeque<memory::enrichment::PendingEnrichment>>,
         > = std::sync::Arc::new(tokio::sync::Mutex::new(std::collections::VecDeque::new()));
@@ -622,6 +636,7 @@ impl AgentMemory {
             let queue = enrichment_queue.clone();
             let notify = enrichment_notify.clone();
             let shutdown = enrichment_shutdown.clone();
+            let inflight = enrichment_inflight.clone();
             let storage = storage.clone();
             let Some(kg) = knowledge_graph.clone() else {
                 unreachable!("guarded by knowledge_graph.is_some() above")
@@ -629,19 +644,18 @@ impl AgentMemory {
             let worker_state = state.clone();
             let reasoner_cell = reasoner_cell.clone();
             let scoring = retrieval_scoring_provider.clone();
-            let params = memory::enrichment::EnrichmentParams {
-                distillation_live,
-                exclude_raw_default: config.retrieval_excludes_raw_sources,
-            };
+            let params = memory::enrichment::EnrichmentParams { distillation_live };
             let concurrency = config.enrichment_concurrency.max(1);
             Some(tokio::spawn(async move {
                 loop {
-                    notify.notified().await;
-                    if shutdown.load(std::sync::atomic::Ordering::SeqCst)
-                        && queue.lock().await.is_empty()
-                    {
-                        break;
-                    }
+                    // Drain whatever is queued right now. `Notify::notify_one`
+                    // coalesces concurrent notifications into a single permit,
+                    // so a `store()` while we're already draining plus a
+                    // subsequent `shutdown()` can both collapse onto one
+                    // permit; draining first (before checking shutdown) makes
+                    // sure any entry queued before shutdown is always
+                    // enriched, and the loop then exits below without parking
+                    // on a `notified()` that will never be woken again.
                     let reasoner = reasoner_cell.lock().await.clone();
                     memory::enrichment::drain_and_enrich(
                         &queue,
@@ -652,8 +666,15 @@ impl AgentMemory {
                         &scoring,
                         params,
                         concurrency,
+                        &inflight,
                     )
                     .await;
+                    if shutdown.load(std::sync::atomic::Ordering::SeqCst)
+                        && queue.lock().await.is_empty()
+                    {
+                        break;
+                    }
+                    notify.notified().await;
                 }
             }))
         } else {
@@ -680,6 +701,8 @@ impl AgentMemory {
             enrichment_notify,
             #[cfg(feature = "embeddings")]
             enrichment_shutdown,
+            #[cfg(feature = "embeddings")]
+            enrichment_inflight,
             #[cfg(feature = "embeddings")]
             enrichment_worker,
             #[cfg(feature = "embeddings")]
@@ -2263,6 +2286,110 @@ mod tests {
         mem.store("turn1", "Alice: Berlin").await.unwrap();
         // No enrich_pending() call; the background worker drains it.
         mem.wait_for_enrichment().await;
+        assert!(mem.get_entry_for_test("turn1::fact0").await.is_some());
+    }
+
+    // Regression test for the shutdown-hang bug: `Notify::notify_one`
+    // coalesces concurrent permits, so a `store()` racing a `shutdown()`
+    // could previously leave a queued entry undrained and park the worker
+    // forever, hanging `shutdown().await`. The drain-then-check loop always
+    // drains before checking the shutdown flag, so this must complete well
+    // within the timeout.
+    #[cfg(feature = "embeddings")]
+    #[tokio::test]
+    async fn shutdown_drains_queued_entries_and_returns() {
+        let config = MemoryConfig {
+            enrichment_mode: memory::enrichment::EnrichmentMode::Background,
+            store_extracted_facts: true,
+            enable_knowledge_graph: true,
+            ..Default::default()
+        };
+        let mut mem = AgentMemory::new(config).await.unwrap();
+        mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
+            facts: vec!["Alice lives in Berlin".to_string()],
+            fail: false,
+        }))
+        .await;
+        mem.store("turn1", "Alice: Berlin").await.unwrap();
+        // Immediately shut down without waiting for enrichment first; a
+        // pre-fix worker loop can park forever here.
+        tokio::time::timeout(std::time::Duration::from_secs(10), mem.shutdown())
+            .await
+            .expect("shutdown() hung: queued entry was never drained before exit");
+        assert!(mem.get_entry_for_test("turn1::fact0").await.is_some());
+    }
+
+    // Regression test for the early-return bug: `wait_for_enrichment` only
+    // polled the queue, but `drain_and_enrich` empties the queue into a
+    // local batch *before* running the (potentially slow) enrichment, so the
+    // queue looks empty for the whole duration of enrichment. A slow stub
+    // reasoner makes the race deterministic: pre-fix this assertion would
+    // fail because the fact isn't written yet when `wait_for_enrichment`
+    // returns; post-fix the in-flight counter keeps it waiting.
+    #[cfg(feature = "embeddings")]
+    #[derive(Clone)]
+    struct SlowStubReasoner {
+        facts: Vec<String>,
+    }
+
+    #[cfg(feature = "embeddings")]
+    #[async_trait::async_trait]
+    impl memory::reasoning::MemoryReasoner for SlowStubReasoner {
+        async fn extract(
+            &self,
+            _text: &str,
+            _ctx: &memory::reasoning::ExtractionContext,
+        ) -> Result<memory::reasoning::Extraction> {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            Ok(memory::reasoning::Extraction {
+                facts: self
+                    .facts
+                    .iter()
+                    .map(|t| memory::reasoning::Fact {
+                        text: t.clone(),
+                        entities: Vec::new(),
+                        relations: Vec::new(),
+                    })
+                    .collect(),
+            })
+        }
+        async fn resolve(
+            &self,
+            _candidate: &memory::reasoning::Fact,
+            _neighbors: &[memory::reasoning::NeighborFact],
+        ) -> Result<memory::reasoning::ConflictResolution> {
+            Ok(memory::reasoning::ConflictResolution::Insert)
+        }
+        async fn synthesize(
+            &self,
+            _cluster: &[MemoryEntry],
+        ) -> Result<Option<memory::reasoning::Insight>> {
+            Ok(None)
+        }
+        fn name(&self) -> &str {
+            "SlowStubReasoner"
+        }
+    }
+
+    #[cfg(feature = "embeddings")]
+    #[tokio::test]
+    async fn wait_for_enrichment_blocks_until_enriched() {
+        let config = MemoryConfig {
+            enrichment_mode: memory::enrichment::EnrichmentMode::Background,
+            store_extracted_facts: true,
+            enable_knowledge_graph: true,
+            ..Default::default()
+        };
+        let mut mem = AgentMemory::new(config).await.unwrap();
+        mem.set_reasoner_for_test(std::sync::Arc::new(SlowStubReasoner {
+            facts: vec!["Alice lives in Berlin".to_string()],
+        }))
+        .await;
+        mem.store("turn1", "Alice: Berlin").await.unwrap();
+        mem.wait_for_enrichment().await;
+        // Must be true immediately after wait_for_enrichment returns, not
+        // merely "eventually" -- proving the wait covered enrichment, not
+        // just the queue drain.
         assert!(mem.get_entry_for_test("turn1::fact0").await.is_some());
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,10 @@ use uuid::Uuid;
 /// Main memory system for AI agents
 pub struct AgentMemory {
     _config: MemoryConfig,
-    state: memory::state::AgentState,
+    /// Immutable session identifier, cached so `session_id()` stays sync
+    /// (the value equals the id passed to `AgentState::new`).
+    session_id: Uuid,
+    state: std::sync::Arc<tokio::sync::RwLock<memory::state::AgentState>>,
     storage: std::sync::Arc<dyn memory::storage::Storage + Send + Sync>,
     checkpoint_manager: memory::checkpoint::CheckpointManager,
     /// Knowledge graph shared with the retrieval pipeline's `GraphRetriever`
@@ -217,7 +220,8 @@ impl AgentMemory {
             config.checkpoint_interval
         );
 
-        let state = memory::state::AgentState::new(config.session_id.unwrap_or_else(Uuid::new_v4));
+        let session_id = config.session_id.unwrap_or_else(Uuid::new_v4);
+        let state = memory::state::AgentState::new(session_id);
         tracing::debug!("Agent state initialized");
 
         // Initialize knowledge graph if enabled
@@ -508,7 +512,8 @@ impl AgentMemory {
         // Build base agent without multimodal memory initialized
         let agent = Self {
             _config: config.clone(),
-            state,
+            session_id,
+            state: std::sync::Arc::new(tokio::sync::RwLock::new(state)),
             storage,
             checkpoint_manager,
             knowledge_graph,
@@ -639,7 +644,7 @@ impl AgentMemory {
         let entry = MemoryEntry::new(key.to_string(), value.to_string(), MemoryType::ShortTerm);
 
         // Check if this is an update to existing memory
-        let is_update = self.state.has_memory(key);
+        let is_update = self.state.read().await.has_memory(key);
         let change_type = if is_update {
             memory::temporal::ChangeType::Updated
         } else {
@@ -649,7 +654,7 @@ impl AgentMemory {
         tracing::debug!("Memory operation type: {:?}", change_type);
 
         self.storage.store(&entry).await?;
-        self.state.add_memory(entry.clone());
+        self.state.write().await.add_memory(entry.clone());
         tracing::debug!("Memory stored in state and storage");
 
         // Track accumulation for triggered reflection.
@@ -769,11 +774,13 @@ impl AgentMemory {
         }
 
         // Check if we need to create a checkpoint
-        if self.checkpoint_manager.should_checkpoint(&self.state) {
+        let state_guard = self.state.read().await;
+        if self.checkpoint_manager.should_checkpoint(&state_guard) {
             self.checkpoint_manager
-                .create_checkpoint(&self.state)
+                .create_checkpoint(&state_guard)
                 .await?;
         }
+        drop(state_guard);
 
         Ok(degradations)
     }
@@ -847,8 +854,8 @@ impl AgentMemory {
                 .custom_fields
                 .insert(Self::RAW_SOURCE_FIELD.to_string(), Utc::now().to_rfc3339());
             self.storage.store(&entry).await?;
-            if self.state.has_memory(key) {
-                self.state.add_memory(entry);
+            if self.state.read().await.has_memory(key) {
+                self.state.write().await.add_memory(entry);
             }
         }
         Ok(())
@@ -869,8 +876,8 @@ impl AgentMemory {
             self.storage.store(&entry).await?;
             // Keep in-memory state consistent (best-effort; state is the search
             // corpus for the non-pipeline path).
-            if self.state.has_memory(key) {
-                self.state.add_memory(entry);
+            if self.state.read().await.has_memory(key) {
+                self.state.write().await.add_memory(entry);
             }
         }
         Ok(())
@@ -1112,8 +1119,11 @@ impl AgentMemory {
         let mut entries: Vec<MemoryEntry> = Vec::with_capacity(pending.len());
         for key in &pending {
             // A pending memory may have been deleted since it was stored;
-            // reflection simply skips it.
-            if let Some(entry) = self.state.get_memory(key) {
+            // reflection simply skips it. Bind by value first so the write
+            // guard drops before the body (avoids holding it across the loop
+            // body / any future state access).
+            let maybe_entry = self.state.write().await.get_memory(key);
+            if let Some(entry) = maybe_entry {
                 entries.push(entry);
             }
         }
@@ -1161,7 +1171,7 @@ impl AgentMemory {
             .with_metadata(metadata);
 
         self.storage.store(&entry).await?;
-        self.state.add_memory(entry.clone());
+        self.state.write().await.add_memory(entry.clone());
 
         if let Some(ref kg) = self.knowledge_graph {
             let mut kg = kg.write().await;
@@ -1188,12 +1198,12 @@ impl AgentMemory {
     /// All insight memories produced by reflection (custom field
     /// `memory_source == "reflection"`), sorted by key for determinism.
     #[cfg(feature = "embeddings")]
-    pub fn insight_memories(&self) -> Vec<MemoryEntry> {
-        let mut insights: Vec<MemoryEntry> = self
-            .state
+    pub async fn insight_memories(&self) -> Vec<MemoryEntry> {
+        let state_guard = self.state.read().await;
+        let mut insights: Vec<MemoryEntry> = state_guard
             .get_short_term_memories()
             .values()
-            .chain(self.state.get_long_term_memories().values())
+            .chain(state_guard.get_long_term_memories().values())
             .filter(|e| {
                 e.metadata
                     .get_custom_field("memory_source")
@@ -1241,8 +1251,13 @@ impl AgentMemory {
         // Validate input
         validate_non_empty_string(key, "memory key")?;
 
-        // First check short-term memory
-        if let Some(mut entry) = self.state.get_memory(key) {
+        // First check short-term memory. Bind by value BEFORE the `if let`:
+        // an `if let ... = scrutinee` extends the scrutinee temporary (the
+        // write guard) across the ENTIRE body, and the body reacquires
+        // `self.state.write()` on the promotion path — holding both would
+        // deadlock (tokio RwLock is not reentrant).
+        let maybe_entry = self.state.write().await.get_memory(key);
+        if let Some(mut entry) = maybe_entry {
             tracing::debug!("Memory found in short-term memory");
 
             // Check if memory should be promoted to long-term
@@ -1256,7 +1271,7 @@ impl AgentMemory {
                     );
                     entry = pm.promote_memory(entry)?;
                     // Update in state and storage
-                    self.state.add_memory(entry.clone());
+                    self.state.write().await.add_memory(entry.clone());
                     self.storage.store(&entry).await?;
                 }
             }
@@ -1307,7 +1322,7 @@ impl AgentMemory {
             }
 
             // Add to state for future fast access
-            self.state.add_memory(entry.clone());
+            self.state.write().await.add_memory(entry.clone());
 
             // Refresh knowledge graph if enabled
             if let Some(ref kg) = self.knowledge_graph {
@@ -1375,6 +1390,8 @@ impl AgentMemory {
             // metadata (retrievals bump the state entry, not storage).
             let entry = self
                 .state
+                .read()
+                .await
                 .peek_memory(&stored.key)
                 .cloned()
                 .unwrap_or(stored);
@@ -1393,12 +1410,12 @@ impl AgentMemory {
                         "Forgetting pass demoting memory to short-term tier"
                     );
                     self.storage.store(&demoted).await?;
-                    if self.state.peek_memory(&demoted.key).is_some() {
+                    if self.state.read().await.peek_memory(&demoted.key).is_some() {
                         // Preserve real access metadata: relocating between
                         // tiers is not an access, so do not bump
                         // last_accessed/access_count (which would grant
                         // artificial recency protection on later passes).
-                        self.state.insert_preserving_access(demoted.clone());
+                        self.state.write().await.insert_preserving_access(demoted.clone());
                     }
                     report.demoted.push(demoted.key);
                 }
@@ -1408,7 +1425,7 @@ impl AgentMemory {
                         retained_strength = strength,
                         "Forgetting pass evicting memory at lowest tier"
                     );
-                    self.state.remove_memory(&entry.key);
+                    self.state.write().await.remove_memory(&entry.key);
                     self.storage.delete(&entry.key).await?;
                     report.evicted.push(entry.key);
                 }
@@ -1468,7 +1485,8 @@ impl AgentMemory {
 
     /// Create a checkpoint of the current state
     pub async fn checkpoint(&self) -> Result<Uuid> {
-        self.checkpoint_manager.create_checkpoint(&self.state).await
+        let state_guard = self.state.read().await;
+        self.checkpoint_manager.create_checkpoint(&state_guard).await
     }
 
     /// Restore from a checkpoint
@@ -1526,7 +1544,7 @@ impl AgentMemory {
 
         // Step 3: only now that storage matches the checkpoint exactly,
         // swap the in-process state cache.
-        self.state = restored_state;
+        *self.state.write().await = restored_state;
 
         Ok(())
     }
@@ -1534,22 +1552,23 @@ impl AgentMemory {
     /// Get current memory statistics
     /// Get the session ID for this agent memory instance
     pub fn session_id(&self) -> Uuid {
-        self.state.session_id()
+        self.session_id
     }
 
-    pub fn stats(&self) -> MemoryStats {
+    pub async fn stats(&self) -> MemoryStats {
+        let state_guard = self.state.read().await;
         MemoryStats {
-            short_term_count: self.state.short_term_memory_count(),
-            long_term_count: self.state.long_term_memory_count(),
-            total_size: self.state.total_memory_size(),
-            session_id: self.state.session_id(),
-            created_at: self.state.created_at(),
+            short_term_count: state_guard.short_term_memory_count(),
+            long_term_count: state_guard.long_term_memory_count(),
+            total_size: state_guard.total_memory_size(),
+            session_id: state_guard.session_id(),
+            created_at: state_guard.created_at(),
         }
     }
 
     /// Clear all memories (use with caution)
     pub async fn clear(&mut self) -> Result<()> {
-        self.state.clear();
+        self.state.write().await.clear();
         self.storage.clear().await?;
 
         // Clear knowledge graph if enabled
@@ -1658,8 +1677,8 @@ impl AgentMemory {
     }
 
     /// Check if a memory exists
-    pub fn has_memory(&self, key: &str) -> bool {
-        self.state.has_memory(key)
+    pub async fn has_memory(&self, key: &str) -> bool {
+        self.state.read().await.has_memory(key)
     }
 
     /// Semantic search using embeddings (if enabled)
@@ -2442,5 +2461,42 @@ mod tests {
         let config = MemoryConfig::default();
         assert!(!config.enable_cross_platform);
         assert!(config.cross_platform_config.is_none());
+    }
+
+    /// Regression test for the `retrieve()` promotion-on-retrieve deadlock.
+    ///
+    /// `retrieve()` previously took `self.state.write().await.get_memory(key)`
+    /// as an `if let` scrutinee, which keeps the write guard alive across the
+    /// whole body. When promotion fired (`should_promote` true), the body then
+    /// took a SECOND `self.state.write().await` to re-insert the promoted
+    /// entry — `tokio::sync::RwLock` is not reentrant, so this deadlocked.
+    ///
+    /// This config uses the Importance policy with threshold 0.0 so promotion
+    /// fires for any freshly stored short-term entry. On the buggy code this
+    /// test HANGS; with the guard bound-and-dropped before the `if let`, it
+    /// returns. A wall-clock timeout guards against a regression re-hanging the
+    /// suite instead of failing it.
+    #[tokio::test]
+    async fn retrieve_with_promotion_does_not_deadlock() {
+        let config = MemoryConfig {
+            enable_memory_promotion: true,
+            promotion_config: Some(memory::promotion::PromotionConfig {
+                policy_type: memory::promotion::PromotionPolicyType::Importance,
+                importance_threshold: 0.0,
+                ..memory::promotion::PromotionConfig::default()
+            }),
+            ..MemoryConfig::default()
+        };
+        let mut mem = AgentMemory::new(config).await.unwrap();
+        mem.store("promo_k", "value to promote").await.unwrap();
+
+        let got = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            mem.retrieve("promo_k"),
+        )
+        .await
+        .expect("retrieve() must not deadlock on the promotion path")
+        .unwrap();
+        assert!(got.is_some(), "retrieved promoted memory must be present");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -615,7 +615,8 @@ impl AgentMemory {
         // moved into `agent` below; it operates purely on shared `Arc`
         // handles, so it can run independently of the `AgentMemory` value.
         #[cfg(feature = "embeddings")]
-        let enrichment_worker = if config.enrichment_mode == memory::enrichment::EnrichmentMode::Background
+        let enrichment_worker = if config.enrichment_mode
+            == memory::enrichment::EnrichmentMode::Background
             && knowledge_graph.is_some()
         {
             let queue = enrichment_queue.clone();
@@ -1598,7 +1599,10 @@ impl AgentMemory {
                         // tiers is not an access, so do not bump
                         // last_accessed/access_count (which would grant
                         // artificial recency protection on later passes).
-                        self.state.write().await.insert_preserving_access(demoted.clone());
+                        self.state
+                            .write()
+                            .await
+                            .insert_preserving_access(demoted.clone());
                     }
                     report.demoted.push(demoted.key);
                 }
@@ -1669,7 +1673,9 @@ impl AgentMemory {
     /// Create a checkpoint of the current state
     pub async fn checkpoint(&self) -> Result<Uuid> {
         let state_guard = self.state.read().await;
-        self.checkpoint_manager.create_checkpoint(&state_guard).await
+        self.checkpoint_manager
+            .create_checkpoint(&state_guard)
+            .await
     }
 
     /// Restore from a checkpoint
@@ -2200,8 +2206,11 @@ mod tests {
         mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
             facts: vec!["Alice lives in Berlin".to_string()],
             fail: false,
-        })).await;
-        mem.store("turn1", "Alice: I moved to Berlin").await.unwrap();
+        }))
+        .await;
+        mem.store("turn1", "Alice: I moved to Berlin")
+            .await
+            .unwrap();
         // Deferred: no fact-memory yet (enrichment not run), raw is present.
         assert!(mem.get_entry_for_test("turn1").await.is_some());
         assert!(mem.get_entry_for_test("turn1::fact0").await.is_none());
@@ -2221,8 +2230,11 @@ mod tests {
         mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
             facts: vec!["Alice lives in Berlin".to_string()],
             fail: false,
-        })).await;
-        mem.store("turn1", "Alice: I moved to Berlin").await.unwrap();
+        }))
+        .await;
+        mem.store("turn1", "Alice: I moved to Berlin")
+            .await
+            .unwrap();
         assert!(mem.get_entry_for_test("turn1::fact0").await.is_none());
         let report = mem.enrich_pending().await;
         assert_eq!(report.entries, 1);
@@ -2267,7 +2279,8 @@ mod tests {
         mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
             facts: vec![],
             fail: true,
-        })).await;
+        }))
+        .await;
         mem.store("turn1", "Alice: Berlin").await.unwrap();
         let report = mem.enrich_pending().await;
         assert_eq!(report.entries, 1);
@@ -2288,7 +2301,8 @@ mod tests {
         mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
             facts: vec!["Alice lives in Berlin".to_string()],
             fail: false,
-        })).await;
+        }))
+        .await;
         mem.store("turn1", "Alice: I moved to Berlin last year")
             .await
             .unwrap();
@@ -2312,7 +2326,8 @@ mod tests {
         mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
             facts: vec![],
             fail: true,
-        })).await;
+        }))
+        .await;
         // Write still succeeds (best-effort); raw turn stays searchable/untagged.
         mem.store("turn1", "Alice: I moved to Berlin")
             .await
@@ -2482,7 +2497,8 @@ mod tests {
         mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
             facts: vec!["Alice lives in Berlin".to_string()],
             fail: false,
-        })).await;
+        }))
+        .await;
         mem.store("turn1", "Alice: I moved to Berlin last year")
             .await
             .unwrap();
@@ -2512,7 +2528,8 @@ mod tests {
         mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
             facts: vec!["Alice lives in Berlin".to_string()],
             fail: false,
-        })).await;
+        }))
+        .await;
         mem.store("turn1", "Alice: I moved to Berlin last year")
             .await
             .unwrap();
@@ -2780,13 +2797,10 @@ mod tests {
         let mut mem = AgentMemory::new(config).await.unwrap();
         mem.store("promo_k", "value to promote").await.unwrap();
 
-        let got = tokio::time::timeout(
-            std::time::Duration::from_secs(10),
-            mem.retrieve("promo_k"),
-        )
-        .await
-        .expect("retrieve() must not deadlock on the promotion path")
-        .unwrap();
+        let got = tokio::time::timeout(std::time::Duration::from_secs(10), mem.retrieve("promo_k"))
+            .await
+            .expect("retrieve() must not deadlock on the promotion path")
+            .unwrap();
         assert!(got.is_some(), "retrieved promoted memory must be present");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,12 @@ pub struct AgentMemory {
     /// candidate cap regardless of store size.
     #[cfg(all(feature = "embeddings", feature = "test-utils"))]
     neighbor_examined_max: std::sync::atomic::AtomicUsize,
+    /// Entries awaiting enrichment when `MemoryConfig::enrichment_mode` is
+    /// `Deferred` or `Background` (see `memory::enrichment`).
+    #[cfg(feature = "embeddings")]
+    enrichment_queue: std::sync::Arc<
+        tokio::sync::Mutex<std::collections::VecDeque<memory::enrichment::PendingEnrichment>>,
+    >,
 }
 
 impl AgentMemory {
@@ -189,6 +195,11 @@ impl AgentMemory {
     #[cfg(all(feature = "embeddings", test))]
     async fn get_entry_for_test(&self, key: &str) -> Option<MemoryEntry> {
         self.storage.retrieve(key).await.ok().flatten()
+    }
+
+    #[cfg(all(feature = "embeddings", test))]
+    async fn enrichment_queue_len(&self) -> usize {
+        self.enrichment_queue.lock().await.len()
     }
 
     /// Create a new agent memory system with the given configuration
@@ -551,6 +562,10 @@ impl AgentMemory {
             retrieval_tfidf_stats,
             #[cfg(all(feature = "embeddings", feature = "test-utils"))]
             neighbor_examined_max: std::sync::atomic::AtomicUsize::new(0),
+            #[cfg(feature = "embeddings")]
+            enrichment_queue: std::sync::Arc::new(tokio::sync::Mutex::new(
+                std::collections::VecDeque::new(),
+            )),
         };
 
         // Initialize multimodal memory after creating base agent to avoid circular dependency
@@ -767,9 +782,28 @@ impl AgentMemory {
         // extraction does not recurse.
         #[cfg(feature = "embeddings")]
         if self.knowledge_graph.is_some() && !self.storing_facts {
-            if let Err(e) = self.reason_over_store(&entry).await {
-                tracing::warn!(error = %e, "reasoning degraded during store");
-                degradations.reasoning = Some(e.to_string());
+            match self._config.enrichment_mode {
+                memory::enrichment::EnrichmentMode::Inline => {
+                    if let Err(e) = self.reason_over_store(&entry).await {
+                        tracing::warn!(error = %e, "reasoning degraded during store");
+                        degradations.reasoning = Some(e.to_string());
+                    }
+                }
+                memory::enrichment::EnrichmentMode::Deferred
+                | memory::enrichment::EnrichmentMode::Background => {
+                    // Never enqueue a fact-memory (re-entrancy guard already
+                    // ensures fact stores set storing_facts, so we never reach
+                    // here for them; the key check is belt-and-braces).
+                    if !key.contains("::fact") {
+                        self.enrichment_queue.lock().await.push_back(
+                            memory::enrichment::PendingEnrichment {
+                                key: key.to_string(),
+                                value: value.to_string(),
+                            },
+                        );
+                        // Background notification wired in Task 5.
+                    }
+                }
             }
         }
 
@@ -1851,6 +1885,12 @@ pub struct MemoryConfig {
     /// augment recovered baseline accuracy (0.505 → 0.258 facts-primary vs 0.500
     /// augment). Only has an effect when distillation is live.
     pub retrieval_excludes_raw_sources: bool,
+    /// How write-path LLM enrichment is scheduled (see
+    /// [`memory::enrichment::EnrichmentMode`]). Default `Inline` (enrich
+    /// synchronously inside `store`), byte-for-byte today's behavior.
+    pub enrichment_mode: memory::enrichment::EnrichmentMode,
+    /// Bounded concurrency for `enrich_pending`/background enrichment. Default 8.
+    pub enrichment_concurrency: usize,
 }
 
 impl Default for MemoryConfig {
@@ -1911,6 +1951,8 @@ impl Default for MemoryConfig {
             // facts alongside raw turns rather than excluding raw from search.
             // The A/B showed exclusion is what hurt QA; augment ties baseline.
             retrieval_excludes_raw_sources: false,
+            enrichment_mode: memory::enrichment::EnrichmentMode::Inline,
+            enrichment_concurrency: 8,
         }
     }
 }
@@ -1984,6 +2026,37 @@ mod tests {
         fn name(&self) -> &str {
             "StubReasoner"
         }
+    }
+
+    #[tokio::test]
+    async fn enrichment_defaults_to_inline() {
+        let config = MemoryConfig::default();
+        assert_eq!(
+            config.enrichment_mode,
+            memory::enrichment::EnrichmentMode::Inline
+        );
+        assert_eq!(config.enrichment_concurrency, 8);
+    }
+
+    #[cfg(feature = "embeddings")]
+    #[tokio::test]
+    async fn deferred_mode_queues_without_inline_enrich() {
+        let config = MemoryConfig {
+            enrichment_mode: memory::enrichment::EnrichmentMode::Deferred,
+            store_extracted_facts: true,
+            enable_knowledge_graph: true,
+            ..Default::default()
+        };
+        let mut mem = AgentMemory::new(config).await.unwrap();
+        mem.set_reasoner_for_test(std::sync::Arc::new(StubReasoner {
+            facts: vec!["Alice lives in Berlin".to_string()],
+            fail: false,
+        }));
+        mem.store("turn1", "Alice: I moved to Berlin").await.unwrap();
+        // Deferred: no fact-memory yet (enrichment not run), raw is present.
+        assert!(mem.get_entry_for_test("turn1").await.is_some());
+        assert!(mem.get_entry_for_test("turn1::fact0").await.is_none());
+        assert_eq!(mem.enrichment_queue_len().await, 1);
     }
 
     #[cfg(feature = "embeddings")]

--- a/src/memory/enrichment.rs
+++ b/src/memory/enrichment.rs
@@ -56,9 +56,6 @@ mod enrich_one_engine {
         /// Mirrors `AgentMemory.distillation_live`: whether extracted facts
         /// are persisted as their own retrievable memories.
         pub distillation_live: bool,
-        /// Reserved for a future step (raw-source exclusion default);
-        /// unused by `enrich_one` itself today.
-        pub exclude_raw_default: bool,
     }
 
     /// Summary of what `enrich_one` did for a single entry.
@@ -143,6 +140,13 @@ mod enrich_one_engine {
     /// inline enrichment path: raw storage + state, plus a best-effort
     /// scoring-provider embed so the fact stays pipeline-retrievable (this
     /// mirrors what `AgentMemory::store_with_report` does for every entry).
+    ///
+    /// Deferred/Background fact-memories are written to storage + state and
+    /// the scoring corpus (so they are retrievable via storage/dense/sparse
+    /// search and are checkpointable), but -- unlike the Inline path -- do
+    /// NOT get a knowledge-graph memory node, temporal tracking, or
+    /// analytics events. Graph-based retrieval over deferred facts therefore
+    /// differs from Inline.
     async fn store_fact_shared(
         storage: &Arc<dyn Storage + Send + Sync>,
         state: &Arc<RwLock<AgentState>>,
@@ -328,6 +332,7 @@ mod enrich_one_engine {
     }
 
     #[cfg(test)]
+    #[allow(clippy::unwrap_used)]
     mod tests {
         use super::*;
         use crate::memory::knowledge_graph::GraphConfig;
@@ -389,7 +394,6 @@ mod enrich_one_engine {
 
             let params = EnrichmentParams {
                 distillation_live: true,
-                exclude_raw_default: false,
             };
 
             let outcome = enrich_one(
@@ -442,6 +446,7 @@ pub struct EnrichmentReport {
 /// `AgentMemory::enrich_pending` (Deferred mode, explicit call) and the
 /// Background worker loop (continuous drain on notify).
 #[cfg(feature = "embeddings")]
+#[allow(clippy::too_many_arguments)]
 pub async fn drain_and_enrich(
     queue: &std::sync::Arc<tokio::sync::Mutex<std::collections::VecDeque<PendingEnrichment>>>,
     storage: &std::sync::Arc<dyn crate::memory::storage::Storage + Send + Sync>,
@@ -451,6 +456,7 @@ pub async fn drain_and_enrich(
     scoring: &Option<std::sync::Arc<dyn crate::memory::embeddings::provider::EmbeddingProvider>>,
     params: EnrichmentParams,
     concurrency: usize,
+    inflight: &std::sync::Arc<std::sync::atomic::AtomicUsize>,
 ) -> EnrichmentReport {
     use futures::stream::{self, StreamExt};
 
@@ -461,22 +467,31 @@ pub async fn drain_and_enrich(
     if pending.is_empty() {
         return EnrichmentReport::default();
     }
+    // Count the whole batch as in-flight up front: the queue is emptied
+    // above before any entry has actually finished enriching, so callers
+    // like `wait_for_enrichment` that only poll the queue would otherwise
+    // see "empty" while enrichment is still running. Each task decrements
+    // its own entry once `enrich_one` returns (success or error).
+    inflight.fetch_add(pending.len(), std::sync::atomic::Ordering::SeqCst);
     let concurrency = concurrency.max(1);
     let outcomes = stream::iter(pending)
         .map(|p| {
-            let (storage, kg, state, reasoner, scoring, params) = (
+            let (storage, kg, state, reasoner, scoring, params, inflight) = (
                 storage.clone(),
                 kg.clone(),
                 state.clone(),
                 reasoner.clone(),
                 scoring.clone(),
                 params,
+                inflight.clone(),
             );
             async move {
-                enrich_one(
+                let result = enrich_one(
                     &storage, &kg, &state, &reasoner, &scoring, params, &p.key, &p.value,
                 )
-                .await
+                .await;
+                inflight.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+                result
             }
         })
         .buffer_unordered(concurrency)

--- a/src/memory/enrichment.rs
+++ b/src/memory/enrichment.rs
@@ -1,0 +1,22 @@
+//! Async/deferred write-path enrichment: the raw store is fast; the slow LLM
+//! enrichment (extract -> resolve -> supersede -> fact-store) runs later,
+//! concurrently, on shared handles. See docs/superpowers/specs/2026-07-22-*.
+
+/// How write-path LLM enrichment is scheduled relative to `store()`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EnrichmentMode {
+    /// Enrich synchronously inside `store()` (today's behavior). Default.
+    #[default]
+    Inline,
+    /// `store()` enqueues; enrichment runs on an explicit `enrich_pending()`.
+    Deferred,
+    /// `store()` enqueues + notifies a background worker that drains continuously.
+    Background,
+}
+
+/// One entry awaiting enrichment (queued by `store()` in Deferred/Background).
+#[derive(Debug, Clone)]
+pub struct PendingEnrichment {
+    pub key: String,
+    pub value: String,
+}

--- a/src/memory/enrichment.rs
+++ b/src/memory/enrichment.rs
@@ -424,3 +424,13 @@ mod enrich_one_engine {
 
 #[cfg(feature = "embeddings")]
 pub use enrich_one_engine::{enrich_one, EnrichmentOutcome, EnrichmentParams};
+
+/// Summary of a batch drain-and-enrich run (`AgentMemory::enrich_pending`).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct EnrichmentReport {
+    pub entries: usize,
+    pub facts_stored: usize,
+    pub supersessions: usize,
+    pub raw_sources_tagged: usize,
+    pub errors: usize,
+}

--- a/src/memory/enrichment.rs
+++ b/src/memory/enrichment.rs
@@ -20,3 +20,407 @@ pub struct PendingEnrichment {
     pub key: String,
     pub value: String,
 }
+
+// --- `enrich_one` engine: the write-path enrichment logic (extract ->
+// resolve -> supersede -> fact-store -> tag raw), lifted from the `&mut
+// self` methods in `src/lib.rs` onto shared `Arc` handles so later tasks can
+// run it concurrently (Deferred/Background modes) instead of inline in
+// `store()`. See docs/superpowers/specs/2026-07-22-*.
+
+#[cfg(feature = "embeddings")]
+mod enrich_one_engine {
+    use crate::error::Result;
+    use crate::memory::embeddings::provider::EmbeddingProvider;
+    use crate::memory::knowledge_graph::MemoryKnowledgeGraph;
+    use crate::memory::reasoning::{ConflictResolution, Fact, MemoryReasoner, NeighborFact};
+    use crate::memory::state::AgentState;
+    use crate::memory::storage::Storage;
+    use crate::memory::types::{MemoryEntry, MemoryType};
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    /// Custom-field key recording when a memory was bi-temporally superseded.
+    /// Mirrors `AgentMemory::SUPERSEDED_FIELD`.
+    const SUPERSEDED_FIELD: &str = "superseded_at";
+    /// Custom-field key recording when a raw turn was summarized by
+    /// distillation. Mirrors `AgentMemory::RAW_SOURCE_FIELD`.
+    const RAW_SOURCE_FIELD: &str = "raw_source";
+    /// Upper bound on the keyword-hit candidates `neighbor_facts_shared`
+    /// pulls per search. Mirrors `AgentMemory::NEIGHBOR_CANDIDATE_LIMIT`.
+    const NEIGHBOR_CANDIDATE_LIMIT: usize = 20;
+
+    /// Per-entry enrichment knobs, mirroring the relevant fields of
+    /// `AgentMemory`/`MemoryConfig` that `enrich_one` needs.
+    #[derive(Debug, Clone, Copy)]
+    pub struct EnrichmentParams {
+        /// Mirrors `AgentMemory.distillation_live`: whether extracted facts
+        /// are persisted as their own retrievable memories.
+        pub distillation_live: bool,
+        /// Reserved for a future step (raw-source exclusion default);
+        /// unused by `enrich_one` itself today.
+        pub exclude_raw_default: bool,
+    }
+
+    /// Summary of what `enrich_one` did for a single entry.
+    #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+    pub struct EnrichmentOutcome {
+        pub facts_stored: usize,
+        pub supersessions: usize,
+        pub raw_tagged: bool,
+    }
+
+    /// Run the reasoner over a freshly stored entry `(key, value)`: extract
+    /// facts, resolve each against the most similar existing memories, apply
+    /// the resolution to the knowledge graph, optionally persist each fact as
+    /// its own retrievable memory, and tag the raw turn as summarized once
+    /// at least one fact was stored.
+    ///
+    /// Mirrors `AgentMemory::reason_over_store` exactly, but operates on
+    /// shared `Arc` handles instead of `&mut self` so it can run outside the
+    /// inline write path (Deferred/Background enrichment).
+    pub async fn enrich_one(
+        storage: &Arc<dyn Storage + Send + Sync>,
+        kg: &Arc<RwLock<MemoryKnowledgeGraph>>,
+        state: &Arc<RwLock<AgentState>>,
+        reasoner: &Arc<dyn MemoryReasoner>,
+        scoring: &Option<Arc<dyn EmbeddingProvider>>,
+        params: EnrichmentParams,
+        key: &str,
+        value: &str,
+    ) -> Result<EnrichmentOutcome> {
+        let ctx = crate::memory::reasoning::ExtractionContext {
+            source_key: key.to_string(),
+            timestamp: chrono::Utc::now(),
+        };
+        let extraction = reasoner.extract(value, &ctx).await?;
+        let mut outcome = EnrichmentOutcome::default();
+        // Empty extraction: default behavior stays identical (no KG change
+        // beyond what the earlier subsystems already applied).
+        if extraction.facts.is_empty() {
+            return Ok(outcome);
+        }
+        let mut stored_any_fact = false;
+        for (i, fact) in extraction.facts.iter().enumerate() {
+            let neighbors = neighbor_facts_shared(storage, key, fact, 5).await?;
+            let resolution = reasoner.resolve(fact, &neighbors).await?;
+            // The reasoner picks its target among the neighbors we supplied;
+            // for id-less outcomes (UpdateInPlace/Append) the target is the
+            // best neighbor by the same deterministic ordering.
+            let best_neighbor_id = neighbors.first().map(|n| n.id.clone());
+            let superseded =
+                apply_resolution_shared(kg, key, fact, resolution, best_neighbor_id).await?;
+            // Mark the superseded memory itself (not just its KG edges) so
+            // bi-temporal validity is visible to retrieval.
+            if let Some(old_key) = superseded {
+                mark_field_shared(storage, state, &old_key, SUPERSEDED_FIELD).await?;
+                outcome.supersessions += 1;
+            }
+
+            // Persist the extracted fact as its own retrievable memory so
+            // search surfaces distilled facts, not just raw turns.
+            if params.distillation_live && !fact.text.trim().is_empty() {
+                let fact_key = format!("{key}::fact{i}");
+                store_fact_shared(storage, state, scoring, &fact_key, &fact.text).await?;
+                stored_any_fact = true;
+                outcome.facts_stored += 1;
+            }
+        }
+        // Failure-ordering invariant: tag the raw turn as a summarized source
+        // ONLY after >=1 fact has been stored. If extraction or fact storage
+        // failed above (propagated via `?`), we never reach here, so the raw
+        // turn stays untagged and searchable -- a distillation outage
+        // degrades to raw-turn retrieval rather than hiding a turn with no
+        // replacement.
+        if stored_any_fact {
+            mark_field_shared(storage, state, key, RAW_SOURCE_FIELD).await?;
+            outcome.raw_tagged = true;
+        }
+        Ok(outcome)
+    }
+
+    /// Store an extracted fact directly (not via a recursive
+    /// `store_with_report`) so `enrich_one` never recurses through the
+    /// inline enrichment path: raw storage + state, plus a best-effort
+    /// scoring-provider embed so the fact stays pipeline-retrievable (this
+    /// mirrors what `AgentMemory::store_with_report` does for every entry).
+    async fn store_fact_shared(
+        storage: &Arc<dyn Storage + Send + Sync>,
+        state: &Arc<RwLock<AgentState>>,
+        scoring: &Option<Arc<dyn EmbeddingProvider>>,
+        fact_key: &str,
+        fact_text: &str,
+    ) -> Result<()> {
+        let entry = MemoryEntry::new(
+            fact_key.to_string(),
+            fact_text.to_string(),
+            MemoryType::LongTerm,
+        );
+        storage.store(&entry).await?;
+        state.write().await.add_memory(entry.clone());
+        if let Some(provider) = scoring {
+            // Keep the retrieval scoring corpus live so the pipeline can
+            // rank the fact; best-effort like the inline write path.
+            let _ = provider.embed(fact_text, None).await;
+        }
+        Ok(())
+    }
+
+    /// Tag `key`'s stored entry with `field` = now (RFC3339), re-persist it,
+    /// and keep in-memory state consistent if the key is tracked there.
+    /// Mirrors `AgentMemory::mark_superseded`/`mark_raw_source`.
+    async fn mark_field_shared(
+        storage: &Arc<dyn Storage + Send + Sync>,
+        state: &Arc<RwLock<AgentState>>,
+        key: &str,
+        field: &str,
+    ) -> Result<()> {
+        if let Some(mut entry) = storage.retrieve(key).await? {
+            entry
+                .metadata
+                .custom_fields
+                .insert(field.to_string(), chrono::Utc::now().to_rfc3339());
+            storage.store(&entry).await?;
+            if state.read().await.has_memory(key) {
+                state.write().await.add_memory(entry);
+            }
+        }
+        Ok(())
+    }
+
+    /// Build the top-`k` neighbor list for a candidate `fact`, excluding the
+    /// entry being stored. Ported verbatim from `AgentMemory::neighbor_facts`
+    /// (candidate source, ranking, and tie-breaking are unchanged).
+    async fn neighbor_facts_shared(
+        storage: &Arc<dyn Storage + Send + Sync>,
+        current_key: &str,
+        fact: &Fact,
+        k: usize,
+    ) -> Result<Vec<NeighborFact>> {
+        fn tokens(text: &str) -> std::collections::HashSet<String> {
+            text.to_lowercase()
+                .split(|c: char| !c.is_alphanumeric())
+                .filter(|w| !w.is_empty())
+                .map(str::to_string)
+                .collect()
+        }
+        let candidate_tokens = tokens(&fact.text);
+        if candidate_tokens.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // (a) Build a keyword query from distinctive (>=3 char) tokens so a
+        // handful of long, discriminating terms outrank many short stopword
+        // matches. Fall back to the raw text if nothing survives the filter.
+        let distinctive: Vec<&str> = fact
+            .text
+            .split(|c: char| !c.is_alphanumeric())
+            .filter(|w| w.chars().count() >= 3)
+            .collect();
+        let query = if distinctive.is_empty() {
+            fact.text.clone()
+        } else {
+            distinctive.join(" ")
+        };
+
+        // Collect a bounded, deduplicated candidate set: the keyword hits ...
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut candidates: Vec<crate::memory::types::MemoryFragment> = Vec::new();
+        // +1 head-room: the search may return the entry being stored itself.
+        for fragment in storage.search(&query, NEIGHBOR_CANDIDATE_LIMIT + 1).await? {
+            if seen.insert(fragment.entry.key.clone()) {
+                candidates.push(fragment);
+            }
+        }
+        // (b) ... unioned with a targeted lookup per relation subject so a
+        // same-subject memory can never be squeezed out of the candidate set.
+        for relation in &fact.relations {
+            if relation.subject.trim().is_empty() {
+                continue;
+            }
+            for fragment in storage
+                .search(&relation.subject, NEIGHBOR_CANDIDATE_LIMIT + 1)
+                .await?
+            {
+                if seen.insert(fragment.entry.key.clone()) {
+                    candidates.push(fragment);
+                }
+            }
+        }
+
+        let mut neighbors: Vec<NeighborFact> = candidates
+            .iter()
+            .filter(|fragment| fragment.entry.key != current_key)
+            .filter_map(|fragment| {
+                let mem_tokens = tokens(&fragment.entry.value);
+                if mem_tokens.is_empty() {
+                    return None;
+                }
+                let intersection = candidate_tokens.intersection(&mem_tokens).count() as f64;
+                let similarity = intersection
+                    / ((candidate_tokens.len() as f64).sqrt() * (mem_tokens.len() as f64).sqrt());
+                if similarity > 0.0 {
+                    Some(NeighborFact {
+                        id: fragment.entry.key.clone(),
+                        similarity,
+                        text: fragment.entry.value.clone(),
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect();
+        neighbors.sort_by(|a, b| {
+            b.similarity
+                .total_cmp(&a.similarity)
+                .then_with(|| a.id.cmp(&b.id))
+        });
+        neighbors.truncate(k);
+        Ok(neighbors)
+    }
+
+    /// Apply a conflict resolution outcome to the knowledge graph. Ported
+    /// verbatim from `AgentMemory::apply_resolution`. The `kg` write guard is
+    /// held only for the span of this function (the KG mutation itself);
+    /// callers must never hold it across a `reasoner.extract`/`resolve`
+    /// await.
+    async fn apply_resolution_shared(
+        kg: &Arc<RwLock<MemoryKnowledgeGraph>>,
+        entry_key: &str,
+        fact: &Fact,
+        resolution: ConflictResolution,
+        best_neighbor_id: Option<String>,
+    ) -> Result<Option<String>> {
+        let mut superseded_key: Option<String> = None;
+        let mut kg = kg.write().await;
+        match resolution {
+            ConflictResolution::Insert => {
+                kg.add_extracted_fact(entry_key, fact).await?;
+            }
+            ConflictResolution::Supersede { old_id, reason } => {
+                tracing::debug!(old_id = %old_id, reason = %reason, "superseding fact");
+                // Bi-temporally invalidate only the contradicted edges of
+                // the old memory (same subject + predicate as the new fact).
+                kg.supersede_matching_relations(&old_id, fact).await?;
+                kg.add_extracted_fact(entry_key, fact).await?;
+                // `old_id` is the superseded memory's key (see
+                // `neighbor_facts_shared`): report it so the caller can mark
+                // the memory itself superseded, making bi-temporal validity
+                // visible to retrieval.
+                superseded_key = Some(old_id);
+            }
+            ConflictResolution::UpdateInPlace { reason } => {
+                tracing::debug!(reason = %reason, "updating fact in place");
+                if let Some(target) = best_neighbor_id {
+                    kg.update_memory_node_content(&target, &fact.text).await?;
+                }
+            }
+            ConflictResolution::Append { reason } => {
+                tracing::debug!(reason = %reason, "appending to existing fact");
+                if let Some(target) = best_neighbor_id {
+                    kg.append_memory_content(&target, &fact.text).await?;
+                }
+            }
+            ConflictResolution::NoOp { reason } => {
+                tracing::debug!(reason = %reason, "reasoner chose no-op");
+            }
+        }
+        Ok(superseded_key)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::memory::knowledge_graph::GraphConfig;
+        use crate::memory::storage::memory::MemoryStorage;
+
+        #[derive(Clone)]
+        struct StubReasoner;
+
+        #[async_trait::async_trait]
+        impl MemoryReasoner for StubReasoner {
+            async fn extract(
+                &self,
+                _text: &str,
+                _ctx: &crate::memory::reasoning::ExtractionContext,
+            ) -> Result<crate::memory::reasoning::Extraction> {
+                Ok(crate::memory::reasoning::Extraction {
+                    facts: vec![Fact {
+                        text: "Alice lives in Berlin".to_string(),
+                        entities: vec![],
+                        relations: vec![],
+                    }],
+                })
+            }
+            async fn resolve(
+                &self,
+                _candidate: &Fact,
+                _neighbors: &[NeighborFact],
+            ) -> Result<ConflictResolution> {
+                Ok(ConflictResolution::Insert)
+            }
+            async fn synthesize(
+                &self,
+                _cluster: &[MemoryEntry],
+            ) -> Result<Option<crate::memory::reasoning::Insight>> {
+                Ok(None)
+            }
+            fn name(&self) -> &str {
+                "StubReasoner"
+            }
+        }
+
+        #[tokio::test]
+        async fn enrich_one_stores_fact_and_tags_raw() {
+            let storage: Arc<dyn Storage + Send + Sync> = Arc::new(MemoryStorage::new());
+            let kg = Arc::new(RwLock::new(MemoryKnowledgeGraph::new(
+                GraphConfig::default(),
+            )));
+            let state = Arc::new(RwLock::new(AgentState::new(uuid::Uuid::new_v4())));
+            let reasoner: Arc<dyn MemoryReasoner> = Arc::new(StubReasoner);
+            let scoring: Option<Arc<dyn EmbeddingProvider>> = None;
+
+            let raw = MemoryEntry::new(
+                "turn1".to_string(),
+                "Alice: Berlin".to_string(),
+                MemoryType::ShortTerm,
+            );
+            storage.store(&raw).await.unwrap();
+            state.write().await.add_memory(raw.clone());
+
+            let params = EnrichmentParams {
+                distillation_live: true,
+                exclude_raw_default: false,
+            };
+
+            let outcome = enrich_one(
+                &storage,
+                &kg,
+                &state,
+                &reasoner,
+                &scoring,
+                params,
+                "turn1",
+                "Alice: Berlin",
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(outcome.facts_stored, 1);
+            assert!(outcome.raw_tagged);
+            assert_eq!(outcome.supersessions, 0);
+
+            let stored_fact = storage.retrieve("turn1::fact0").await.unwrap();
+            assert!(stored_fact.is_some());
+            assert_eq!(stored_fact.unwrap().value, "Alice lives in Berlin");
+
+            let raw_after = storage.retrieve("turn1").await.unwrap().unwrap();
+            assert!(raw_after
+                .metadata
+                .custom_fields
+                .contains_key(RAW_SOURCE_FIELD));
+        }
+    }
+}
+
+#[cfg(feature = "embeddings")]
+pub use enrich_one_engine::{enrich_one, EnrichmentOutcome, EnrichmentParams};

--- a/src/memory/enrichment.rs
+++ b/src/memory/enrichment.rs
@@ -434,3 +434,70 @@ pub struct EnrichmentReport {
     pub raw_sources_tagged: usize,
     pub errors: usize,
 }
+
+/// Drain the entire pending-enrichment queue and enrich each entry with
+/// bounded concurrency, folding the per-entry outcomes into a single
+/// `EnrichmentReport`. Best-effort: a per-entry failure is counted in the
+/// report, never aborts the batch. Shared core used by both
+/// `AgentMemory::enrich_pending` (Deferred mode, explicit call) and the
+/// Background worker loop (continuous drain on notify).
+#[cfg(feature = "embeddings")]
+pub async fn drain_and_enrich(
+    queue: &std::sync::Arc<tokio::sync::Mutex<std::collections::VecDeque<PendingEnrichment>>>,
+    storage: &std::sync::Arc<dyn crate::memory::storage::Storage + Send + Sync>,
+    kg: &std::sync::Arc<tokio::sync::RwLock<crate::memory::knowledge_graph::MemoryKnowledgeGraph>>,
+    state: &std::sync::Arc<tokio::sync::RwLock<crate::memory::state::AgentState>>,
+    reasoner: &std::sync::Arc<dyn crate::memory::reasoning::MemoryReasoner>,
+    scoring: &Option<std::sync::Arc<dyn crate::memory::embeddings::provider::EmbeddingProvider>>,
+    params: EnrichmentParams,
+    concurrency: usize,
+) -> EnrichmentReport {
+    use futures::stream::{self, StreamExt};
+
+    let pending: Vec<PendingEnrichment> = {
+        let mut q = queue.lock().await;
+        q.drain(..).collect()
+    };
+    if pending.is_empty() {
+        return EnrichmentReport::default();
+    }
+    let concurrency = concurrency.max(1);
+    let outcomes = stream::iter(pending)
+        .map(|p| {
+            let (storage, kg, state, reasoner, scoring, params) = (
+                storage.clone(),
+                kg.clone(),
+                state.clone(),
+                reasoner.clone(),
+                scoring.clone(),
+                params,
+            );
+            async move {
+                enrich_one(
+                    &storage, &kg, &state, &reasoner, &scoring, params, &p.key, &p.value,
+                )
+                .await
+            }
+        })
+        .buffer_unordered(concurrency)
+        .collect::<Vec<_>>()
+        .await;
+    let mut report = EnrichmentReport {
+        entries: outcomes.len(),
+        ..Default::default()
+    };
+    for o in outcomes {
+        match o {
+            Ok(oc) => {
+                report.facts_stored += oc.facts_stored;
+                report.supersessions += oc.supersessions;
+                report.raw_sources_tagged += usize::from(oc.raw_tagged);
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "enrichment degraded for entry");
+                report.errors += 1;
+            }
+        }
+    }
+    report
+}

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -10,6 +10,7 @@
 pub mod checkpoint;
 pub mod consolidation;
 pub mod context;
+pub mod enrichment;
 pub mod forgetting;
 pub mod indexing;
 pub mod knowledge_graph;

--- a/tests/external_integrations_tests.rs
+++ b/tests/external_integrations_tests.rs
@@ -300,7 +300,7 @@ mod external_integration_tests {
         assert!(!search_results.is_empty());
 
         // Test stats
-        let stats = memory.stats();
+        let stats = memory.stats().await;
         assert!(stats.short_term_count > 0);
 
         Ok(())

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -135,7 +135,7 @@ async fn test_memory_statistics() -> Result<()> {
     let mut memory = AgentMemory::new(config).await?;
 
     // Initial stats should be empty
-    let initial_stats = memory.stats();
+    let initial_stats = memory.stats().await;
     assert_eq!(initial_stats.short_term_count, 0);
     assert_eq!(initial_stats.long_term_count, 0);
 
@@ -144,7 +144,7 @@ async fn test_memory_statistics() -> Result<()> {
     memory.store("key2", "value2").await?;
     memory.store("key3", "value3").await?;
 
-    let stats = memory.stats();
+    let stats = memory.stats().await;
     assert_eq!(stats.short_term_count, 3); // Default is short-term
     assert_eq!(stats.long_term_count, 0);
     assert!(stats.total_size > 0);
@@ -173,7 +173,7 @@ async fn test_memory_clearing() -> Result<()> {
     assert!(memory.retrieve("key2").await?.is_none());
 
     // Stats should be reset
-    let stats = memory.stats();
+    let stats = memory.stats().await;
     assert_eq!(stats.short_term_count, 0);
     assert_eq!(stats.long_term_count, 0);
 
@@ -280,7 +280,7 @@ async fn test_memory_types() -> Result<()> {
     // For now, we'll test with the basic store method
     // In a full implementation, we'd have methods to specify memory type
 
-    let stats = memory.stats();
+    let stats = memory.stats().await;
     assert!(stats.short_term_count > 0);
 
     Ok(())

--- a/tests/knowledge_graph_tests.rs
+++ b/tests/knowledge_graph_tests.rs
@@ -47,7 +47,7 @@ async fn test_memory_with_knowledge_graph() -> Result<(), Box<dyn Error>> {
     assert!(!search_results.is_empty());
 
     // Test that knowledge graph is enabled
-    let stats = memory.stats();
+    let stats = memory.stats().await;
     assert!(stats.short_term_count >= 3);
 
     Ok(())
@@ -135,7 +135,7 @@ async fn test_knowledge_graph_with_related_memories() -> Result<(), Box<dyn Erro
     assert!(!ml_search.is_empty());
 
     // Test that knowledge graph is working (basic functionality)
-    let stats = memory.stats();
+    let stats = memory.stats().await;
     assert_eq!(stats.short_term_count, 4);
 
     Ok(())
@@ -162,7 +162,7 @@ async fn test_knowledge_graph_stats() -> Result<(), Box<dyn Error>> {
         .await?;
 
     // Test that stats reflect the stored memories
-    let stats = memory.stats();
+    let stats = memory.stats().await;
     assert_eq!(stats.short_term_count, 3);
     assert!(stats.total_size > 0);
 

--- a/tests/performance_tests.rs
+++ b/tests/performance_tests.rs
@@ -222,7 +222,7 @@ async fn test_memory_usage() -> Result<(), Box<dyn Error>> {
     let mut memory = AgentMemory::new(config).await?;
 
     // Get initial memory stats
-    let initial_stats = memory.stats();
+    let initial_stats = memory.stats().await;
     println!("Initial stats: {:?}", initial_stats);
 
     let num_memories = 1000;
@@ -235,12 +235,12 @@ async fn test_memory_usage() -> Result<(), Box<dyn Error>> {
 
         // Check stats every 100 memories
         if i % 100 == 0 {
-            let current_stats = memory.stats();
+            let current_stats = memory.stats().await;
             println!("After {} memories: {:?}", i + 1, current_stats);
         }
     }
 
-    let final_stats = memory.stats();
+    let final_stats = memory.stats().await;
     println!("Final stats: {:?}", final_stats);
 
     // Verify memory growth is reasonable

--- a/tests/phase2_distributed_tests.rs
+++ b/tests/phase2_distributed_tests.rs
@@ -378,7 +378,7 @@ mod distributed_tests {
         assert_eq!(retrieved2.unwrap().value, "Distributed memory content 2");
 
         // Check statistics
-        let stats = memory.stats();
+        let stats = memory.stats().await;
         assert_eq!(stats.short_term_count, 2);
     }
 

--- a/tests/phase5_multimodal_tests.rs
+++ b/tests/phase5_multimodal_tests.rs
@@ -505,7 +505,7 @@ async fn test_phase5_memory_config_integration() {
 
     // Test that memory system can be created with Phase 5 features enabled
     let memory = AgentMemory::new(config).await.unwrap();
-    let stats = memory.stats();
+    let stats = memory.stats().await;
 
     assert_eq!(stats.short_term_count, 0);
     assert_eq!(stats.long_term_count, 0);

--- a/tests/reflection_tests.rs
+++ b/tests/reflection_tests.rs
@@ -103,7 +103,7 @@ async fn reflect_synthesizes_one_insight_with_provenance_edges() {
     assert!(!insight.text.is_empty(), "insight text must be non-empty");
 
     // The insight was written as a distinguishable memory.
-    let insight_entries = memory.insight_memories();
+    let insight_entries = memory.insight_memories().await;
     assert_eq!(insight_entries.len(), 1, "one insight memory written");
     let insight_entry = &insight_entries[0];
     assert_eq!(insight_entry.value, insight.text);

--- a/tools/eval/src/bin/run_eval.rs
+++ b/tools/eval/src/bin/run_eval.rs
@@ -174,6 +174,12 @@ async fn main() -> Result<(), String> {
     // `--reflect` triggers reflection/synthesis after ingestion so insight
     // memories join the QA haystack (measures capability 2 of the v2 spec).
     let reflect = args.iter().any(|a| a == "--reflect");
+    // `--deferred-enrichment` measures the write-path speedup of deferred
+    // (queue-then-batch) enrichment vs synchronous (Inline) ingest, for
+    // conversation 0 only. Requires the library LLM reasoner
+    // (SYNAPTIC_LLM_URL/SYNAPTIC_LLM_MODEL + the `llm-reasoning` feature);
+    // prints a not-run notice (never fabricated numbers) if unset.
+    let deferred_enrichment = args.iter().any(|a| a == "--deferred-enrichment");
     let dataset_path = args
         .iter()
         .find(|a| !a.starts_with("--") && a.parse::<usize>().is_err())
@@ -223,6 +229,9 @@ async fn main() -> Result<(), String> {
 
     // 1. Retrieval quality + latency (default AgentMemory pipeline), one
     //    concurrent task per conversation (independent haystacks).
+    if deferred_enrichment {
+        return run_deferred_enrichment(&conversations, &mut w).await;
+    }
     if recall_curve {
         return run_recall_curve(&conversations, &mut w).await;
     }
@@ -739,6 +748,78 @@ mod forget_curve_tests {
         for &i in &test {
             assert_eq!(fnv(&keys[i]) & 1, 1);
         }
+    }
+}
+
+/// `--deferred-enrichment`: measure the write-path speedup of deferred
+/// (queue-then-bounded-concurrent-batch) enrichment vs synchronous (Inline)
+/// ingest, on conversation 0 only. Requires the library LLM reasoner
+/// (`SYNAPTIC_LLM_URL`/`SYNAPTIC_LLM_MODEL`, built with `llm-reasoning`);
+/// without it, prints a not-run notice — never a fabricated number.
+async fn run_deferred_enrichment(
+    conversations: &[EvalConversation],
+    w: &mut impl FnMut(String) -> Result<(), String>,
+) -> Result<(), String> {
+    w("== Deferred-enrichment ingest speedup (conv 0) ==".to_string())?;
+    if conversations.is_empty() {
+        w("not run: no conversations loaded".to_string())?;
+        return Ok(());
+    }
+
+    let llm_url = std::env::var("SYNAPTIC_LLM_URL").ok();
+    let llm_model = std::env::var("SYNAPTIC_LLM_MODEL").ok();
+    if llm_url.is_none() || llm_model.is_none() {
+        w(
+            "not run: requires SYNAPTIC_LLM_URL and SYNAPTIC_LLM_MODEL (the library LLM \
+             reasoner) plus the `llm-reasoning` build feature"
+                .to_string(),
+        )?;
+        return Ok(());
+    }
+    #[cfg(not(feature = "llm-reasoning"))]
+    {
+        w("not run: binary built without the `llm-reasoning` feature".to_string())?;
+        return Ok(());
+    }
+    #[cfg(feature = "llm-reasoning")]
+    {
+        use synaptic::memory::enrichment::EnrichmentMode;
+        let conversation = &conversations[0];
+        let deferred_cfg = MemoryConfig {
+            enrichment_mode: EnrichmentMode::Deferred,
+            store_extracted_facts: true,
+            enable_knowledge_graph: true,
+            ..Default::default()
+        };
+        let concurrency = deferred_cfg.enrichment_concurrency;
+        let mut deferred_memory = AgentMemory::new(deferred_cfg)
+            .await
+            .map_err(|e| e.to_string())?;
+        let (raw_secs, enrich_secs) = runner::ingest_deferred(conversation, &mut deferred_memory)
+            .await
+            .map_err(|e| e.to_string())?;
+        let total = raw_secs + enrich_secs;
+
+        let sync_cfg = MemoryConfig {
+            enrichment_mode: EnrichmentMode::Inline,
+            store_extracted_facts: true,
+            enable_knowledge_graph: true,
+            ..Default::default()
+        };
+        let mut sync_memory = AgentMemory::new(sync_cfg).await.map_err(|e| e.to_string())?;
+        let sync_start = std::time::Instant::now();
+        runner::ingest(conversation, &mut sync_memory)
+            .await
+            .map_err(|e| e.to_string())?;
+        let sync_secs = sync_start.elapsed().as_secs_f64();
+
+        w(format!("synchronous (Inline) ingest: {sync_secs:.3}s"))?;
+        w(format!(
+            "deferred: raw {raw_secs:.3}s + enrich {enrich_secs:.3}s = {total:.3}s  (concurrency {concurrency})"
+        ))?;
+        let speedup = if total > 0.0 { sync_secs / total } else { 0.0 };
+        w(format!("speedup: {speedup:.1}x"))?;
+        Ok(())
     }
 }
 

--- a/tools/eval/src/bin/run_eval.rs
+++ b/tools/eval/src/bin/run_eval.rs
@@ -806,7 +806,9 @@ async fn run_deferred_enrichment(
             enable_knowledge_graph: true,
             ..Default::default()
         };
-        let mut sync_memory = AgentMemory::new(sync_cfg).await.map_err(|e| e.to_string())?;
+        let mut sync_memory = AgentMemory::new(sync_cfg)
+            .await
+            .map_err(|e| e.to_string())?;
         let sync_start = std::time::Instant::now();
         runner::ingest(conversation, &mut sync_memory)
             .await

--- a/tools/eval/src/runner.rs
+++ b/tools/eval/src/runner.rs
@@ -107,6 +107,30 @@ pub async fn ingest(
     })
 }
 
+/// Ingest all turns with enrichment deferred, then run one bounded-concurrent
+/// enrich_pending pass. Returns (raw_ingest_secs, enrich_secs).
+pub async fn ingest_deferred(
+    conversation: &EvalConversation,
+    memory: &mut AgentMemory,
+) -> Result<(f64, f64), RunnerError> {
+    let t0 = Instant::now();
+    for session in &conversation.sessions {
+        for (i, turn) in session.turns.iter().enumerate() {
+            let key = turn_memory_key(session, i);
+            let value = match turn.timestamp.as_ref().or(session.timestamp.as_ref()) {
+                Some(ts) => format!("[{ts}] {}: {}", turn.speaker, turn.text),
+                None => format!("{}: {}", turn.speaker, turn.text),
+            };
+            memory.store(&key, &value).await.map_err(mem_err)?;
+        }
+    }
+    let raw_secs = t0.elapsed().as_secs_f64();
+    let t1 = Instant::now();
+    let _report = memory.enrich_pending().await;
+    let enrich_secs = t1.elapsed().as_secs_f64();
+    Ok((raw_secs, enrich_secs))
+}
+
 /// Result of running one question through retrieval.
 #[derive(Debug, Clone)]
 pub struct QuestionOutcome {
@@ -223,7 +247,7 @@ pub async fn measure_growth(targets: &[usize]) -> Result<Vec<GrowthPoint>, Runne
             target_memories: target,
             stored_memories: store_durations.len(),
             stored_bytes_estimate,
-            library_reported_total_size: memory.stats().total_size,
+            library_reported_total_size: memory.stats().await.total_size,
             store_latency: LatencySummary::from_durations(&store_durations),
             probe_search_micros,
         });


### PR DESCRIPTION
Decouples the fast raw `store()` from slow per-turn LLM enrichment — the architectural bottleneck that made write-time distillation and LLM-supersession detection impractical (ingest gated on ~5.7s/turn LLM calls). Spec + plan under `docs/superpowers/`.

## What
- `AgentMemory.state` → `Arc<RwLock<AgentState>>` (behavior-preserving foundation).
- `MemoryConfig::enrichment_mode`: **`Inline`** (default, unchanged) / `Deferred` / `Background`. In Deferred/Background, `store()` records the raw memory + enqueues; enrichment (`extract → resolve → supersede → fact-store`) runs later.
- `enrich_one` engine (`src/memory/enrichment.rs`): the existing enrichment logic lifted onto shared `Arc` handles; feeds storage + state + the scoring provider so facts stay retrievable; preserves the failure-ordering invariant.
- `enrich_pending()`: bounded-concurrent drain (default 8) → `EnrichmentReport`, best-effort.
- `Background` worker + `shutdown()` / `wait_for_enrichment()` (in-flight-tracked for determinism).

## Measurement (LoCoMo conv-0, 419 turns, local 7B reasoner)
| path | time |
|---|---|
| synchronous (Inline) ingest | 1433.9 s (~24 min) |
| deferred: raw write | **2.3 s** |
| deferred: enrich (concurrency 8) | 1343.5 s |

**The write hot path drops 1434 s → 2.3 s (~630×)** — `store()` is fully decoupled from LLM latency. In `Background` mode enrichment runs off the critical path entirely.

**Honest caveat:** the *total* enrichment speedup is 1.1× — a single 7B model on one GPU (ollama, default `num_parallel` ≈ 1–2) serves the 8 concurrent requests nearly serially, so the LLM backend, not the write path, is now the ceiling. The concurrency mechanism is proven (16 in-flight connections during the deferred enrich); realizing it on total time needs a parallel/batching-capable backend (`OLLAMA_NUM_PARALLEL=8`, replicas, or a hosted API). Documented in `docs/evaluation.md`.

## Quality
6 TDD tasks, per-task spec+quality reviews. The per-task review **found and fixed a real deadlock** in `retrieve()` (an `if let` write-guard held across a promotion re-lock — passed 484 tests but hung on promotion-eligible retrieval; now regression-tested). The final whole-branch review **found a `shutdown()` hang + a `wait_for_enrichment()` early-return** (both fixed with regression tests). 493 lib tests pass (no hangs), clippy `--all-targets` clean, fmt clean, deadlock-free (all lock sites traced), `Inline` default byte-for-byte unchanged.

Documented divergence: Deferred/Background fact-memories are retrievable via storage/dense/sparse search and checkpointable, but (unlike Inline) don't get a KG node / temporal / analytics — noted in the spec and `store_fact_shared`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)